### PR TITLE
Re-apply resource factor backoff after revert

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -161,9 +161,17 @@ class Commit0Evaluation(Evaluation):
         logger.info("Total instances to process: %d", len(instances))
         return instances
 
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
         """
         Create workspace and set up the commit0 repository.
+
+        Args:
+            instance: The evaluation instance to prepare workspace for.
+            resource_factor: Resource factor for runtime allocation (default: 1).
+                           Higher values allocate more CPU/memory resources.
+                           Used by APIRemoteWorkspace for remote runtime allocation.
         """
         repo_name = instance.data["repo"].split("/")[1]
         base_docker_image = get_base_docker_image(repo_name)
@@ -201,7 +209,8 @@ class Commit0Evaluation(Evaluation):
                 )
 
             logger.info(
-                f"Using remote workspace with image {agent_server_image} (sdk sha: {sdk_short_sha})"
+                f"Using remote workspace with image {agent_server_image} "
+                f"(sdk sha: {sdk_short_sha}, resource_factor: {resource_factor})"
             )
             workspace = APIRemoteWorkspace(
                 runtime_api_url=os.getenv(
@@ -211,6 +220,7 @@ class Commit0Evaluation(Evaluation):
                 server_image=agent_server_image,
                 resource_factor=self.metadata.runtime_resource_factor,
                 target_type="source" if "source" in build_target else "binary",
+                resource_factor=resource_factor,
             )
         else:
             raise ValueError(

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -131,8 +131,17 @@ class GAIAEvaluation(Evaluation):
         logger.info(f"Total instances to process: {len(instances)}")
         return instances
 
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
-        """Create workspace and copy necessary files."""
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
+        """Create workspace and copy necessary files.
+
+        Args:
+            instance: The evaluation instance to prepare workspace for.
+            resource_factor: Resource factor for runtime allocation (default: 1).
+                           Higher values allocate more CPU/memory resources.
+                           Used by APIRemoteWorkspace for remote runtime allocation.
+        """
         logger.info(f"Preparing workspace for instance {instance.id}")
 
         if self.metadata.workspace_type == "docker":
@@ -165,7 +174,8 @@ class GAIAEvaluation(Evaluation):
                 )
 
             logger.info(
-                f"Using remote workspace with GAIA image {agent_server_image} (sdk sha: {sdk_short_sha})"
+                f"Using remote workspace with GAIA image {agent_server_image} "
+                f"(sdk sha: {sdk_short_sha}, resource_factor: {resource_factor})"
             )
             workspace = APIRemoteWorkspace(
                 runtime_api_url=os.getenv(
@@ -175,6 +185,7 @@ class GAIAEvaluation(Evaluation):
                 server_image=agent_server_image,
                 resource_factor=self.metadata.runtime_resource_factor,
                 target_type="binary",  # GAIA images use binary target
+                resource_factor=resource_factor,
             )
         else:
             raise ValueError(

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -173,9 +173,17 @@ class MultiSWEBenchEvaluation(Evaluation):
         return instances
 
     # ---- Hook: prepare a workspace per instance ----------------------------------
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
+
+        Args:
+            instance: The evaluation instance to prepare workspace for.
+            resource_factor: Resource factor for runtime allocation (default: 1).
+                           Higher values allocate more CPU/memory resources.
+                           Used by APIRemoteWorkspace for remote runtime allocation.
         """
         # Ensure instance.data has required fields for docker image naming
         if "version" not in instance.data and "number" in instance.data:
@@ -246,7 +254,8 @@ class MultiSWEBenchEvaluation(Evaluation):
                     "make sure to build, push it, and make it public accessible before using remote workspace."
                 )
             logger.info(
-                f"Using remote workspace with image {agent_server_image} (sdk sha: {sdk_short_sha})"
+                f"Using remote workspace with image {agent_server_image} "
+                f"(sdk sha: {sdk_short_sha}, resource_factor: {resource_factor})"
             )
             workspace = APIRemoteWorkspace(
                 runtime_api_url=os.getenv(
@@ -256,6 +265,7 @@ class MultiSWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 resource_factor=self.metadata.runtime_resource_factor,
                 target_type="source" if "source" in build_target else "binary",
+                resource_factor=resource_factor,
             )
         else:
             raise ValueError(

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -359,8 +359,17 @@ class OpenAgentSafetyEvaluation(Evaluation):
         logger.info("Total instances to process: %d", len(instances))
         return instances
 
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
-        """Create a fresh Docker workspace for this instance."""
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
+        """Create a fresh Docker workspace for this instance.
+
+        Args:
+            instance: The evaluation instance to prepare workspace for.
+            resource_factor: Resource factor for runtime allocation (default: 1).
+                           Higher values allocate more CPU/memory resources.
+                           Note: Currently only used by remote workspaces.
+        """
         server_image = build_workspace_image()
 
         workspace = DockerWorkspace(

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -96,9 +96,17 @@ class SWEBenchEvaluation(Evaluation):
         return instances
 
     # ---- Hook: prepare a workspace per instance ----------------------------------
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
+
+        Args:
+            instance: The evaluation instance to prepare workspace for.
+            resource_factor: Resource factor for runtime allocation (default: 1).
+                           Higher values allocate more CPU/memory resources.
+                           Used by APIRemoteWorkspace for remote runtime allocation.
         """
         official_docker_image = get_official_docker_image(instance.id)
         build_target = "source-minimal"
@@ -166,7 +174,8 @@ class SWEBenchEvaluation(Evaluation):
                     "make sure to build, push it, and make it public accessible before using remote workspace."
                 )
             logger.info(
-                f"Using remote workspace with image {agent_server_image} (sdk sha: {sdk_short_sha})"
+                f"Using remote workspace with image {agent_server_image} "
+                f"(sdk sha: {sdk_short_sha}, resource_factor: {resource_factor})"
             )
             workspace = APIRemoteWorkspace(
                 runtime_api_url=os.getenv(
@@ -176,6 +185,7 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 resource_factor=self.metadata.runtime_resource_factor,
                 target_type="source" if "source" in build_target else "binary",
+                resource_factor=resource_factor,
             )
         else:
             raise ValueError(

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -103,9 +103,17 @@ class SWEBenchEvaluation(Evaluation):
         return instances
 
     # ---- Hook: prepare a workspace per instance ----------------------------------
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
+
+        Args:
+            instance: The evaluation instance to prepare workspace for.
+            resource_factor: Resource factor for runtime allocation (default: 1).
+                           Higher values allocate more CPU/memory resources.
+                           Used by APIRemoteWorkspace for remote runtime allocation.
         """
         # Use multimodal image
         official_docker_image = get_official_docker_image(instance.id)
@@ -166,7 +174,8 @@ class SWEBenchEvaluation(Evaluation):
                     "make sure to build, push it, and make it public accessible before using remote workspace."
                 )
             logger.info(
-                f"Using remote workspace with image {agent_server_image} (sdk sha: {sdk_short_sha})"
+                f"Using remote workspace with image {agent_server_image} "
+                f"(sdk sha: {sdk_short_sha}, resource_factor: {resource_factor})"
             )
             workspace = APIRemoteWorkspace(
                 runtime_api_url=os.getenv(
@@ -176,6 +185,7 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 resource_factor=self.metadata.runtime_resource_factor,
                 target_type="source" if "source" in build_target else "binary",
+                resource_factor=resource_factor,
             )
         else:
             raise ValueError(

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -135,9 +135,17 @@ class SWTBenchEvaluation(Evaluation):
         return instances
 
     # ---- Hook: prepare a workspace per instance ----------------------------------
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
         """
         Create workspace based on workspace_type (docker or remote).
+
+        Args:
+            instance: The evaluation instance to prepare workspace for.
+            resource_factor: Resource factor for runtime allocation (default: 1).
+                           Higher values allocate more CPU/memory resources.
+                           Used by APIRemoteWorkspace for remote runtime allocation.
         """
         official_docker_image = get_official_docker_image(instance.id)
         build_target = "source-minimal"
@@ -191,7 +199,8 @@ class SWTBenchEvaluation(Evaluation):
                     "make sure to build, push it, and make it public accessible before using remote workspace."
                 )
             logger.info(
-                f"Using remote workspace with image {agent_server_image} (sdk sha: {sdk_short_sha})"
+                f"Using remote workspace with image {agent_server_image} "
+                f"(sdk sha: {sdk_short_sha}, resource_factor: {resource_factor})"
             )
             workspace = APIRemoteWorkspace(
                 runtime_api_url=os.getenv(
@@ -201,6 +210,7 @@ class SWTBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 resource_factor=self.metadata.runtime_resource_factor,
                 target_type="source" if "source" in build_target else "binary",
+                resource_factor=resource_factor,
             )
         else:
             raise ValueError(

--- a/benchmarks/utils/exceptions.py
+++ b/benchmarks/utils/exceptions.py
@@ -1,6 +1,68 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
 class EvalException(Exception):
     pass
 
 
 class EvalTimeoutException(Exception):
     pass
+
+
+# Runtime error exceptions for testing and handling
+class AgentRuntimeDisconnectedError(Exception):
+    """Raised when the agent runtime becomes disconnected."""
+
+    pass
+
+
+# Fatal runtime error types that indicate the runtime crashed or disconnected
+# These are based on the OpenHands evaluation patterns
+FATAL_RUNTIME_ERRORS = [
+    "RuntimeTimeoutError",
+    "RuntimeUnavailableError",
+    "RuntimeDisconnectedError",
+    "RuntimeNotFoundError",
+    "AgentRuntimeTimeoutError",
+    "AgentRuntimeUnavailableError",
+    "AgentRuntimeDisconnectedError",
+    "AgentRuntimeNotFoundError",
+    "ConnectionError",
+    "RuntimeError",  # Generic runtime errors
+    "httpx.ConnectError",
+    "httpx.ReadTimeout",
+    "httpx.ConnectTimeout",
+]
+
+
+def is_fatal_runtime_error(error: str | Exception | None) -> bool:
+    """Check if an error indicates a fatal runtime failure.
+
+    Fatal runtime errors are those that indicate the runtime crashed,
+    disconnected, or became unavailable. These errors should trigger
+    a retry with increased resources.
+
+    Args:
+        error: The error string, exception, or None
+
+    Returns:
+        True if this is a fatal runtime error that should trigger resource increase
+    """
+    if error is None:
+        return False
+
+    error_str = str(error) if isinstance(error, Exception) else error
+
+    # Also check the exception type name
+    if isinstance(error, Exception):
+        error_str = f"{type(error).__name__}: {error_str}"
+
+    for fatal_error in FATAL_RUNTIME_ERRORS:
+        if fatal_error in error_str:
+            logger.warning(f"Fatal runtime error detected: {error_str}")
+            return True
+
+    return False

--- a/benchmarks/utils/models.py
+++ b/benchmarks/utils/models.py
@@ -57,6 +57,22 @@ class EvalMetadata(BaseModel):
         default="docker",
         description="Type of workspace to use, e.g., 'docker' or 'remote'",
     )
+    base_resource_factor: int = Field(
+        default=1,
+        ge=1,
+        le=8,
+        description=(
+            "Base resource factor for runtime allocation. "
+            "When a runtime crashes, this will be exponentially increased "
+            "(2^runtime_failure_count) up to max_resource_factor."
+        ),
+    )
+    max_resource_factor: int = Field(
+        default=8,
+        ge=1,
+        le=16,
+        description="Maximum resource factor to use after retries.",
+    )
 
 
 EvalInstanceID = str

--- a/tests/test_iterative_resume.py
+++ b/tests/test_iterative_resume.py
@@ -25,7 +25,9 @@ class MockEvaluation(Evaluation):
         """Return pre-configured instances."""
         return object.__getattribute__(self, "_test_instances")
 
-    def prepare_workspace(self, instance: EvalInstance) -> RemoteWorkspace:
+    def prepare_workspace(
+        self, instance: EvalInstance, resource_factor: int = 1
+    ) -> RemoteWorkspace:
         """Return a mock workspace."""
         mock_workspace = Mock(spec=RemoteWorkspace)
         mock_workspace.__enter__ = Mock(return_value=mock_workspace)

--- a/tests/test_workspace_cleanup.py
+++ b/tests/test_workspace_cleanup.py
@@ -52,7 +52,7 @@ def test_workspace_cleanup_called_on_success():
         def prepare_instances(self) -> List[EvalInstance]:
             return [test_instance]
 
-        def prepare_workspace(self, instance: EvalInstance):
+        def prepare_workspace(self, instance: EvalInstance, resource_factor: int = 1):
             return mock_workspace
 
         def evaluate_instance(self, instance, workspace):
@@ -102,7 +102,7 @@ def test_workspace_cleanup_called_on_failure():
         def prepare_instances(self) -> List[EvalInstance]:
             return [test_instance]
 
-        def prepare_workspace(self, instance: EvalInstance):
+        def prepare_workspace(self, instance: EvalInstance, resource_factor: int = 1):
             return mock_workspace
 
         def evaluate_instance(self, instance, workspace):
@@ -163,7 +163,7 @@ def test_workspace_cleanup_handles_cleanup_exception():
         def prepare_instances(self) -> List[EvalInstance]:
             return [test_instance]
 
-        def prepare_workspace(self, instance: EvalInstance):
+        def prepare_workspace(self, instance: EvalInstance, resource_factor: int = 1):
             return mock_workspace
 
         def evaluate_instance(self, instance, workspace):
@@ -221,7 +221,7 @@ def test_workspace_cleanup_with_retries():
         def prepare_instances(self) -> List[EvalInstance]:
             return [test_instance]
 
-        def prepare_workspace(self, instance: EvalInstance):
+        def prepare_workspace(self, instance: EvalInstance, resource_factor: int = 1):
             return create_mock_workspace()
 
         def evaluate_instance(self, instance, workspace):
@@ -247,6 +247,87 @@ def test_workspace_cleanup_with_retries():
     assert len(workspaces_created) == 3, "Should create workspace for each attempt"
     for workspace in workspaces_created:
         workspace.__exit__.assert_called_once_with(None, None, None)
+
+    # Final result should be successful
+    assert result_instance.id == "test_instance"
+    assert result_output.instance_id == "test_instance"
+    assert result_output.error is None
+
+
+def test_resource_factor_increases_on_runtime_failures():
+    """Test that resource factor increases exponentially on runtime failures."""
+    # Import here to avoid circular imports
+    from benchmarks.utils.evaluation import Evaluation
+    from benchmarks.utils.exceptions import AgentRuntimeDisconnectedError
+
+    # Track resource factors passed to prepare_workspace
+    resource_factors_used = []
+
+    def create_mock_workspace(resource_factor):
+        workspace = Mock()
+        workspace.__exit__ = Mock()
+        resource_factors_used.append(resource_factor)
+        return workspace
+
+    # Create test instance
+    test_instance = EvalInstance(id="test_instance", data={"test": "data"})
+
+    # Create evaluation metadata with retries
+    llm = LLM(model="test-model")
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset="test",
+        dataset_split="test",
+        max_iterations=10,
+        eval_output_dir="/tmp/test",
+        details={},
+        eval_limit=1,
+        max_attempts=1,
+        max_retries=3,  # Allow 3 retries
+        base_resource_factor=1,
+        max_resource_factor=8,
+        critic=PassCritic(),
+    )
+
+    # Track evaluation attempts
+    attempt_count = 0
+
+    # Create a concrete evaluation class for testing with resource_factor support
+    class TestEvaluation(Evaluation):
+        def prepare_instances(self) -> List[EvalInstance]:
+            return [test_instance]
+
+        def prepare_workspace(self, instance: EvalInstance, resource_factor: int = 1):
+            return create_mock_workspace(resource_factor)
+
+        def evaluate_instance(self, instance, workspace):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count <= 3:
+                # Simulate runtime crashes with fatal runtime error
+                raise AgentRuntimeDisconnectedError(
+                    f"Runtime disconnected on attempt {attempt_count}"
+                )
+            return EvalOutput(
+                instance_id=instance.id,
+                test_result={"success": True},
+                instruction="test instruction",
+                error=None,
+                history=[],
+                instance=instance.data,
+            )
+
+    evaluator = TestEvaluation(metadata=metadata, num_workers=1)
+
+    # Call the method directly
+    result_instance, result_output = evaluator._process_one_mp(test_instance)
+
+    # Verify resource factors increased exponentially: 1, 2, 4, 8
+    assert len(resource_factors_used) == 4, "Should have 4 attempts"
+    assert resource_factors_used[0] == 1, "First attempt should have factor 1"
+    assert resource_factors_used[1] == 2, "Second attempt should have factor 2"
+    assert resource_factors_used[2] == 4, "Third attempt should have factor 4"
+    assert resource_factors_used[3] == 8, "Fourth attempt should have factor 8"
 
     # Final result should be successful
     assert result_instance.id == "test_instance"


### PR DESCRIPTION
Restores the changes from #258 (reverted by #270) so we can iterate and validate the runtime crash resource scaling.