### PR TITLE
Fix Docker container cleanup issue in SWE-Bench evaluation

### DIFF
--- a/tests/test_workspace_cleanup.py
+++ b/tests/test_workspace_cleanup.py
@@ -1,0 +1,253 @@
+"""Tests for workspace cleanup functionality in the evaluation module."""
+
+from typing import List
+from unittest.mock import Mock
+
+import pytest
+
+from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
+from openhands.sdk import LLM
+
+
+def test_workspace_cleanup_called_on_success():
+    """Test that workspace cleanup is called when evaluation succeeds."""
+    # Import here to avoid circular imports
+    from benchmarks.utils.evaluation import Evaluation
+
+    # Create a mock workspace
+    mock_workspace = Mock()
+    mock_workspace.__exit__ = Mock()
+
+    # Create test instance
+    test_instance = EvalInstance(id="test_instance", data={"test": "data"})
+
+    # Create test output
+    test_output = EvalOutput(
+        instance_id="test_instance",
+        test_result={"success": True},
+        instruction="test instruction",
+        error=None,
+        history=[],
+        instance={"test": "data"},
+    )
+
+    # Create evaluation metadata
+    llm = LLM(model="test-model")
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset="test",
+        dataset_split="test",
+        max_iterations=10,
+        eval_output_dir="/tmp/test",
+        details={},
+        eval_limit=1,
+        max_attempts=1,
+        max_retries=0,
+    )
+
+    # Create a concrete evaluation class for testing
+    class TestEvaluation(Evaluation):
+        def prepare_instances(self) -> List[EvalInstance]:
+            return [test_instance]
+
+        def prepare_workspace(self, instance: EvalInstance):
+            return mock_workspace
+
+        def evaluate_instance(self, instance, workspace):
+            return test_output
+
+    evaluator = TestEvaluation(metadata=metadata, num_workers=1)
+
+    # Call the method directly
+    result_instance, result_output = evaluator._process_one_mp(test_instance)
+
+    # Verify the workspace cleanup was called
+    mock_workspace.__exit__.assert_called_once_with(None, None, None)
+    assert result_instance.id == "test_instance"
+    assert result_output.instance_id == "test_instance"
+    assert result_output.error is None
+
+
+def test_workspace_cleanup_called_on_failure():
+    """Test that workspace cleanup is called when evaluation fails."""
+    # Import here to avoid circular imports
+    from benchmarks.utils.evaluation import Evaluation
+
+    # Create a mock workspace
+    mock_workspace = Mock()
+    mock_workspace.__exit__ = Mock()
+
+    # Create test instance
+    test_instance = EvalInstance(id="test_instance", data={"test": "data"})
+
+    # Create evaluation metadata
+    llm = LLM(model="test-model")
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset="test",
+        dataset_split="test",
+        max_iterations=10,
+        eval_output_dir="/tmp/test",
+        details={},
+        eval_limit=1,
+        max_attempts=1,
+        max_retries=0,
+    )
+
+    # Create a concrete evaluation class for testing
+    class TestEvaluation(Evaluation):
+        def prepare_instances(self) -> List[EvalInstance]:
+            return [test_instance]
+
+        def prepare_workspace(self, instance: EvalInstance):
+            return mock_workspace
+
+        def evaluate_instance(self, instance, workspace):
+            raise RuntimeError("Test evaluation failure")
+
+    evaluator = TestEvaluation(metadata=metadata, num_workers=1)
+
+    # Call the method directly
+    result_instance, result_output = evaluator._process_one_mp(test_instance)
+
+    # Verify the workspace cleanup was called even on failure
+    mock_workspace.__exit__.assert_called_once_with(None, None, None)
+    assert result_instance.id == "test_instance"
+    assert result_output.instance_id == "test_instance"
+    assert result_output.error is not None
+    assert "Test evaluation failure" in result_output.error
+
+
+def test_workspace_cleanup_handles_cleanup_exception():
+    """Test that evaluation continues even if workspace cleanup fails."""
+    # Import here to avoid circular imports
+    from benchmarks.utils.evaluation import Evaluation
+
+    # Create a mock workspace that fails on cleanup
+    mock_workspace = Mock()
+    mock_workspace.__exit__ = Mock(side_effect=RuntimeError("Cleanup failed"))
+
+    # Create test instance
+    test_instance = EvalInstance(id="test_instance", data={"test": "data"})
+
+    # Create test output
+    test_output = EvalOutput(
+        instance_id="test_instance",
+        test_result={"success": True},
+        instruction="test instruction",
+        error=None,
+        history=[],
+        instance={"test": "data"},
+    )
+
+    # Create evaluation metadata
+    llm = LLM(model="test-model")
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset="test",
+        dataset_split="test",
+        max_iterations=10,
+        eval_output_dir="/tmp/test",
+        details={},
+        eval_limit=1,
+        max_attempts=1,
+        max_retries=0,
+    )
+
+    # Create a concrete evaluation class for testing
+    class TestEvaluation(Evaluation):
+        def prepare_instances(self) -> List[EvalInstance]:
+            return [test_instance]
+
+        def prepare_workspace(self, instance: EvalInstance):
+            return mock_workspace
+
+        def evaluate_instance(self, instance, workspace):
+            return test_output
+
+    evaluator = TestEvaluation(metadata=metadata, num_workers=1)
+
+    # Call the method directly - should not raise an exception
+    result_instance, result_output = evaluator._process_one_mp(test_instance)
+
+    # Verify the workspace cleanup was attempted
+    mock_workspace.__exit__.assert_called_once_with(None, None, None)
+    assert result_instance.id == "test_instance"
+    assert result_output.instance_id == "test_instance"
+    assert result_output.error is None  # Main evaluation should still succeed
+
+
+def test_workspace_cleanup_with_retries():
+    """Test that workspace cleanup is called for each retry attempt."""
+    # Import here to avoid circular imports
+    from benchmarks.utils.evaluation import Evaluation
+
+    # Track all workspaces created
+    workspaces_created = []
+
+    def create_mock_workspace():
+        workspace = Mock()
+        workspace.__exit__ = Mock()
+        workspaces_created.append(workspace)
+        return workspace
+
+    # Create test instance
+    test_instance = EvalInstance(id="test_instance", data={"test": "data"})
+
+    # Create evaluation metadata with retries
+    llm = LLM(model="test-model")
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset="test",
+        dataset_split="test",
+        max_iterations=10,
+        eval_output_dir="/tmp/test",
+        details={},
+        eval_limit=1,
+        max_attempts=1,
+        max_retries=2,  # Allow 2 retries
+    )
+
+    # Track evaluation attempts
+    attempt_count = 0
+
+    # Create a concrete evaluation class for testing
+    class TestEvaluation(Evaluation):
+        def prepare_instances(self) -> List[EvalInstance]:
+            return [test_instance]
+
+        def prepare_workspace(self, instance: EvalInstance):
+            return create_mock_workspace()
+
+        def evaluate_instance(self, instance, workspace):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count <= 2:
+                raise RuntimeError(f"Attempt {attempt_count} failed")
+            return EvalOutput(
+                instance_id=instance.id,
+                test_result={"success": True},
+                instruction="test instruction",
+                error=None,
+                history=[],
+                instance=instance.data,
+            )
+
+    evaluator = TestEvaluation(metadata=metadata, num_workers=1)
+
+    # Call the method directly
+    result_instance, result_output = evaluator._process_one_mp(test_instance)
+
+    # Verify cleanup was called for all attempts (3 total: initial + 2 retries)
+    assert len(workspaces_created) == 3, "Should create workspace for each attempt"
+    for workspace in workspaces_created:
+        workspace.__exit__.assert_called_once_with(None, None, None)
+
+    # Final result should be successful
+    assert result_instance.id == "test_instance"
+    assert result_output.instance_id == "test_instance"
+    assert result_output.error is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

This PR fixes issue #33 where Docker containers were not being stopped automatically after SWE-Bench task completion. The problem was that the evaluation code relied on Python's garbage collector to call the workspace destructor, which is not guaranteed to happen immediately.

## Root Cause

As identified by @adityasoni9998, the issue was that Python's garbage collection is non-deterministic, so the workspace destructor (`__del__`) wasn't being called immediately after the evaluation completed. This led to Docker containers remaining running even after the evaluation process finished.

## Solution

1. **Explicit Cleanup**: Added explicit workspace cleanup in the `_process_one_mp` function using a `finally` block to ensure cleanup happens regardless of success or failure.

2. **Context Manager Protocol**: Used the `__exit__` method instead of a direct `cleanup()` call to leverage the context manager protocol, which is available on all workspace types.

3. **Error Handling**: Added proper exception handling for cleanup failures to prevent cleanup errors from affecting the main evaluation results.

4. **Comprehensive Testing**: Added extensive tests to verify cleanup behavior in all scenarios:
   - Successful evaluation
   - Failed evaluation  
   - Cleanup exceptions
   - Retry scenarios

## Changes Made

### `benchmarks/utils/evaluation.py`
- Modified `_process_one_mp` method to explicitly call workspace cleanup in a `finally` block
- Used `workspace.__exit__(None, None, None)` to leverage the context manager protocol
- Added proper error handling and logging for cleanup failures

### `tests/test_workspace_cleanup.py` (new file)
- Added 4 comprehensive test cases covering all cleanup scenarios
- Tests verify cleanup is called in success/failure cases, handles exceptions, and works with retries
- Uses proper mocking to verify the `__exit__` method is called correctly

## Testing

All tests pass:
```bash
$ uv run pytest tests/test_workspace_cleanup.py -v
========== 4 passed in 2.98s ==========
```

Pre-commit checks also pass:
```bash
$ uv run pre-commit run --files benchmarks/utils/evaluation.py tests/test_workspace_cleanup.py
Ruff format..............................................................Passed
Ruff lint................................................................Passed  
PEP8 style check (pycodestyle)...........................................Passed
Type check with Pyright (strict).........................................Passed
```

## Impact

- **Immediate**: Docker containers will now be stopped immediately after each evaluation completes
- **Resource Usage**: Prevents accumulation of hundreds of running containers as reported in the issue
- **Memory**: Reduces RAM usage from lingering containers
- **Reliability**: Ensures consistent cleanup behavior regardless of evaluation outcome

## Backwards Compatibility

This change is fully backwards compatible. It only adds explicit cleanup calls and doesn't change any existing APIs or behavior.

Fixes #33

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/84487ce34622468981e19da63f0e3fcd)