### PR TITLE
Fix: Don't crash when no entries are converted in swebenchmultimodal

### DIFF
--- a/benchmarks/swebenchmultimodal/eval_infer.py
+++ b/benchmarks/swebenchmultimodal/eval_infer.py
@@ -106,9 +106,6 @@ def convert_to_swebench_format(
         f"{error_count} errors"
     )
 
-    if converted_count == 0:
-        raise ValueError("No valid entries were converted")
-
 
 def run_swebench_multimodal_evaluation(
     predictions_file: str,

--- a/tests/test_swebenchmultimodal.py
+++ b/tests/test_swebenchmultimodal.py
@@ -1,0 +1,30 @@
+"""Tests for SWE-Bench Multimodal eval_infer functionality."""
+
+import tempfile
+
+from benchmarks.swebenchmultimodal.eval_infer import convert_to_swebench_format
+
+
+class TestConvertToSwebenchFormat:
+    """Tests for convert_to_swebench_format function."""
+
+    def test_empty_input_file_does_not_raise(self):
+        """Test that an empty input file does not raise an exception."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as infile:
+            infile.write("")  # Empty file
+            input_path = infile.name
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".swebench.jsonl", delete=False
+        ) as outfile:
+            output_path = outfile.name
+
+        # Should not raise - let the harness handle empty results
+        convert_to_swebench_format(input_path, output_path)
+
+        # Verify output file is empty
+        with open(output_path, "r") as f:
+            lines = f.readlines()
+        assert len(lines) == 0


### PR DESCRIPTION
## Summary

When running `eval_infer` in swebenchmultimodal with no valid entries to convert, the script was crashing with a `ValueError`. This PR removes that exception so the script continues normally, letting the harness be responsible for handling empty results.

## Changes

- Removed the `ValueError` exception in `convert_to_swebench_format` when `converted_count == 0`
- Added a test to verify empty input files don't raise exceptions

Fixes #338

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/77bd065a8cfe43c8b2fadb000b14e847)