### PR TITLE
fix: swe_bench command call

### DIFF
--- a/benchmarks/swe_bench/eval_infer.py
+++ b/benchmarks/swe_bench/eval_infer.py
@@ -133,7 +133,9 @@ def run_swebench_evaluation(
         # Run SWE-Bench evaluation using global python (not UV environment)
         # since swebench is installed globally
         cmd = [
-            "/usr/bin/python3",
+            "uv",
+            "run",
+            "python",
             "-m",
             "swebench.harness.run_evaluation",
             "--dataset_name",


### PR DESCRIPTION
Fixes #69 

Calls `uv run python -m` instead of calling `python3 -m` directly.