### PR TITLE
SWT cost reporting integration

### DIFF
--- a/benchmarks/swt_bench/eval_infer.py
+++ b/benchmarks/swt_bench/eval_infer.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 from benchmarks.utils.patch_utils import remove_files_from_patch
+from benchmarks.utils.report_costs import generate_cost_report
 from openhands.sdk import get_logger
 
 
@@ -305,6 +306,9 @@ Examples:
         if not args.skip_evaluation:
             # Run evaluation
             run_swtbench_evaluation(str(output_file), args.dataset, args.workers)
+
+        # Generate cost report as final step
+        generate_cost_report(str(input_file))
 
         logger.info("Script completed successfully!")
 


### PR DESCRIPTION
Add cost reporting functionality to the SWT-Bench evaluation script:
- Import generate_cost_report from benchmarks.utils.report_costs
- Call generate_cost_report as final step after evaluation completes

This ensures cost tracking is consistently applied across all benchmark evaluations.