### PR TITLE
Add GAIA image build workflow

### DIFF
--- a/.github/workflows/build-gaia-image.yml
+++ b/.github/workflows/build-gaia-image.yml
@@ -1,0 +1,209 @@
+name: Build GAIA Images
+
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      sdk-commit:
+        description: 'Software Agent SDK commit/ref to use'
+        required: true
+        type: string
+      target:
+        description: 'Build target (default: binary-minimal)'
+        required: false
+        default: 'binary-minimal'
+        type: choice
+        options:
+          - binary-minimal
+          - source-minimal
+
+concurrency:
+  group: build-gaia-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.label.name == 'build-gaia')
+
+    runs-on:
+      labels: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      issues: write
+
+    steps:
+      - name: Determine checkout ref
+        id: checkout-ref
+        run: |
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          else
+            echo "ref=" >> "$GITHUB_OUTPUT"
+            echo "Using default ref (the commit that triggered this workflow)"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout-ref.outputs.ref }}
+          submodules: recursive
+
+      - name: Update SDK submodule
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk-commit != '' }}
+        run: |
+          cd vendor/software-agent-sdk
+          git fetch origin ${{ inputs.sdk-commit }}
+          git checkout FETCH_HEAD
+          SDK_SHA=$(git rev-parse HEAD)
+          cd ../..
+          git add vendor/software-agent-sdk
+          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+
+      - name: Set up Docker Buildx with Blacksmith
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          make build
+
+      - name: Build and push GAIA image
+        run: |
+          set -euo pipefail
+
+          TARGET="${{ inputs.target || 'binary-minimal' }}"
+
+          CMD="uv run benchmarks/gaia/build_images.py \
+            --image ghcr.io/openhands/eval-agent-server \
+            --target ${TARGET} \
+            --push"
+
+          echo "Running: $CMD"
+          eval "$CMD"
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+
+      - name: Archive build logs
+        if: always()
+        run: |
+          if [ -d builds ]; then
+            tar -czf build-logs.tar.gz builds/
+            echo "Build logs archived successfully"
+          else
+            echo "No builds directory found"
+          fi
+
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs-${{ github.run_id }}
+          path: build-logs.tar.gz
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Display build summary
+        if: always()
+        run: |
+          # GAIA builds a single universal image, so we just show success/failure
+          MANIFEST_FILE=$(find builds -name "manifest.jsonl" -type f 2>/dev/null | head -1 || true)
+
+          if [ -z "$MANIFEST_FILE" ]; then
+            echo "## Build Summary" >> "$GITHUB_STEP_SUMMARY"
+            echo "❌ Build failed - no manifest found" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Read the single line from the manifest
+          BUILD_DATA=$(cat "$MANIFEST_FILE")
+
+          echo "## GAIA Image Build Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Check if build succeeded
+          if echo "$BUILD_DATA" | python3 -c "import sys, json; data = json.loads(sys.stdin.read()); sys.exit(0 if data.get('error') is None and len(data.get('tags', [])) > 0 else 1)"; then
+            TAGS=$(echo "$BUILD_DATA" | python3 -c "import sys, json; data = json.loads(sys.stdin.read()); print('\n'.join([f'- \`{tag}\`' for tag in data.get('tags', [])]))")
+            echo "✅ **Build Successful**" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Built Image:**" >> "$GITHUB_STEP_SUMMARY"
+            echo "$TAGS" >> "$GITHUB_STEP_SUMMARY"
+          else
+            ERROR=$(echo "$BUILD_DATA" | python3 -c "import sys, json; data = json.loads(sys.stdin.read()); print(data.get('error', 'Unknown error'))")
+            echo "❌ **Build Failed**" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Error:** $ERROR" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment on tracker issue
+        if: success()
+        run: |
+          # Get SDK version
+          SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
+
+          # Read the single manifest file
+          MANIFEST_FILE=$(find builds -name "manifest.jsonl" -type f 2>/dev/null | head -1 || true)
+
+          if [ -z "$MANIFEST_FILE" ]; then
+            echo "No manifest file found"
+            exit 0
+          fi
+
+          # Extract the image tag from the manifest
+          IMAGE_TAG=$(cat "$MANIFEST_FILE" | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+tags = data.get('tags', [])
+print(tags[0] if tags else 'unknown')
+          ")
+
+          if [ "$IMAGE_TAG" = "unknown" ]; then
+            echo "No valid image tag found in manifest"
+            exit 0
+          fi
+
+          # Determine trigger source
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TRIGGER="Manual trigger (workflow_dispatch)"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
+          else
+            TRIGGER="${{ github.event_name }}"
+          fi
+
+          # Post comment
+          COMMENT_BODY=$(cat <<EOF
+## GAIA Image Build Complete ✅
+
+**SDK Version:** [\`${SDK_SHA:0:7}\`](https://github.com/OpenHands/software-agent-sdk/commit/${SDK_SHA})
+**Image Tag:** \`${IMAGE_TAG}\`
+**Workflow Run:** [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+**Triggered by:** ${TRIGGER}
+EOF
+          )
+
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/issues/81/comments" \
+            -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR adds the GitHub Actions workflow for building GAIA benchmark agent server images.

## Background

GAIA (General AI Assistants) benchmark evaluation requires agent server images, similar to SWE-bench. However, unlike SWE-bench which builds per-instance images (one per repository), GAIA uses a single universal image for all instances.

## What's Included

-  - Workflow for building the GAIA agent server image

## Workflow Features

- **Minimal configuration**: Only requires `sdk-commit` and optional `target` parameter
- **Universal image**: Builds one image based on `nikolaik/python-nodejs:python3.12-nodejs22`
- **Simple architecture**: No need for per-instance builds or complex configuration
- **Image tag format**: `ghcr.io/openhands/eval-agent-server:{SDK_SHA}-gaia-binary-minimal`

## Triggering

Can be triggered in two ways:
1. **workflow_dispatch**: Manually via GitHub Actions UI or API
2. **PR label**: Add `build-gaia` label to any PR

## Next Steps

Once this is merged to main:
1. The workflow will be available for dispatch via GitHub API
2. Evaluation orchestration can dispatch builds before running GAIA evaluations
3. This unblocks end-to-end GAIA evaluation on Kubernetes infrastructure

## Related

- Issue #81 - Build tracker issue (workflow posts status updates here)
- PR #125 - Full multi-benchmark evaluation support (includes GAIA evaluation code)

## Note

This PR intentionally only includes the workflow file to enable quick merging. The actual GAIA evaluation implementation code is in PR #125.