### PR TITLE
Add configurable conversation timeout to all benchmarks

### DIFF
--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -303,7 +303,8 @@ class GAIAEvaluation(Evaluation):
             conversation.send_message(msg)
         else:
             conversation.send_message(instruction)
-        conversation.run()
+        run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", "3600"))
+        conversation.run(timeout=run_timeout)
 
         # Extract answer from conversation history
         model_answer_raw = self._extract_answer_from_history(conversation.state.events)

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -340,7 +340,8 @@ class MultiSWEBenchEvaluation(Evaluation):
             workspace_path=workspace.working_dir,
         )
         conversation.send_message(instruction)
-        conversation.run()
+        run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", "3600"))
+        conversation.run(timeout=run_timeout)
 
         # git add
         workspace.execute_command(f"cd {repo_path} ; git add -A")

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -434,10 +434,11 @@ class OpenAgentSafetyEvaluation(Evaluation):
         conversation.send_message(instruction)
 
         # Run conversation with error handling
+        run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", "3600"))
         try:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)
-                conversation.run()
+                conversation.run(timeout=run_timeout)
             logger.info(f"Conversation completed for {instance.id}")
         except ValidationError as e:
             logger.warning(f"Validation error from custom events (continuing): {e}")

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -247,7 +247,8 @@ class SWEBenchEvaluation(Evaluation):
             workspace_path=workspace.working_dir,
         )
         conversation.send_message(instruction)
-        conversation.run()
+        run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", "3600"))
+        conversation.run(timeout=run_timeout)
 
         # git add
         workspace.execute_command(f"cd {repo_path} ; git add -A")

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -291,7 +291,8 @@ class SWEBenchEvaluation(Evaluation):
         else:
             logger.info("No image_assets found, sending text-only instruction")
             conversation.send_message(instruction)
-        conversation.run()
+        run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", "3600"))
+        conversation.run(timeout=run_timeout)
 
         # git add
         workspace.execute_command(f"cd {repo_path} ; git add -A")

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -274,7 +274,8 @@ class SWTBenchEvaluation(Evaluation):
             workspace_path=workspace.working_dir,
         )
         conversation.send_message(instruction)
-        conversation.run()
+        run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", "3600"))
+        conversation.run(timeout=run_timeout)
 
         # git add
         workspace.execute_command(f"cd {repo_path} ; git add -A")


### PR DESCRIPTION
## Summary
Extends the timeout configuration from PR #235 (commit0) to all other benchmarks:
- gaia
- multiswebench
- openagentsafety
- swebench
- swebenchmultimodal
- swtbench

## Changes
Each benchmark's `run_infer.py` now reads the `CONVERSATION_TIMEOUT` environment variable (default: 3600 seconds / 1 hour) and passes it to `conversation.run(timeout=run_timeout)`.

## Notes
- This is a follow-up to #235 as requested in the PR comments
- Default timeout is 1 hour (3600 seconds), configurable via `CONVERSATION_TIMEOUT` env var

## Testing
- Pre-commit checks pass (ruff format, ruff lint, pycodestyle, pyright)

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/84d4d6d1d8a842f0a3a1389e418838ae)