### PR TITLE
Replace All-Hands-AI references with OpenHands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenHands Benchmarks Migration
 
-⚠️ **Migration in Progress**: We are currently migrating the benchmarks infrastructure from [OpenHands](https://github.com/All-Hands-AI/OpenHands/) to work with the [OpenHands Agent SDK](https://github.com/All-Hands-AI/agent-sdk).
+⚠️ **Migration in Progress**: We are currently migrating the benchmarks infrastructure from [OpenHands](https://github.com/OpenHands/OpenHands/) to work with the [OpenHands Agent SDK](https://github.com/OpenHands/agent-sdk).
 
 ## Current Status
 
@@ -62,6 +62,6 @@ During this migration period, please:
 
 ## Links
 
-- **Original OpenHands**: https://github.com/All-Hands-AI/OpenHands/
-- **Agent SDK**: https://github.com/All-Hands-AI/agent-sdk
+- **Original OpenHands**: https://github.com/OpenHands/OpenHands/
+- **Agent SDK**: https://github.com/OpenHands/agent-sdk
 - **SWE-Bench**: https://www.swebench.com/

--- a/benchmarks/swe_bench/SWE-Gym.md
+++ b/benchmarks/swe_bench/SWE-Gym.md
@@ -34,8 +34,8 @@ We use it to train strong LM agents that achieve state-of-the-art open results o
 The process of running SWE-Gym is very similar to how you'd run SWE-Bench evaluation.
 
 
-1. First, clone OpenHands repo `git clone https://github.com/All-Hands-AI/OpenHands.git`
-2. Then setup the repo following [Development.md](https://github.com/All-Hands-AI/OpenHands/blob/main/Development.md)
+1. First, clone OpenHands repo `git clone https://github.com/OpenHands/OpenHands.git`
+2. Then setup the repo following [Development.md](https://github.com/OpenHands/OpenHands/blob/main/Development.md)
 3. Then you can simply serve your own model as an OpenAI compatible endpoint, put those info in config.toml. You can do this by following instruction [here](../../README.md#setup).
 4. And then simply do the following to sample for 16x parallelism:
 

--- a/benchmarks/swe_bench/eval_infer.py
+++ b/benchmarks/swe_bench/eval_infer.py
@@ -75,7 +75,7 @@ def get_config(metadata: EvalMetadata, instance: pd.Series) -> OpenHandsConfig:
     logger.info(
         f"Using instance container image: {base_container_image}. "
         f"Please make sure this image exists. "
-        f"Submit an issue on https://github.com/All-Hands-AI/OpenHands if you run into any issues."
+        f"Submit an issue on https://github.com/OpenHands/OpenHands if you run into any issues."
     )
     sandbox_config = get_default_sandbox_config_for_eval()
     sandbox_config.base_container_image = base_container_image

--- a/benchmarks/swe_bench/run_infer.py
+++ b/benchmarks/swe_bench/run_infer.py
@@ -308,8 +308,8 @@ image = (
         "python3-dev",
     )
     .pip_install(
-        "git+openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git#subdirectory=openhands/sdk",
-        "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git#subdirectory=openhands/tools",
+        "git+openhands-sdk @ git+https://github.com/OpenHands/agent-sdk.git#subdirectory=openhands/sdk",
+        "openhands-tools @ git+https://github.com/OpenHands/agent-sdk.git#subdirectory=openhands/tools",
     )
 )
 

--- a/benchmarks/swe_bench/run_infer_original.py
+++ b/benchmarks/swe_bench/run_infer_original.py
@@ -491,7 +491,7 @@ def get_config(
     logger.info(
         f"Using instance container image: {base_container_image}. "
         f"Please make sure this image exists. "
-        f"Submit an issue on https://github.com/All-Hands-AI/benchmarks if you run into any issues."
+        f"Submit an issue on https://github.com/OpenHands/benchmarks if you run into any issues."
     )
 
     sandbox_config = get_default_sandbox_config_for_eval()

--- a/benchmarks/swe_bench/run_localize.py
+++ b/benchmarks/swe_bench/run_localize.py
@@ -179,7 +179,7 @@ def get_config(
     logger.info(
         f"Using instance container image: {base_container_image}. "
         f"Please make sure this image exists. "
-        f"Submit an issue on https://github.com/All-Hands-AI/OpenHands if you run into any issues."
+        f"Submit an issue on https://github.com/OpenHands/OpenHands if you run into any issues."
     )
 
     sandbox_config = get_default_sandbox_config_for_eval()

--- a/benchmarks/swe_bench/scripts/eval/verify_costs.py
+++ b/benchmarks/swe_bench/scripts/eval/verify_costs.py
@@ -9,7 +9,7 @@ def verify_instance_costs(row: pd.Series) -> float:
     Verifies that the accumulated_cost matches the sum of individual costs in metrics.
     Also checks for duplicate consecutive costs which might indicate buggy counting.
     If the consecutive costs are identical, the file is affected by this bug:
-    https://github.com/All-Hands-AI/OpenHands/issues/5383
+    https://github.com/OpenHands/OpenHands/issues/5383
 
     Args:
         row: DataFrame row containing instance data with metrics

--- a/benchmarks/swe_bench/scripts/setup/prepare_swe_utils.sh
+++ b/benchmarks/swe_bench/scripts/setup/prepare_swe_utils.sh
@@ -6,13 +6,13 @@ mkdir -p $EVAL_WORKSPACE
 
 # 1. Prepare REPO
 echo "==== Prepare SWE-bench repo ===="
-OH_SWE_BENCH_REPO_PATH="https://github.com/All-Hands-AI/SWE-bench.git"
+OH_SWE_BENCH_REPO_PATH="https://github.com/OpenHands/SWE-bench.git"
 OH_SWE_BENCH_REPO_BRANCH="eval"
 git clone -b $OH_SWE_BENCH_REPO_BRANCH $OH_SWE_BENCH_REPO_PATH $EVAL_WORKSPACE/OH-SWE-bench
 
 # 2. Prepare DATA
 echo "==== Prepare SWE-bench data ===="
-EVAL_IMAGE=ghcr.io/all-hands-ai/eval-swe-bench:builder_with_conda
+EVAL_IMAGE=ghcr.io/openhands/eval-swe-bench:builder_with_conda
 EVAL_WORKSPACE=$(realpath $EVAL_WORKSPACE)
 chmod +x $EVAL_WORKSPACE/OH-SWE-bench/swebench/harness/prepare_data.sh
 if [ -d $EVAL_WORKSPACE/eval_data ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
     "toml",
     "tqdm",
     "unidiff>=0.7.5,<0.8.0",
-    "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git#subdirectory=openhands/sdk",
-    "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git#subdirectory=openhands/tools",
+    "openhands-sdk @ git+https://github.com/OpenHands/agent-sdk.git#subdirectory=openhands/sdk",
+    "openhands-tools @ git+https://github.com/OpenHands/agent-sdk.git#subdirectory=openhands/tools",
     "modal>=1.1.4",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1272,8 +1272,8 @@ dev = [
 requires-dist = [
     { name = "datasets" },
     { name = "modal", specifier = ">=1.1.4" },
-    { name = "openhands-sdk", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk" },
-    { name = "openhands-tools", git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools" },
+    { name = "openhands-sdk", git = "https://github.com/OpenHands/agent-sdk.git?subdirectory=openhands%2Fsdk" },
+    { name = "openhands-tools", git = "https://github.com/OpenHands/agent-sdk.git?subdirectory=openhands%2Ftools" },
     { name = "pandas" },
     { name = "toml" },
     { name = "tqdm" },
@@ -1292,7 +1292,7 @@ dev = [
 [[package]]
 name = "openhands-sdk"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Fsdk#b3ddfb3468c22a37fbb87d96323914d23bacb4ed" }
+source = { git = "https://github.com/OpenHands/agent-sdk.git?subdirectory=openhands%2Fsdk#b3ddfb3468c22a37fbb87d96323914d23bacb4ed" }
 dependencies = [
     { name = "fastmcp" },
     { name = "litellm" },
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "openhands-tools"
 version = "1.0.0"
-source = { git = "https://github.com/All-Hands-AI/agent-sdk.git?subdirectory=openhands%2Ftools#b3ddfb3468c22a37fbb87d96323914d23bacb4ed" }
+source = { git = "https://github.com/OpenHands/agent-sdk.git?subdirectory=openhands%2Ftools#b3ddfb3468c22a37fbb87d96323914d23bacb4ed" }
 dependencies = [
     { name = "bashlex" },
     { name = "binaryornot" },


### PR DESCRIPTION
This PR replaces all occurrences of 'All-Hands-AI' with 'OpenHands' or 'openhands' while preserving case patterns.

## Changes made:
- `All-Hands-AI` → `OpenHands`
- `all-hands-ai` → `openhands`
- `ALL-HANDS-AI` → `OPENHANDS`
- Other case variations handled appropriately

This is part of the organization rebranding effort.

## Files changed:
- 10 files were modified

## Review notes:
- All changes are simple string replacements
- Case patterns are preserved
- No functional changes to code logic