### PR TITLE
Enable browser tools for SWE-bench Multimodal evaluation

### DIFF
--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -220,8 +220,8 @@ class SWEBenchEvaluation(Evaluation):
         Do not write files here; just return EvalOutput.
         """
         tools = get_default_tools(
-            # Disable browser tools in CLI mode
-            enable_browser=False,
+            # Enable browser tools for frontend development tasks
+            enable_browser=True,
         )
         agent = Agent(
             llm=self.metadata.llm,


### PR DESCRIPTION
## Summary
Enable browser tools for the SWE-bench Multimodal benchmark evaluation.

## Problem
SWE-bench Multimodal is focused on **frontend development tasks**, but browser tools were explicitly disabled (`enable_browser=False`). This prevents the agent from:
- Viewing rendered UI to verify fixes
- Taking screenshots to understand visual bugs  
- Interactive debugging of frontend issues

## Solution
Change `enable_browser=False` to `enable_browser=True` in `benchmarks/swebenchmultimodal/run_infer.py`.

This aligns with how the GAIA benchmark is configured, which also uses `enable_browser=True`.

## Changes
- `benchmarks/swebenchmultimodal/run_infer.py`: Enable browser tools for frontend development tasks

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)