### PR TITLE
Use metadata_benchmarks.json to prevent override by evaluation repo

### DIFF
--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -46,7 +46,9 @@ class Evaluation(ABC, BaseModel):
         os.makedirs(self.metadata.eval_output_dir, exist_ok=True)
 
         # Save metadata to JSON file
-        metadata_file = os.path.join(self.metadata.eval_output_dir, "metadata.json")
+        metadata_file = os.path.join(
+            self.metadata.eval_output_dir, "metadata_benchmarks.json"
+        )
         with open(metadata_file, "w", encoding="utf-8") as f:
             f.write(self.metadata.model_dump_json(indent=2))
         logger.info(f"Saved metadata to {metadata_file}")


### PR DESCRIPTION
## Problem
The evaluation repository was overriding the `metadata.json` file created by the benchmarks repository, causing the benchmarks metadata to be lost during workflow runs.

## Solution
Changed the benchmarks repository to create `metadata_benchmarks.json` instead of `metadata.json`. This allows both repositories to maintain their own metadata files:
- **Benchmarks repo**: `metadata_benchmarks.json` ✅ (this PR)
- **Evaluation repo**: `metadata_evaluation.json` (companion PR)

## Changes
- Updated `benchmarks/utils/evaluation.py` to save metadata to `metadata_benchmarks.json` in the `model_post_init` method
- No other code references `metadata.json`, so no additional changes needed

## Testing
- ✅ All pre-commit checks passed (ruff format, ruff lint, pycodestyle, pyright)
- ✅ Verified that `metadata_benchmarks.json` is created correctly
- ✅ Confirmed old `metadata.json` is not created

## Related Changes
A companion PR will be created for the evaluation repository to use `metadata_evaluation.json`.

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1613c8932fdf408f9c479ecc1c4b92db)