### PR TITLE
refactor: removed redundant read_completed_instances function and logic

### DIFF
--- a/benchmarks/swe_bench/run_infer.py
+++ b/benchmarks/swe_bench/run_infer.py
@@ -10,11 +10,9 @@ from benchmarks.utils.dataset import get_dataset
 from benchmarks.utils.evaluation import Evaluation
 from benchmarks.utils.evaluation_utils import (
     construct_eval_output_dir,
-    read_completed_instances,
 )
 from benchmarks.utils.models import (
     EvalInstance,
-    EvalInstanceID,
     EvalMetadata,
     EvalOutput,
 )
@@ -104,12 +102,9 @@ class SWEBenchEvaluation(Evaluation):
             completed_instances=self._get_completed_instances(),
         )
 
-        completed: set[EvalInstanceID] = read_completed_instances(self.output_path)
         instances: List[EvalInstance] = []
         for _, row in df.iterrows():
             inst_id = str(row["instance_id"])
-            if inst_id in completed:
-                continue
             instances.append(EvalInstance(id=inst_id, data=row.to_dict()))
 
         logger.info("Total instances to process: %d", len(instances))

--- a/benchmarks/utils/evaluation_utils.py
+++ b/benchmarks/utils/evaluation_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 
 from openhands.sdk import get_logger
@@ -30,23 +29,3 @@ def construct_eval_output_dir(
     os.makedirs(eval_output_dir, exist_ok=True)
 
     return eval_output_dir
-
-
-def read_completed_instances(output_file: str) -> set:
-    """Read completed instance IDs from existing output file."""
-    completed_instances = set()
-    if os.path.exists(output_file):
-        try:
-            with open(output_file, "r") as f:
-                for line in f:
-                    line = line.strip()
-                    if line:
-                        try:
-                            result = json.loads(line)
-                            if "instance_id" in result:
-                                completed_instances.add(result["instance_id"])
-                        except json.JSONDecodeError:
-                            continue
-        except Exception as e:
-            logger.warning(f"Error reading existing results from {output_file}: {e}")
-    return completed_instances


### PR DESCRIPTION
Fixes #17 

The filtering done by read_completed_instances was also being done in

 completed_instances=self._get_completed_instances(),

inside

        df = get_dataset(
            dataset_name=self.metadata.dataset,
            split=self.metadata.dataset_split,
            eval_limit=self.metadata.eval_limit,
            completed_instances=self._get_completed_instances(),
        )