### PR TITLE
Add build-swebench-50 and build-swebench-200 labels support

### DIFF
--- a/.github/workflows/build-swe-bench-images.yml
+++ b/.github/workflows/build-swe-bench-images.yml
@@ -42,7 +42,9 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' &&
-       github.event.label.name == 'build-swebench')
+       (github.event.label.name == 'build-swebench' ||
+        github.event.label.name == 'build-swebench-50' ||
+        github.event.label.name == 'build-swebench-200'))
 
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
@@ -68,6 +70,22 @@ jobs:
           if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
           # Empty string means "no limit"
           if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+
+      # Set N_LIMIT based on the label that triggered the workflow
+      - name: Set N_LIMIT based on label
+        if: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          LABEL_NAME="${{ github.event.label.name }}"
+          if [ "$LABEL_NAME" = "build-swebench-50" ]; then
+            echo "N_LIMIT=50" >> "$GITHUB_ENV"
+            echo "Building 50 images based on label: build-swebench-50"
+          elif [ "$LABEL_NAME" = "build-swebench-200" ]; then
+            echo "N_LIMIT=200" >> "$GITHUB_ENV"
+            echo "Building 200 images based on label: build-swebench-200"
+          elif [ "$LABEL_NAME" = "build-swebench" ]; then
+            echo "N_LIMIT=" >> "$GITHUB_ENV"
+            echo "Building all images based on label: build-swebench"
+          fi
 
       - name: Set up Docker Buildx with Blacksmith
         uses: useblacksmith/setup-docker-builder@v1


### PR DESCRIPTION
This PR adds support for additional labels to control the number of SWE-bench images to build:

- **build-swebench-50**: Build only 50 images (for quick testing)
- **build-swebench-200**: Build 200 images (for medium testing)
- **build-swebench**: Build all images (no limit, existing behavior)

## Changes
- Updated the workflow trigger condition to accept all three labels
- Added a new step to set N_LIMIT based on the label that triggered the workflow
- build-swebench now sets N_LIMIT to empty (no limit) instead of 500

This allows for more flexible testing and faster feedback loops when working with SWE-bench images.