### PR TITLE
Fix issue #83: Prevent quoted @openhands mentions from triggering agent flows

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -1,0 +1,76 @@
+name: OpenHands Issue Resolver
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-mention:
+    name: Check for Valid Mention
+    runs-on: ubuntu-latest
+    outputs:
+      should_trigger: ${{ steps.check.outputs.should_trigger }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Check if mention is in unquoted text
+        id: check
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || '' }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || github.event.review.author_association || '' }}
+        run: |
+          # Check if user has permission to trigger the bot
+          if [[ "$AUTHOR_ASSOCIATION" != "OWNER" && "$AUTHOR_ASSOCIATION" != "COLLABORATOR" && "$AUTHOR_ASSOCIATION" != "MEMBER" ]]; then
+            echo "User does not have permission to trigger bot"
+            echo "should_trigger=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check if mention is in unquoted text
+          if uv run python benchmarks/scripts/check_mention.py "$COMMENT_BODY" "@openhands"; then
+            echo "Mention found in unquoted text - will trigger bot"
+            echo "should_trigger=true" >> $GITHUB_OUTPUT
+          else
+            echo "Mention only in quoted text or not found - will not trigger bot"
+            echo "should_trigger=false" >> $GITHUB_OUTPUT
+          fi
+
+  call-resolver:
+    name: Run OpenHands Resolver
+    needs: check-mention
+    if: needs.check-mention.outputs.should_trigger == 'true'
+    uses: All-Hands-AI/OpenHands/.github/workflows/openhands-resolver.yml@main
+    with:
+      max_iterations: 50
+      macro: "@openhands"
+      target_branch: "main"
+      pr_type: "draft"
+      LLM_MODEL: "anthropic/claude-sonnet-4-20250514"
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_USERNAME: ${{ secrets.PAT_USERNAME }}

--- a/benchmarks/scripts/check_mention.py
+++ b/benchmarks/scripts/check_mention.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Script to check if a GitHub comment contains an unquoted mention.
+
+This script is designed to be used in GitHub Actions workflows to prevent
+triggering the bot when mentions only appear in quoted reply blocks.
+
+Usage:
+    python check_mention.py <comment_body> <mention>
+
+Exit codes:
+    0: Mention found in unquoted text (should trigger bot)
+    1: Mention not found or only in quoted text (should not trigger bot)
+"""
+
+import sys
+
+from benchmarks.utils.github_comment_utils import is_mention_in_unquoted_text
+
+
+def main():
+    """Check if mention is in unquoted text and return appropriate exit code."""
+    if len(sys.argv) != 3:
+        print("Usage: check_mention.py <comment_body> <mention>", file=sys.stderr)
+        sys.exit(2)
+
+    comment_body = sys.argv[1]
+    mention = sys.argv[2]
+
+    # Check if mention is in unquoted text
+    if is_mention_in_unquoted_text(comment_body, mention):
+        print(f"Mention '{mention}' found in unquoted text - should trigger bot")
+        sys.exit(0)
+    else:
+        print(
+            f"Mention '{mention}' not found or only in quoted text - should not trigger bot"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/utils/github_comment_utils.py
+++ b/benchmarks/utils/github_comment_utils.py
@@ -1,0 +1,55 @@
+"""Utility functions for processing GitHub comments."""
+
+
+def is_mention_in_unquoted_text(comment_body: str, mention: str) -> bool:
+    """
+    Check if a mention appears in unquoted (non-blockquote) text.
+
+    GitHub's "Quote reply" feature creates markdown blockquotes with lines
+    starting with '>'. This function checks if the mention appears outside
+    of these quoted blocks.
+
+    Args:
+        comment_body: The full comment body text
+        mention: The mention string to search for (e.g., '@openhands')
+
+    Returns:
+        True if the mention appears in unquoted text, False if it only
+        appears in quoted blocks or doesn't appear at all.
+
+    Examples:
+        >>> body = "Hello @openhands please help"
+        >>> is_mention_in_unquoted_text(body, "@openhands")
+        True
+
+        >>> body = "> Someone said @openhands\\nI agree"
+        >>> is_mention_in_unquoted_text(body, "@openhands")
+        False
+
+        >>> body = "> Someone said @openhands\\n@openhands please help"
+        >>> is_mention_in_unquoted_text(body, "@openhands")
+        True
+    """
+    if not comment_body or not mention:
+        return False
+
+    # Split comment into lines
+    lines = comment_body.split("\n")
+
+    # Check each line
+    for line in lines:
+        stripped_line = line.lstrip()
+
+        # Skip empty lines
+        if not stripped_line:
+            continue
+
+        # Check if this is a quoted line (starts with >)
+        is_quoted = stripped_line.startswith(">")
+
+        # If the line is not quoted and contains the mention, return True
+        if not is_quoted and mention in line:
+            return True
+
+    # If we get here, the mention either doesn't exist or only exists in quoted lines
+    return False

--- a/tests/test_github_comment_utils.py
+++ b/tests/test_github_comment_utils.py
@@ -1,0 +1,96 @@
+"""Tests for GitHub comment utility functions."""
+
+from benchmarks.utils.github_comment_utils import is_mention_in_unquoted_text
+
+
+class TestIsMentionInUnquotedText:
+    """Tests for is_mention_in_unquoted_text function."""
+
+    def test_direct_mention_only(self):
+        """Test a direct mention without any quotes."""
+        body = "Hello @openhands please help with this issue"
+        assert is_mention_in_unquoted_text(body, "@openhands") is True
+
+    def test_quoted_mention_only(self):
+        """Test a mention that only appears in a quoted block."""
+        body = "> Someone said @openhands earlier\n> Can you help?"
+        assert is_mention_in_unquoted_text(body, "@openhands") is False
+
+    def test_mixed_mention_quoted_and_direct(self):
+        """Test a mention in both quoted and unquoted text."""
+        body = "> Someone said @openhands earlier\n\nYes, @openhands please help!"
+        assert is_mention_in_unquoted_text(body, "@openhands") is True
+
+    def test_multiple_quote_levels(self):
+        """Test nested quotes (>> for double-quoted)."""
+        body = ">> Original: @openhands\n> Reply: @openhands\nMy response"
+        assert is_mention_in_unquoted_text(body, "@openhands") is False
+
+    def test_mention_after_quote_on_same_line(self):
+        """Test mention on a quoted line (should not trigger)."""
+        body = "> Please @openhands help with this"
+        assert is_mention_in_unquoted_text(body, "@openhands") is False
+
+    def test_no_mention(self):
+        """Test when mention doesn't appear at all."""
+        body = "This is a regular comment without any mentions"
+        assert is_mention_in_unquoted_text(body, "@openhands") is False
+
+    def test_empty_body(self):
+        """Test with empty comment body."""
+        assert is_mention_in_unquoted_text("", "@openhands") is False
+
+    def test_empty_mention(self):
+        """Test with empty mention string."""
+        body = "Hello world"
+        assert is_mention_in_unquoted_text(body, "") is False
+
+    def test_quote_with_spaces(self):
+        """Test quoted lines with leading spaces before >."""
+        body = "  > Quoted text with @openhands\nNormal text"
+        assert is_mention_in_unquoted_text(body, "@openhands") is False
+
+    def test_multiline_with_direct_mention_first(self):
+        """Test direct mention followed by quoted mention."""
+        body = "@openhands please help\n> Someone else said @openhands too"
+        assert is_mention_in_unquoted_text(body, "@openhands") is True
+
+    def test_github_quote_reply_example(self):
+        """Test realistic GitHub quote reply scenario."""
+        # Simulates what happens when someone clicks "Quote reply"
+        original_comment = "@openhands fix this bug"
+        quoted_reply = f"> {original_comment}\n\nI second this request"
+
+        # Should not trigger because mention is only in the quote
+        assert is_mention_in_unquoted_text(quoted_reply, "@openhands") is False
+
+    def test_github_quote_reply_with_new_mention(self):
+        """Test quote reply where user also adds a direct mention."""
+        quoted_reply = "> @openhands fix this bug\n\n@openhands please also check this"
+
+        # Should trigger because there's a direct mention
+        assert is_mention_in_unquoted_text(quoted_reply, "@openhands") is True
+
+    def test_different_mention_string(self):
+        """Test with a different mention string."""
+        body = "@openhands-agent please help"
+        assert is_mention_in_unquoted_text(body, "@openhands-agent") is True
+
+        body = "> @openhands-agent was mentioned"
+        assert is_mention_in_unquoted_text(body, "@openhands-agent") is False
+
+    def test_mention_in_code_block_not_quoted(self):
+        """Test mention in code block (should still trigger as it's not a quote)."""
+        body = "```python\n# Call @openhands\n```"
+        # This should trigger because it's not a quoted line (>)
+        assert is_mention_in_unquoted_text(body, "@openhands") is True
+
+    def test_blank_lines_between_quotes(self):
+        """Test handling of blank lines between quoted sections."""
+        body = "> First quote @openhands\n\n> Second quote"
+        assert is_mention_in_unquoted_text(body, "@openhands") is False
+
+    def test_mention_multiple_times_in_unquoted(self):
+        """Test multiple mentions in unquoted text."""
+        body = "@openhands please help. CC @openhands-team"
+        assert is_mention_in_unquoted_text(body, "@openhands") is True


### PR DESCRIPTION
## Description

This PR fixes issue #83 by preventing @openhands mentions that appear in quoted reply blocks from triggering the OpenHands agent workflow.

## Problem

When a user quotes a GitHub comment containing `@openhands` (using GitHub's "Quote reply" feature), the quoted mention was incorrectly triggering another OpenHands agent flow. This resulted in unwanted duplicate workflows.

## Solution

This PR introduces filtering logic to distinguish between direct @openhands mentions and mentions that appear only in quoted reply blocks:

1. **New utility function**: `is_mention_in_unquoted_text()` in `benchmarks/utils/github_comment_utils.py`
   - Parses comment body to detect if mentions appear in markdown blockquotes (lines starting with `>`)
   - Returns `True` only if the mention appears in unquoted text

2. **GitHub Actions workflow**: `.github/workflows/openhands-resolver.yml`
   - Adds a pre-check job that validates mentions before triggering the resolver
   - Uses the utility function to filter out quoted mentions
   - Maintains existing authorization checks (OWNER, COLLABORATOR, MEMBER only)
   - Calls the main OpenHands resolver workflow only when appropriate

3. **Helper script**: `benchmarks/scripts/check_mention.py`
   - Command-line script for use in GitHub Actions
   - Returns appropriate exit codes for workflow decisions

## Testing

Added comprehensive test suite with 16 test cases covering:
- Direct mentions (should trigger)
- Quoted-only mentions (should not trigger)
- Mixed scenarios (quoted + direct)
- Multiple quote levels
- Edge cases (empty strings, code blocks, etc.)
- Realistic GitHub quote reply scenarios

All tests pass:
```
tests/test_github_comment_utils.py::TestIsMentionInUnquotedText::test_direct_mention_only PASSED
tests/test_github_comment_utils.py::TestIsMentionInUnquotedText::test_quoted_mention_only PASSED
tests/test_github_comment_utils.py::TestIsMentionInUnquotedText::test_mixed_mention_quoted_and_direct PASSED
... (13 more tests)
16 passed in 0.03s
```

## Changes Made

- `benchmarks/utils/github_comment_utils.py` - Core filtering logic
- `benchmarks/scripts/check_mention.py` - CLI script for workflow use
- `.github/workflows/openhands-resolver.yml` - New workflow with quote filtering
- `tests/test_github_comment_utils.py` - Comprehensive test suite

## Expected Behavior After Fix

### Scenario 1: Direct mention (should trigger ✅)
```
User comment: "@openhands please fix this bug"
Result: Agent workflow triggers
```

### Scenario 2: Quoted mention only (should NOT trigger ❌)
```
User clicks "Quote reply" on a comment containing @openhands:
> @openhands please fix this bug

I agree with this request.

Result: Agent workflow does NOT trigger
```

### Scenario 3: Quote + new mention (should trigger ✅)
```
> @openhands please fix this bug

@openhands could you also check this related issue?

Result: Agent workflow triggers (due to the second, unquoted mention)
```

Fixes #83

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/31df597934554c46983fbdf9c82ff963)