### PR TITLE
Regroup constant values in constants.py files

### DIFF
--- a/benchmarks/commit0/constants.py
+++ b/benchmarks/commit0/constants.py
@@ -1,0 +1,23 @@
+"""
+Commit0 benchmark-specific constants.
+
+This file contains constant values specific to the Commit0 benchmark.
+Shared constants are defined in benchmarks/utils/constants.py.
+"""
+
+import os
+
+
+# Dataset configuration
+COMMIT0_DATASET = "wentingzhao/commit0_combined"
+COMMIT0_DEFAULT_SPLIT = "test"
+DEFAULT_REPO_SPLIT = "lite"
+
+# Docker image configuration
+DEFAULT_DOCKER_IMAGE_PREFIX = "docker.io/wentingzhao/"
+DOCKER_IMAGE_PREFIX = os.environ.get(
+    "EVAL_DOCKER_IMAGE_PREFIX", DEFAULT_DOCKER_IMAGE_PREFIX
+)
+
+# Build target configuration
+DEFAULT_BUILD_TARGET = "source-minimal"

--- a/benchmarks/gaia/build_images.py
+++ b/benchmarks/gaia/build_images.py
@@ -13,6 +13,7 @@ Example:
 import sys
 from pathlib import Path
 
+from benchmarks.gaia.constants import GAIA_BASE_IMAGE, GAIA_DEFAULT_SPLIT
 from benchmarks.utils.build_utils import (
     BuildOutput,
     _get_sdk_submodule_info,
@@ -26,8 +27,6 @@ from openhands.sdk import get_logger
 
 logger = get_logger(__name__)
 
-# GAIA base image: Python 3.12 + Node.js 22 (default for agent server)
-GAIA_BASE_IMAGE = "nikolaik/python-nodejs:python3.12-nodejs22"
 # MCP layer Dockerfile
 MCP_DOCKERFILE = Path(__file__).with_name("Dockerfile.gaia")
 
@@ -74,7 +73,7 @@ def main(argv: list[str]) -> int:
         return f"gaia-{args.target}"
 
     # Build base GAIA image
-    build_dir = default_build_output_dir("gaia", "validation")
+    build_dir = default_build_output_dir("gaia", GAIA_DEFAULT_SPLIT)
     exit_code = build_all_images(
         base_images=base_images,
         target=args.target,

--- a/benchmarks/gaia/constants.py
+++ b/benchmarks/gaia/constants.py
@@ -1,0 +1,22 @@
+"""
+GAIA benchmark-specific constants.
+
+This file contains constant values specific to the GAIA benchmark.
+Shared constants are defined in benchmarks/utils/constants.py.
+"""
+
+from pathlib import Path
+
+
+# Dataset configuration
+GAIA_DATASET = "gaia-benchmark/GAIA"
+GAIA_DEFAULT_SPLIT = "validation"
+
+# Docker image configuration
+GAIA_BASE_IMAGE = "nikolaik/python-nodejs:python3.12-nodejs22"
+
+# Cache directory for GAIA dataset files
+DATASET_CACHE_DIR = Path(__file__).parent / "data"
+
+# GAIA data year (used for file paths)
+GAIA_DATA_YEAR = "2023"

--- a/benchmarks/multiswebench/constants.py
+++ b/benchmarks/multiswebench/constants.py
@@ -1,0 +1,32 @@
+"""
+Multi-SWE-bench benchmark-specific constants.
+
+This file contains constant values specific to the Multi-SWE-bench benchmark.
+Shared constants are defined in benchmarks/utils/constants.py.
+"""
+
+import os
+from pathlib import Path
+
+
+# Dataset configuration
+MULTISWEBENCH_DATASET = "ByteDance-Seed/Multi-SWE-bench"
+MULTISWEBENCH_DEFAULT_SPLIT = "test"
+DEFAULT_LANG = "java"
+
+# Docker image configuration
+DEFAULT_DOCKER_IMAGE_PREFIX = "mswebench"
+DOCKER_IMAGE_PREFIX = os.environ.get(
+    "EVAL_DOCKER_IMAGE_PREFIX", DEFAULT_DOCKER_IMAGE_PREFIX
+)
+
+# Cache directory for Multi-SWE-bench dataset files
+DATASET_CACHE_DIR = Path(__file__).parent / "data"
+
+# Build target configuration
+DEFAULT_BUILD_TARGET = "source-minimal"
+
+# Environment variables for Multi-SWE-Bench configuration
+USE_HINT_TEXT = os.environ.get("USE_HINT_TEXT", "false").lower() == "true"
+USE_INSTANCE_IMAGE = os.environ.get("USE_INSTANCE_IMAGE", "true").lower() == "true"
+RUN_WITH_BROWSING = os.environ.get("RUN_WITH_BROWSING", "false").lower() == "true"

--- a/benchmarks/openagentsafety/constants.py
+++ b/benchmarks/openagentsafety/constants.py
@@ -1,0 +1,12 @@
+"""
+OpenAgentSafety benchmark-specific constants.
+
+This file contains constant values specific to the OpenAgentSafety benchmark.
+Shared constants are defined in benchmarks/utils/constants.py.
+"""
+
+# Docker image configuration
+OPENAGENTSAFETY_SERVER_IMAGE = "openagentsafety-agent-server:local"
+
+# Default NPC model configuration
+DEFAULT_NPC_MODEL = "litellm_proxy/openai/gpt-4o"

--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -12,6 +12,10 @@ Example:
 import sys
 from pathlib import Path
 
+from benchmarks.swebench.constants import (
+    SWEBENCH_DOCKER_IMAGE_PREFIX,
+    WRAPPED_REPOS,
+)
 from benchmarks.utils.build_utils import (
     BuildOutput,
     build_all_images,
@@ -26,13 +30,11 @@ from openhands.sdk import get_logger
 
 logger = get_logger(__name__)
 WRAPPER_DOCKERFILE = Path(__file__).with_name("Dockerfile.swebench-deps")
-# Repos that require the docutils/roman wrapper layer
-WRAPPED_REPOS = {"sphinx-doc"}
 
 
 def get_official_docker_image(
     instance_id: str,
-    docker_image_prefix="docker.io/swebench/",
+    docker_image_prefix: str = SWEBENCH_DOCKER_IMAGE_PREFIX,
 ) -> str:
     # Official SWE-Bench image
     # swebench/sweb.eval.x86_64.django_1776_django-11333:v1

--- a/benchmarks/swebench/constants.py
+++ b/benchmarks/swebench/constants.py
@@ -1,0 +1,19 @@
+"""
+SWE-bench benchmark-specific constants.
+
+This file contains constant values specific to the SWE-bench benchmark.
+Shared constants are defined in benchmarks/utils/constants.py.
+"""
+
+# Dataset configuration
+SWEBENCH_DATASET = "princeton-nlp/SWE-bench_Verified"
+SWEBENCH_DEFAULT_SPLIT = "test"
+
+# Docker image configuration
+SWEBENCH_DOCKER_IMAGE_PREFIX = "docker.io/swebench/"
+
+# Repos that require the docutils/roman wrapper layer
+WRAPPED_REPOS = {"sphinx-doc"}
+
+# Build target configuration
+DEFAULT_BUILD_TARGET = "source-minimal"

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -10,9 +10,15 @@ from benchmarks.swebench.build_images import (
     should_wrap_instance_id,
     wrap_image,
 )
+from benchmarks.swebench.constants import DEFAULT_BUILD_TARGET
 from benchmarks.utils.args_parser import get_parser
 from benchmarks.utils.build_utils import build_image
-from benchmarks.utils.constants import EVAL_AGENT_SERVER_IMAGE
+from benchmarks.utils.constants import (
+    DEFAULT_ENV_SETUP_COMMANDS,
+    DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT,
+    DEFAULT_RUNTIME_API_URL,
+    EVAL_AGENT_SERVER_IMAGE,
+)
 from benchmarks.utils.conversation import build_event_persistence_callback
 from benchmarks.utils.critics import create_critic
 from benchmarks.utils.dataset import get_dataset
@@ -114,7 +120,7 @@ class SWEBenchEvaluation(Evaluation):
                            Used by APIRemoteWorkspace for remote runtime allocation.
         """
         official_docker_image = get_official_docker_image(instance.id)
-        build_target = "source-minimal"
+        build_target = DEFAULT_BUILD_TARGET
         custom_tag = extract_custom_tag(official_docker_image)
         # For non-binary targets, append target suffix
         suffix = f"-{build_target}" if build_target != "binary" else ""
@@ -183,11 +189,14 @@ class SWEBenchEvaluation(Evaluation):
                 f"Using remote workspace with image {agent_server_image} "
                 f"(sdk sha: {sdk_short_sha}, resource_factor: {resource_factor})"
             )
-            startup_timeout = float(os.getenv("REMOTE_RUNTIME_STARTUP_TIMEOUT", "600"))
+            startup_timeout = float(
+                os.getenv(
+                    "REMOTE_RUNTIME_STARTUP_TIMEOUT",
+                    str(DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT),
+                )
+            )
             workspace = APIRemoteWorkspace(
-                runtime_api_url=os.getenv(
-                    "RUNTIME_API_URL", "https://runtime.eval.all-hands.dev"
-                ),
+                runtime_api_url=os.getenv("RUNTIME_API_URL", DEFAULT_RUNTIME_API_URL),
                 runtime_api_key=runtime_api_key,
                 server_image=agent_server_image,
                 target_type="source" if "source" in build_target else "binary",
@@ -364,7 +373,7 @@ def main() -> None:
         details={},
         prompt_path=args.prompt_path,
         eval_limit=args.n_limit,
-        env_setup_commands=["export PIP_CACHE_DIR=~/.cache/pip"],
+        env_setup_commands=DEFAULT_ENV_SETUP_COMMANDS,
         max_attempts=args.max_attempts,
         critic=critic,
         selected_instances_file=args.select,

--- a/benchmarks/swebenchmultimodal/constants.py
+++ b/benchmarks/swebenchmultimodal/constants.py
@@ -1,0 +1,13 @@
+"""
+SWE-bench Multimodal benchmark-specific constants.
+
+This file contains constant values specific to the SWE-bench Multimodal benchmark.
+Shared constants are defined in benchmarks/utils/constants.py.
+"""
+
+# Dataset configuration
+SWEBENCH_MULTIMODAL_DATASET = "princeton-nlp/SWE-bench_Multimodal"
+SWEBENCH_MULTIMODAL_DEFAULT_SPLIT = "dev"
+
+# Build target configuration
+DEFAULT_BUILD_TARGET = "source-minimal"

--- a/benchmarks/swtbench/constants.py
+++ b/benchmarks/swtbench/constants.py
@@ -1,0 +1,12 @@
+"""
+SWT-bench benchmark-specific constants.
+
+This file contains constant values specific to the SWT-bench benchmark.
+Shared constants are defined in benchmarks/utils/constants.py.
+"""
+
+# Docker image configuration
+SWTBENCH_DOCKER_IMAGE_PREFIX = "docker.io/swtbench/"
+
+# Build target configuration
+DEFAULT_BUILD_TARGET = "source-minimal"

--- a/benchmarks/utils/args_parser.py
+++ b/benchmarks/utils/args_parser.py
@@ -4,6 +4,17 @@ Argument parsing utilities for SWE-bench benchmarks.
 
 import argparse
 
+from benchmarks.utils.constants import (
+    DEFAULT_DATASET,
+    DEFAULT_EVAL_LIMIT,
+    DEFAULT_MAX_ATTEMPTS,
+    DEFAULT_MAX_ITERATIONS,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_NUM_WORKERS,
+    DEFAULT_OUTPUT_DIR,
+    DEFAULT_SPLIT,
+    DEFAULT_WORKSPACE_TYPE,
+)
 from benchmarks.utils.critics import add_critic_args
 
 
@@ -23,41 +34,49 @@ def get_parser(add_llm_config: bool = True) -> argparse.ArgumentParser:
     parser.add_argument(
         "--dataset",
         type=str,
-        default="princeton-nlp/SWE-bench_Verified",
+        default=DEFAULT_DATASET,
         help="Dataset name",
     )
-    parser.add_argument("--split", type=str, default="test", help="Dataset split")
+    parser.add_argument(
+        "--split", type=str, default=DEFAULT_SPLIT, help="Dataset split"
+    )
     parser.add_argument(
         "--workspace",
         type=str,
-        default="docker",
+        default=DEFAULT_WORKSPACE_TYPE,
         choices=["docker", "remote"],
-        help="Type of workspace to use (default: docker)",
+        help=f"Type of workspace to use (default: {DEFAULT_WORKSPACE_TYPE})",
     )
     parser.add_argument(
-        "--max-iterations", type=int, default=100, help="Maximum iterations"
+        "--max-iterations",
+        type=int,
+        default=DEFAULT_MAX_ITERATIONS,
+        help="Maximum iterations",
     )
     parser.add_argument(
-        "--num-workers", type=int, default=1, help="Number of evaluation workers"
+        "--num-workers",
+        type=int,
+        default=DEFAULT_NUM_WORKERS,
+        help="Number of evaluation workers",
     )
     parser.add_argument("--note", type=str, default="initial", help="Evaluation note")
     parser.add_argument(
         "--output-dir",
         type=str,
-        default="./eval_outputs",
+        default=DEFAULT_OUTPUT_DIR,
         help="Evaluation output directory",
     )
     parser.add_argument(
         "--n-limit",
         type=int,
-        default=0,
+        default=DEFAULT_EVAL_LIMIT,
         help="Limit number of instances to evaluate",
     )
     parser.add_argument(
         "--max-attempts",
         type=int,
-        default=3,
-        help="Maximum number of attempts for iterative mode (default: 3, min: 1)",
+        default=DEFAULT_MAX_ATTEMPTS,
+        help=f"Maximum number of attempts for iterative mode (default: {DEFAULT_MAX_ATTEMPTS}, min: 1)",
     )
 
     # Add critic arguments
@@ -72,7 +91,7 @@ def get_parser(add_llm_config: bool = True) -> argparse.ArgumentParser:
     parser.add_argument(
         "--max-retries",
         type=int,
-        default=3,
-        help="Maximum retries for instances that throw exceptions (default: 3)",
+        default=DEFAULT_MAX_RETRIES,
+        help=f"Maximum retries for instances that throw exceptions (default: {DEFAULT_MAX_RETRIES})",
     )
     return parser

--- a/benchmarks/utils/constants.py
+++ b/benchmarks/utils/constants.py
@@ -1,2 +1,37 @@
+"""
+Shared constants for all benchmarks.
+
+This file contains constant values that are shared across multiple benchmarks.
+Benchmark-specific constants should be defined in {benchmark}/constants.py.
+"""
+
+# Output file configuration
 OUTPUT_FILENAME = "output.jsonl"
+
+# Docker image configuration
 EVAL_AGENT_SERVER_IMAGE = "ghcr.io/openhands/eval-agent-server"
+
+# Default dataset configuration
+DEFAULT_DATASET = "princeton-nlp/SWE-bench_Verified"
+DEFAULT_SPLIT = "test"
+
+# Default evaluation parameters
+DEFAULT_MAX_ITERATIONS = 100
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_NUM_WORKERS = 1
+DEFAULT_EVAL_LIMIT = 0
+
+# Workspace configuration
+DEFAULT_WORKSPACE_TYPE = "docker"
+DEFAULT_OUTPUT_DIR = "./eval_outputs"
+
+# Remote runtime configuration
+DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT = 600
+DEFAULT_RUNTIME_API_URL = "https://runtime.eval.all-hands.dev"
+
+# Environment setup commands (shared across benchmarks)
+DEFAULT_ENV_SETUP_COMMANDS = ["export PIP_CACHE_DIR=~/.cache/pip"]
+
+# Critic configuration
+DEFAULT_CRITIC = "pass"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,300 @@
+"""Tests for constants module.
+
+This test suite verifies that:
+1. Shared constants are properly defined in benchmarks/utils/constants.py
+2. Benchmark-specific constants are properly defined in {benchmark}/constants.py
+3. All constants can be imported correctly
+"""
+
+
+class TestSharedConstants:
+    """Test shared constants in benchmarks/utils/constants.py."""
+
+    def test_shared_constants_import(self):
+        """Test that shared constants can be imported."""
+        from benchmarks.utils.constants import (
+            DEFAULT_CRITIC,
+            DEFAULT_DATASET,
+            DEFAULT_ENV_SETUP_COMMANDS,
+            DEFAULT_EVAL_LIMIT,
+            DEFAULT_MAX_ATTEMPTS,
+            DEFAULT_MAX_ITERATIONS,
+            DEFAULT_MAX_RETRIES,
+            DEFAULT_NUM_WORKERS,
+            DEFAULT_OUTPUT_DIR,
+            DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT,
+            DEFAULT_RUNTIME_API_URL,
+            DEFAULT_SPLIT,
+            DEFAULT_WORKSPACE_TYPE,
+            EVAL_AGENT_SERVER_IMAGE,
+            OUTPUT_FILENAME,
+        )
+
+        # Verify values are not None
+        assert OUTPUT_FILENAME is not None
+        assert EVAL_AGENT_SERVER_IMAGE is not None
+        assert DEFAULT_DATASET is not None
+        assert DEFAULT_SPLIT is not None
+        assert DEFAULT_MAX_ITERATIONS is not None
+        assert DEFAULT_MAX_ATTEMPTS is not None
+        assert DEFAULT_MAX_RETRIES is not None
+        assert DEFAULT_NUM_WORKERS is not None
+        assert DEFAULT_EVAL_LIMIT is not None
+        assert DEFAULT_WORKSPACE_TYPE is not None
+        assert DEFAULT_OUTPUT_DIR is not None
+        assert DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT is not None
+        assert DEFAULT_RUNTIME_API_URL is not None
+        assert DEFAULT_ENV_SETUP_COMMANDS is not None
+        assert DEFAULT_CRITIC is not None
+
+    def test_shared_constants_values(self):
+        """Test that shared constants have expected values."""
+        from benchmarks.utils.constants import (
+            DEFAULT_DATASET,
+            DEFAULT_MAX_ITERATIONS,
+            DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT,
+            DEFAULT_RUNTIME_API_URL,
+            DEFAULT_SPLIT,
+            DEFAULT_WORKSPACE_TYPE,
+            EVAL_AGENT_SERVER_IMAGE,
+            OUTPUT_FILENAME,
+        )
+
+        assert OUTPUT_FILENAME == "output.jsonl"
+        assert EVAL_AGENT_SERVER_IMAGE == "ghcr.io/openhands/eval-agent-server"
+        assert DEFAULT_DATASET == "princeton-nlp/SWE-bench_Verified"
+        assert DEFAULT_SPLIT == "test"
+        assert DEFAULT_MAX_ITERATIONS == 100
+        assert DEFAULT_WORKSPACE_TYPE == "docker"
+        assert DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT == 600
+        assert "runtime.eval.all-hands.dev" in DEFAULT_RUNTIME_API_URL
+
+
+class TestGAIAConstants:
+    """Test GAIA benchmark-specific constants."""
+
+    def test_gaia_constants_import(self):
+        """Test that GAIA constants can be imported."""
+        from benchmarks.gaia.constants import (
+            DATASET_CACHE_DIR,
+            GAIA_BASE_IMAGE,
+            GAIA_DATA_YEAR,
+            GAIA_DATASET,
+            GAIA_DEFAULT_SPLIT,
+        )
+
+        assert GAIA_DATASET is not None
+        assert GAIA_DEFAULT_SPLIT is not None
+        assert GAIA_BASE_IMAGE is not None
+        assert DATASET_CACHE_DIR is not None
+        assert GAIA_DATA_YEAR is not None
+
+    def test_gaia_constants_values(self):
+        """Test that GAIA constants have expected values."""
+        from benchmarks.gaia.constants import (
+            GAIA_BASE_IMAGE,
+            GAIA_DATA_YEAR,
+            GAIA_DATASET,
+            GAIA_DEFAULT_SPLIT,
+        )
+
+        assert GAIA_DATASET == "gaia-benchmark/GAIA"
+        assert GAIA_DEFAULT_SPLIT == "validation"
+        assert "python" in GAIA_BASE_IMAGE.lower()
+        assert GAIA_DATA_YEAR == "2023"
+
+
+class TestSWEBenchConstants:
+    """Test SWE-bench benchmark-specific constants."""
+
+    def test_swebench_constants_import(self):
+        """Test that SWE-bench constants can be imported."""
+        from benchmarks.swebench.constants import (
+            DEFAULT_BUILD_TARGET,
+            SWEBENCH_DATASET,
+            SWEBENCH_DEFAULT_SPLIT,
+            SWEBENCH_DOCKER_IMAGE_PREFIX,
+            WRAPPED_REPOS,
+        )
+
+        assert SWEBENCH_DATASET is not None
+        assert SWEBENCH_DEFAULT_SPLIT is not None
+        assert SWEBENCH_DOCKER_IMAGE_PREFIX is not None
+        assert WRAPPED_REPOS is not None
+        assert DEFAULT_BUILD_TARGET is not None
+
+    def test_swebench_constants_values(self):
+        """Test that SWE-bench constants have expected values."""
+        from benchmarks.swebench.constants import (
+            DEFAULT_BUILD_TARGET,
+            SWEBENCH_DATASET,
+            SWEBENCH_DEFAULT_SPLIT,
+            SWEBENCH_DOCKER_IMAGE_PREFIX,
+            WRAPPED_REPOS,
+        )
+
+        assert SWEBENCH_DATASET == "princeton-nlp/SWE-bench_Verified"
+        assert SWEBENCH_DEFAULT_SPLIT == "test"
+        assert "swebench" in SWEBENCH_DOCKER_IMAGE_PREFIX.lower()
+        assert isinstance(WRAPPED_REPOS, set)
+        assert DEFAULT_BUILD_TARGET == "source-minimal"
+
+
+class TestSWEBenchMultimodalConstants:
+    """Test SWE-bench Multimodal benchmark-specific constants."""
+
+    def test_swebenchmultimodal_constants_import(self):
+        """Test that SWE-bench Multimodal constants can be imported."""
+        from benchmarks.swebenchmultimodal.constants import (
+            DEFAULT_BUILD_TARGET,
+            SWEBENCH_MULTIMODAL_DATASET,
+            SWEBENCH_MULTIMODAL_DEFAULT_SPLIT,
+        )
+
+        assert SWEBENCH_MULTIMODAL_DATASET is not None
+        assert SWEBENCH_MULTIMODAL_DEFAULT_SPLIT is not None
+        assert DEFAULT_BUILD_TARGET is not None
+
+    def test_swebenchmultimodal_constants_values(self):
+        """Test that SWE-bench Multimodal constants have expected values."""
+        from benchmarks.swebenchmultimodal.constants import (
+            DEFAULT_BUILD_TARGET,
+            SWEBENCH_MULTIMODAL_DATASET,
+            SWEBENCH_MULTIMODAL_DEFAULT_SPLIT,
+        )
+
+        assert SWEBENCH_MULTIMODAL_DATASET == "princeton-nlp/SWE-bench_Multimodal"
+        assert SWEBENCH_MULTIMODAL_DEFAULT_SPLIT == "dev"
+        assert DEFAULT_BUILD_TARGET == "source-minimal"
+
+
+class TestMultiSWEBenchConstants:
+    """Test Multi-SWE-bench benchmark-specific constants."""
+
+    def test_multiswebench_constants_import(self):
+        """Test that Multi-SWE-bench constants can be imported."""
+        from benchmarks.multiswebench.constants import (
+            DATASET_CACHE_DIR,
+            DEFAULT_BUILD_TARGET,
+            DEFAULT_DOCKER_IMAGE_PREFIX,
+            DEFAULT_LANG,
+            DOCKER_IMAGE_PREFIX,
+            MULTISWEBENCH_DATASET,
+            MULTISWEBENCH_DEFAULT_SPLIT,
+            RUN_WITH_BROWSING,
+            USE_HINT_TEXT,
+            USE_INSTANCE_IMAGE,
+        )
+
+        assert MULTISWEBENCH_DATASET is not None
+        assert MULTISWEBENCH_DEFAULT_SPLIT is not None
+        assert DEFAULT_LANG is not None
+        assert DEFAULT_DOCKER_IMAGE_PREFIX is not None
+        assert DOCKER_IMAGE_PREFIX is not None
+        assert DATASET_CACHE_DIR is not None
+        assert DEFAULT_BUILD_TARGET is not None
+        assert isinstance(USE_HINT_TEXT, bool)
+        assert isinstance(USE_INSTANCE_IMAGE, bool)
+        assert isinstance(RUN_WITH_BROWSING, bool)
+
+    def test_multiswebench_constants_values(self):
+        """Test that Multi-SWE-bench constants have expected values."""
+        from benchmarks.multiswebench.constants import (
+            DEFAULT_BUILD_TARGET,
+            DEFAULT_DOCKER_IMAGE_PREFIX,
+            DEFAULT_LANG,
+            MULTISWEBENCH_DATASET,
+            MULTISWEBENCH_DEFAULT_SPLIT,
+        )
+
+        assert MULTISWEBENCH_DATASET == "ByteDance-Seed/Multi-SWE-bench"
+        assert MULTISWEBENCH_DEFAULT_SPLIT == "test"
+        assert DEFAULT_LANG == "java"
+        assert DEFAULT_DOCKER_IMAGE_PREFIX == "mswebench"
+        assert DEFAULT_BUILD_TARGET == "source-minimal"
+
+
+class TestCommit0Constants:
+    """Test Commit0 benchmark-specific constants."""
+
+    def test_commit0_constants_import(self):
+        """Test that Commit0 constants can be imported."""
+        from benchmarks.commit0.constants import (
+            COMMIT0_DATASET,
+            COMMIT0_DEFAULT_SPLIT,
+            DEFAULT_BUILD_TARGET,
+            DEFAULT_DOCKER_IMAGE_PREFIX,
+            DEFAULT_REPO_SPLIT,
+            DOCKER_IMAGE_PREFIX,
+        )
+
+        assert COMMIT0_DATASET is not None
+        assert COMMIT0_DEFAULT_SPLIT is not None
+        assert DEFAULT_REPO_SPLIT is not None
+        assert DEFAULT_DOCKER_IMAGE_PREFIX is not None
+        assert DOCKER_IMAGE_PREFIX is not None
+        assert DEFAULT_BUILD_TARGET is not None
+
+    def test_commit0_constants_values(self):
+        """Test that Commit0 constants have expected values."""
+        from benchmarks.commit0.constants import (
+            COMMIT0_DATASET,
+            COMMIT0_DEFAULT_SPLIT,
+            DEFAULT_BUILD_TARGET,
+            DEFAULT_DOCKER_IMAGE_PREFIX,
+            DEFAULT_REPO_SPLIT,
+        )
+
+        assert COMMIT0_DATASET == "wentingzhao/commit0_combined"
+        assert COMMIT0_DEFAULT_SPLIT == "test"
+        assert DEFAULT_REPO_SPLIT == "lite"
+        assert "wentingzhao" in DEFAULT_DOCKER_IMAGE_PREFIX
+        assert DEFAULT_BUILD_TARGET == "source-minimal"
+
+
+class TestSWTBenchConstants:
+    """Test SWT-bench benchmark-specific constants."""
+
+    def test_swtbench_constants_import(self):
+        """Test that SWT-bench constants can be imported."""
+        from benchmarks.swtbench.constants import (
+            DEFAULT_BUILD_TARGET,
+            SWTBENCH_DOCKER_IMAGE_PREFIX,
+        )
+
+        assert SWTBENCH_DOCKER_IMAGE_PREFIX is not None
+        assert DEFAULT_BUILD_TARGET is not None
+
+    def test_swtbench_constants_values(self):
+        """Test that SWT-bench constants have expected values."""
+        from benchmarks.swtbench.constants import (
+            DEFAULT_BUILD_TARGET,
+            SWTBENCH_DOCKER_IMAGE_PREFIX,
+        )
+
+        assert "swtbench" in SWTBENCH_DOCKER_IMAGE_PREFIX.lower()
+        assert DEFAULT_BUILD_TARGET == "source-minimal"
+
+
+class TestOpenAgentSafetyConstants:
+    """Test OpenAgentSafety benchmark-specific constants."""
+
+    def test_openagentsafety_constants_import(self):
+        """Test that OpenAgentSafety constants can be imported."""
+        from benchmarks.openagentsafety.constants import (
+            DEFAULT_NPC_MODEL,
+            OPENAGENTSAFETY_SERVER_IMAGE,
+        )
+
+        assert OPENAGENTSAFETY_SERVER_IMAGE is not None
+        assert DEFAULT_NPC_MODEL is not None
+
+    def test_openagentsafety_constants_values(self):
+        """Test that OpenAgentSafety constants have expected values."""
+        from benchmarks.openagentsafety.constants import (
+            DEFAULT_NPC_MODEL,
+            OPENAGENTSAFETY_SERVER_IMAGE,
+        )
+
+        assert "openagentsafety" in OPENAGENTSAFETY_SERVER_IMAGE.lower()
+        assert "gpt" in DEFAULT_NPC_MODEL.lower()


### PR DESCRIPTION
## Summary

This PR addresses issue #348 by regrouping constant values that were previously scattered across multiple files into dedicated `constants.py` files for better maintainability and consistency.

## Changes

### 1. Shared Constants (`benchmarks/utils/constants.py`)

Added the following shared constants that are used across multiple benchmarks:
- `OUTPUT_FILENAME` - Default output filename
- `EVAL_AGENT_SERVER_IMAGE` - Agent server image name
- `DEFAULT_DATASET` - Default dataset name
- `DEFAULT_SPLIT` - Default dataset split
- `DEFAULT_MAX_ITERATIONS` - Default max iterations
- `DEFAULT_MAX_ATTEMPTS` - Default max attempts
- `DEFAULT_MAX_RETRIES` - Default max retries
- `DEFAULT_NUM_WORKERS` - Default number of workers
- `DEFAULT_EVAL_LIMIT` - Default evaluation limit
- `DEFAULT_WORKSPACE_TYPE` - Default workspace type
- `DEFAULT_OUTPUT_DIR` - Default output directory
- `DEFAULT_REMOTE_RUNTIME_STARTUP_TIMEOUT` - Default remote runtime startup timeout
- `DEFAULT_RUNTIME_API_URL` - Default runtime API URL
- `DEFAULT_ENV_SETUP_COMMANDS` - Default environment setup commands
- `DEFAULT_CRITIC` - Default critic

### 2. Benchmark-Specific Constants

Created `constants.py` files for each benchmark:

- **gaia/constants.py**: `GAIA_DATASET`, `GAIA_DEFAULT_SPLIT`, `GAIA_BASE_IMAGE`, `DATASET_CACHE_DIR`, `GAIA_DATA_YEAR`
- **swebench/constants.py**: `SWEBENCH_DATASET`, `SWEBENCH_DEFAULT_SPLIT`, `SWEBENCH_DOCKER_IMAGE_PREFIX`, `WRAPPED_REPOS`, `DEFAULT_BUILD_TARGET`
- **swebenchmultimodal/constants.py**: `SWEBENCH_MULTIMODAL_DATASET`, `SWEBENCH_MULTIMODAL_DEFAULT_SPLIT`, `DEFAULT_BUILD_TARGET`
- **multiswebench/constants.py**: `MULTISWEBENCH_DATASET`, `MULTISWEBENCH_DEFAULT_SPLIT`, `DEFAULT_LANG`, `DEFAULT_DOCKER_IMAGE_PREFIX`, `DOCKER_IMAGE_PREFIX`, `DATASET_CACHE_DIR`, `DEFAULT_BUILD_TARGET`, `USE_HINT_TEXT`, `USE_INSTANCE_IMAGE`, `RUN_WITH_BROWSING`
- **commit0/constants.py**: `COMMIT0_DATASET`, `COMMIT0_DEFAULT_SPLIT`, `DEFAULT_REPO_SPLIT`, `DEFAULT_DOCKER_IMAGE_PREFIX`, `DOCKER_IMAGE_PREFIX`, `DEFAULT_BUILD_TARGET`
- **swtbench/constants.py**: `SWTBENCH_DOCKER_IMAGE_PREFIX`, `DEFAULT_BUILD_TARGET`
- **openagentsafety/constants.py**: `OPENAGENTSAFETY_SERVER_IMAGE`, `DEFAULT_NPC_MODEL`

### 3. Updated Imports

Updated all benchmark files to import constants from the appropriate `constants.py` files instead of using hardcoded values:
- `benchmarks/utils/args_parser.py`
- `benchmarks/gaia/run_infer.py`
- `benchmarks/gaia/build_images.py`
- `benchmarks/swebench/run_infer.py`
- `benchmarks/swebench/build_images.py`
- `benchmarks/swebenchmultimodal/run_infer.py`
- `benchmarks/multiswebench/run_infer.py`
- `benchmarks/commit0/run_infer.py`
- `benchmarks/swtbench/run_infer.py`

### 4. Tests

Added comprehensive tests in `tests/test_constants.py` to verify:
- All constants can be imported correctly
- Constants have expected values

## Testing

All tests pass:
```
======================== 38 passed, 3 warnings in 0.66s ========================
```

Fixes #348

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f521a96dd447426385c4b1e970c07198)