### PR TITLE
Add unique_dispatch_id input for workflow run tracking

### DIFF
--- a/.github/workflows/build-swe-bench-images.yml
+++ b/.github/workflows/build-swe-bench-images.yml
@@ -31,7 +31,7 @@ on:
         default: ''
         type: string
       unique-dispatch-id:
-        description: 'Unique ID to identify this workflow dispatch (for tracking)'
+        description: 'Unique identifier for this dispatch (used for workflow run matching)'
         required: false
         default: ''
         type: string


### PR DESCRIPTION
- Add unique_dispatch_id input to build-swe-bench-images workflow
- Enables reliable workflow run identification after dispatch