### PR TITLE
Consolidate repo guidance into AGENTS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing
-
-Contribution guidance has been consolidated into [`AGENTS.md`](AGENTS.md).


### PR DESCRIPTION
## Summary

- Move content from `.openhands/microagents/repo.md` to `AGENTS.md`
- Create symlink `.openhands/skills/repo.md` -> `../../AGENTS.md`
- Create symlink `CONTRIBUTING.md` -> `AGENTS.md` (if not existing)

This establishes `AGENTS.md` as the single source of truth for repository guidance, following the pattern from https://github.com/OpenHands/OpenHands-CLI/pull/340