### PR TITLE
Capture conversation archives for failed eval instances

### DIFF
--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -406,10 +406,6 @@ class Evaluation(ABC, BaseModel):
                 try:
                     workspace = self.prepare_workspace(instance)
                     out = self.evaluate_instance(instance, workspace)
-
-                    # Capture conversation archive after successful evaluation
-                    self._capture_conversation_archive(workspace, instance)
-
                     logger.info("[child] done id=%s", instance.id)
                     return instance, out
                 except Exception as e:
@@ -436,6 +432,14 @@ class Evaluation(ABC, BaseModel):
                 finally:
                     # Ensure workspace cleanup happens regardless of success or failure
                     if workspace is not None:
+                        try:
+                            self._capture_conversation_archive(workspace, instance)
+                        except Exception as archive_error:
+                            logger.warning(
+                                "[child] Failed to capture conversation archive for %s: %s",
+                                instance.id,
+                                archive_error,
+                            )
                         try:
                             # Use the context manager protocol for cleanup
                             workspace.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
- capture conversation archives in `_process_one_mp` even when instances fail, by running archive capture in the cleanup path before workspace teardown
- behavior stays minimal: no extra timeout guard, and tests unchanged

## Behavior notes
- archives are saved as `conversations/{instance.id}.tar.gz` when `/workspace/conversations` exists, regardless of eval success/failure
- no archive is produced if workspace creation fails entirely or the conversations directory isnt present
- relies on the default workspace command timeout (no additional guard)

## Testing
- ./.venv/bin/pytest tests/test_workspace_cleanup.py