### PR TITLE
SWE-Bench: create output.report.json

### DIFF
--- a/benchmarks/swebench/eval_infer.py
+++ b/benchmarks/swebench/eval_infer.py
@@ -265,7 +265,6 @@ Examples:
             shutil.move(str(report_path), str(dest_report_path))
             logger.info(f"Moved report file to: {dest_report_path}")
 
-
         # Generate cost report as final step
         generate_cost_report(str(input_file))
 


### PR DESCRIPTION
## Summary

Fixes #190

After running the SWE-Bench evaluation harness, the generated report file is now moved to the same directory as the input file with the extension changed from `.jsonl` to `.report.json`.

## Changes

- Modified `run_swebench_evaluation` to return the report file path
- Added `model_name` parameter to locate the correct report file (SWE-Bench creates files with pattern `{model_name.replace("/", "__")}.{run_id}.json`)
- Added logic in `main()` to move the report file to the destination using `shutil.move`
- Added logging to indicate the file was moved
- Added tests for the new functionality in `tests/test_swebench_eval.py`

## Example

If the input file is `/path/to/output.jsonl`, after evaluation the report will be moved to `/path/to/output.report.json`.

## Testing

- Added 4 new tests covering:
  - Format conversion
  - Report path return value
  - Handling when report file is not found
  - Model names with slashes (e.g., `org/model-name`)
- All 22 tests pass

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/25aff1ee26c4466daf6aa3f5b478c124)