### PR TITLE
Increase accuracy of SWT bench results

### DIFF
--- a/benchmarks/swtbench/eval_infer.py
+++ b/benchmarks/swtbench/eval_infer.py
@@ -226,6 +226,7 @@ def convert_to_swtbench_format(
 
 def run_swtbench_evaluation(
     predictions_file: str,
+    # Must use SWE-bench dataset because SWT-bench dataset (which is based on SWE-bench) contains a bug in their harness.
     dataset: str = "princeton-nlp/SWE-bench_Verified",
     workers: str = "12",
 ) -> None:
@@ -366,6 +367,7 @@ Examples:
 
     parser.add_argument("input_file", help="Path to the OpenHands output.jsonl file")
 
+    # Must use SWE-bench dataset because SWT-bench dataset (which is based on SWE-bench) contains a bug in their harness.
     parser.add_argument(
         "--dataset",
         default="princeton-nlp/SWE-bench_Verified",


### PR DESCRIPTION
We were getting low SWT bench results due to harness errors. Shoutout to @simonrosenberg , we tested many things to get to this PR.

SWT-bench dataset is based on the SWE-bench dataset but contains less instances (433 vs 500). v0 implementation of SWT-bench used the SWE-bench dataset, when migrating we decided to implement SWT-bench dataset. 
It seems that their harness contains a bug when running with the SWT bench dataset, but works with the SWE-bench dataset.

This fix increases the results of experiment with time stamp  26-01-16-19-09 from

- Total instances: 10
- Submitted instances: 10
- Resolved instances: 0
- Unresolved instances: 9
- Empty patch instances: 0
- Error instances: 1
- Eval limit: 10
- Success rate: 0/10 (0.0%)

to

- Total instances: 10
- Instances completed: 10
- Mean coverage: 0.8166666666666667
- Mean coverage delta: 0.8166666666666667
- Instances resolved: 9
- Instances unresolved: 1
- Instances with errors: 0
- Instances still running: 0
- Still existing images: 10