### PR TITLE
Improve LLM config gitignore documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,7 +210,9 @@ workspace/
 !.openhands/microagents/
 .vscode/
 
-# LLM configuration directory (contains API keys and sensitive configs)
+# LLM configuration files
+# Contains API keys and sensitive configs - see README.md for setup instructions
+# Only the example template is tracked in version control
 .llm_config/
 !.llm_config/example.json
 


### PR DESCRIPTION
## Summary

This PR improves the documentation for the LLM configuration gitignore entries.

## Changes

- Updated the gitignore comment for LLM configuration files to be more descriptive
- Added reference to README.md for setup instructions
- Clarified that only the example template is tracked in version control

## Notes

The `.llm_config/` directory was already properly ignored with an exception for the `example.json` template file. This PR improves the documentation around these entries to make it clearer for contributors.

Fixes #206

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/34740e284a824f39a10f3faaa0dd39ee)