### PR TITLE
Add run-eval dispatch workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -13,7 +13,6 @@ on:
           - swebench
           - swtbench
           - commit0
-          - openagentsafety
       sdk_ref:
         description: SDK commit/ref to evaluate
         required: true

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ gh workflow run run-eval.yml --repo OpenHands/benchmarks --ref main \
 ```
 
 Inputs (forwarded to the SDK `run-eval.yml` workflow):
-- `benchmark`: Benchmark suite to run. Choices: `gaia`, `swebench`, `swtbench`, `commit0`, `openagentsafety`. Default: `swebench`.
+- `benchmark`: Benchmark suite to run. Choices: `gaia`, `swebench`, `swtbench`, `commit0`. Default: `swebench`.
 - `sdk_ref`: SDK commit, tag, or branch to evaluate. Default: `main`.
 - `eval_limit`: Number of instances to run. Choices: `1`, `50`, `200`, `500`. Default: `1`.
 - `model_ids`: Comma-separated model IDs (keys of `MODELS` in the SDK `.github/run-eval/resolve_model_config.py`). Empty uses the SDK default.


### PR DESCRIPTION
## Summary
- add workflow_dispatch-only run-eval dispatcher to software-agent-sdk
- document how to trigger evals from the benchmarks repo

## Testing
- E2E eval (swebench, eval_limit=1, reason=testing benchmarks workflow entrypoint): https://github.com/OpenHands/evaluation/actions/runs/20598716691
- Slack report https://openhands-ai.slack.com/archives/C09QGUDQVTL/p1767105670842899