### PR TITLE
Add EXP_NAME environment variable support to construct_eval_output_dir

### DIFF
--- a/benchmarks/utils/evaluation_utils.py
+++ b/benchmarks/utils/evaluation_utils.py
@@ -24,6 +24,11 @@ def construct_eval_output_dir(
     if eval_note:
         folder += f"_N_{eval_note}"
 
+    # Add experiment name from environment variable
+    exp_name = os.getenv("EXP_NAME")
+    if exp_name:
+        folder += f"-{exp_name}"
+
     # Construct full path
     eval_output_dir = os.path.join(base_dir, dataset_name, folder)
     os.makedirs(eval_output_dir, exist_ok=True)


### PR DESCRIPTION
Fixes #27 
- Read EXP_NAME from environment variable
- Append to folder name with dash separator if present
- Partially implements the format mentioned in comment