### PR TITLE
Add max_retries to run-eval workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: 'false'
         type: string
+      max_retries:
+        description: Max retries per instance (passed to benchmarks)
+        required: false
+        default: '3'
+        type: string
 
 jobs:
   dispatch-run-eval:
@@ -90,6 +95,7 @@ jobs:
           NUM_INFER_WORKERS: ${{ github.event.inputs.num_infer_workers }}
           NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers }}
           PUSH_TO_INDEX: ${{ github.event.inputs.push_to_index }}
+          MAX_RETRIES: ${{ github.event.inputs.max_retries }}
         run: |
           set -euo pipefail
           if [ -z "$PAT_TOKEN" ]; then
@@ -110,7 +116,8 @@ jobs:
             --arg num_infer_workers "$NUM_INFER_WORKERS" \
             --arg num_eval_workers "$NUM_EVAL_WORKERS" \
             --arg push_to_index "$PUSH_TO_INDEX" \
-            '{ref: $ref, inputs: {benchmark: $benchmark, sdk_ref: $sdk_ref, eval_limit: $eval_limit, model_ids: $model_ids, reason: $reason, eval_branch: $eval_branch, benchmarks_branch: $benchmarks_branch, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index}}')
+            --arg max_retries "$MAX_RETRIES" \
+            '{ref: $ref, inputs: {benchmark: $benchmark, sdk_ref: $sdk_ref, eval_limit: $eval_limit, model_ids: $model_ids, reason: $reason, eval_branch: $eval_branch, benchmarks_branch: $benchmarks_branch, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index, max_retries: $max_retries}}')
 
           RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
             -H "Authorization: token $PAT_TOKEN" \


### PR DESCRIPTION
## Summary
- add workflow_dispatch input max_retries (default 3)
- pass it through env and dispatch payload to software-agent-sdk run-eval
- maintain parity with OpenHands/software-agent-sdk#1641

## Testing
- not run (workflow change only)
