### PR TITLE
Add PR label trigger for SWE-Bench image builds

### DIFF
--- a/.github/workflows/build-swe-bench-images.yml
+++ b/.github/workflows/build-swe-bench-images.yml
@@ -1,7 +1,8 @@
 name: Build SWE-Bench Images
 
 on:
-  # pull_request:  # for debugging
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       dataset:
@@ -38,6 +39,10 @@ concurrency:
 
 jobs:
   build-and-push:
+    # Only run on workflow_dispatch or if the PR is labeled with 'build-swebench'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'build-swebench')
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 


### PR DESCRIPTION
## Summary

This PR adds the ability to trigger the `build-swe-bench-images` workflow by adding the label `build-swebench` to a pull request.

## Changes

- **Added pull_request trigger**: The workflow now triggers when a PR is labeled (specifically with the `labeled` event type)
- **Added conditional execution**: Added an `if` condition to ensure the workflow only runs when:
  - Manually triggered via `workflow_dispatch`, OR
  - A PR is labeled with the exact label name `build-swebench`
- **Preserved existing functionality**: All existing `workflow_dispatch` functionality remains intact

## Usage

To trigger this workflow on a PR:
1. Add the label `build-swebench` to any pull request
2. The workflow will automatically start building SWE-Bench images using the default configuration
3. Results will be posted to the tracker issue (#81)

## Testing

The workflow will use the default environment variables when triggered by a PR label:
- `DATASET`: `princeton-nlp/SWE-bench_Verified`
- `SPLIT`: `test`
- `MAX_WORKERS`: `32`
- `N_LIMIT`: `500`

Manual dispatch still allows overriding these values with custom inputs.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/834bafde6e7547919e3e0ca0b9cac0a8)