### PR TITLE
Document build-swebench-50 and build-swebench-200 labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ Uses a [remote runtime API](https://openhands.dev/blog/evaluation-of-llms-as-cod
 #### Prerequisites for Remote Workspace
 
 1. **Pre-built Images**: Images must be built and pushed to a public registry
-   - In this repository, add the `build-swebench` label to a PR to trigger image builds
+   - In this repository, add one of the following labels to a PR to trigger image builds:
+     - `build-swebench-50`: Build 50 images (quick testing)
+     - `build-swebench-200`: Build 200 images (medium testing)
+     - `build-swebench`: Build all images (full evaluation)
    - Images are tagged with the SDK SHA from the `vendor/software-agent-sdk` submodule
 
 2. **Runtime API Key**: Set the `RUNTIME_API_KEY` environment variable

--- a/benchmarks/swe_bench/README.md
+++ b/benchmarks/swe_bench/README.md
@@ -69,9 +69,12 @@ Images must be pre-built and pushed to a **public** container registry before ru
 **Option A: Automated Build via PR Label (Recommended)**
 
 1. Create or update a PR in this repository
-2. Add the `build-swebench` label to the PR
+2. Add one of the following labels to the PR to trigger image builds:
+   - `build-swebench-50`: Build 50 images (quick testing, ~5-10 minutes)
+   - `build-swebench-200`: Build 200 images (medium testing, ~20-40 minutes)
+   - `build-swebench`: Build all images (full evaluation, ~1-2 hours)
 3. The GitHub Action will automatically:
-   - Build agent-server images for all instances in `princeton-nlp/SWE-bench_Verified` (test split)
+   - Build agent-server images for instances in `princeton-nlp/SWE-bench_Verified` (test split)
    - Push images to `ghcr.io/openhands/eval-agent-server` with tags like:
      ```
      ghcr.io/openhands/eval-agent-server:{SDK_SHA}-{INSTANCE_TAG}-source-minimal


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `build-swebench-50` and `build-swebench-200` labels that were introduced in #98.

## Changes

Updated documentation in two locations to document all three build label options:

1. **README.md** - Updated the "Prerequisites for Remote Workspace" section
2. **benchmarks/swe_bench/README.md** - Updated the "Option A: Automated Build via PR Label" section

### Documentation now includes:

- `build-swebench-50`: Build 50 images (quick testing, ~5-10 minutes)
- `build-swebench-200`: Build 200 images (medium testing, ~20-40 minutes)
- `build-swebench`: Build all images (full evaluation, ~1-2 hours)

## Context

PR #98 added support for these labels in the workflow, but the documentation still only mentioned the original `build-swebench` label. This update ensures users are aware of all available options for faster feedback loops during development and testing.

## Related Issues

Addresses documentation follow-up for #98

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/768ed4e845dc4deb9a6e18339a821cf6)