### PR TITLE
Remove push_to_index parameter from run-eval workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -61,11 +61,6 @@ on:
         required: false
         default: ''
         type: string
-      push_to_index:
-        description: 'Push results to openhands-index-results (default: false)'
-        required: false
-        default: 'false'
-        type: string
       enable_conversation_event_logging:
         description: 'Enable Datadog persistence for conversation events (default: false)'
         required: false
@@ -100,7 +95,6 @@ jobs:
           INSTANCE_IDS: ${{ github.event.inputs.instance_ids }}
           NUM_INFER_WORKERS: ${{ github.event.inputs.num_infer_workers }}
           NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers }}
-          PUSH_TO_INDEX: ${{ github.event.inputs.push_to_index }}
           ENABLE_CONVERSATION_EVENT_LOGGING: ${{ github.event.inputs.enable_conversation_event_logging }}
           MAX_RETRIES: ${{ github.event.inputs.max_retries }}
         run: |
@@ -122,10 +116,9 @@ jobs:
             --arg instance_ids "$INSTANCE_IDS" \
             --arg num_infer_workers "$NUM_INFER_WORKERS" \
             --arg num_eval_workers "$NUM_EVAL_WORKERS" \
-            --arg push_to_index "$PUSH_TO_INDEX" \
             --arg enable_conversation_event_logging "$ENABLE_CONVERSATION_EVENT_LOGGING" \
             --arg max_retries "$MAX_RETRIES" \
-            '{ref: $ref, inputs: {benchmark: $benchmark, sdk_ref: $sdk_ref, eval_limit: $eval_limit, model_ids: $model_ids, reason: $reason, eval_branch: $eval_branch, benchmarks_branch: $benchmarks_branch, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index, enable_conversation_event_logging: $enable_conversation_event_logging, max_retries: $max_retries}}')
+            '{ref: $ref, inputs: {benchmark: $benchmark, sdk_ref: $sdk_ref, eval_limit: $eval_limit, model_ids: $model_ids, reason: $reason, eval_branch: $eval_branch, benchmarks_branch: $benchmarks_branch, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, enable_conversation_event_logging: $enable_conversation_event_logging, max_retries: $max_retries}}')
 
           RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
             -H "Authorization: token $PAT_TOKEN" \


### PR DESCRIPTION
The software-agent-sdk workflow no longer accepts the push_to_index parameter (removed in https://github.com/OpenHands/software-agent-sdk/pull/1750).

This PR removes the parameter from the benchmarks run-eval workflow to match the SDK workflow and fix the dispatch failures.

Fixes workflow dispatch errors like:
```
Dispatch failed (status 422):
{
  "message": "Unexpected inputs provided: [\"push_to_index\"]",
  ...
}
```