### PR TITLE
Add sdk-commit parameter to build-swe-bench-images workflow

### DIFF
--- a/.github/workflows/build-swe-bench-images.yml
+++ b/.github/workflows/build-swe-bench-images.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: ''
         type: string
+      sdk-commit:
+        description: 'Software Agent SDK commit/ref to use. Leave blank to use submodule default.'
+        required: false
+        default: ''
+        type: string
 
 # Reasonable defaults for automatic (push) runs; workflow_dispatch can override these.
 env:
@@ -60,6 +65,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
+
+      # Update SDK submodule to specific commit if provided
+      - name: Update SDK submodule
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk-commit != '' }}
+        run: |
+          cd vendor/software-agent-sdk
+          git fetch origin ${{ inputs.sdk-commit }}
+          git checkout ${{ inputs.sdk-commit }}
+          cd ../..
+          echo "Updated SDK submodule to ${{ inputs.sdk-commit }}"
 
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)


### PR DESCRIPTION
This allows callers to specify which SDK commit to use when building images. The workflow will update the vendor/software-agent-sdk submodule to the specified commit before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)