### PR TITLE
Add submitted_instances to SWT-Bench report

### DIFF
--- a/benchmarks/swtbench/eval_infer.py
+++ b/benchmarks/swtbench/eval_infer.py
@@ -155,6 +155,26 @@ def run_swtbench_evaluation(
 
             logger.info(f"SWT-Bench source installed at {swt_bench_dir}")
 
+        run_eval_path = swt_bench_dir / "src" / "run_evaluation.py"
+        if run_eval_path.exists():
+            run_eval_text = run_eval_path.read_text()
+            if "\"submitted_instances\"" not in run_eval_text:
+                old_line = "        \"completed_instances\": len(completed_ids),"
+                new_block = (
+                    "        \"completed_instances\": len(completed_ids),\n"
+                    "        \"submitted_instances\": len(resolved_ids) + len(unresolved_ids) + len(error_ids),"
+                )
+                if old_line not in run_eval_text:
+                    raise RuntimeError(
+                        "Unexpected SWT-Bench run_evaluation.py layout; "
+                        "cannot apply submitted_instances patch"
+                    )
+                run_eval_text = run_eval_text.replace(old_line, new_block)
+                run_eval_path.write_text(run_eval_text)
+                logger.info(
+                    "Patched SWT-Bench run_evaluation.py to emit submitted_instances"
+                )
+
         # Get the directory and filename of the predictions file
         predictions_path = Path(predictions_file).resolve()
         predictions_filename = predictions_path.name


### PR DESCRIPTION
## Summary
- Patch SWT-Bench run_evaluation report to emit submitted_instances (resolved+unresolved+error).
- Keep completed_instances unchanged for compatibility with existing reporting.

## Problem
format_report in evaluation expects submitted_instances to calculate totals; SWT-Bench report.json does not emit it today, so submitted_instances is 0 even when runs complete. This makes Slack summaries misleading.

## Fix
Add submitted_instances to the report dict inside SWT-Bench's run_evaluation.py (patched via eval_infer). The value is deterministic from the resolved/unresolved/error lists, so it matches actual submissions without changing evaluation logic.

## Testing
- Not run (reporting-only change).