### PR TITLE
Fix swtbench-list-images failing due to missing working directory change

### DIFF
--- a/benchmarks/swtbench/image_utils.py
+++ b/benchmarks/swtbench/image_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -87,9 +88,15 @@ def compute_required_images(
     from src.dataset import load_swebench_dataset  # type: ignore[import-not-found]
     from src.exec_spec import make_exec_spec  # type: ignore[import-not-found]
 
-    dataset_entries = load_swebench_dataset(
-        name=dataset, split=split, is_swt=True, filter_swt=True
-    )
+    # Change to swt-bench directory for dataset loading (required for filter files)
+    cwd = os.getcwd()
+    try:
+        os.chdir(swt_bench_dir)
+        dataset_entries = load_swebench_dataset(
+            name=dataset, split=split, is_swt=True, filter_swt=True
+        )
+    finally:
+        os.chdir(cwd)
     entries_by_id = {entry["instance_id"]: entry for entry in dataset_entries}
 
     missing = [iid for iid in instance_ids if iid not in entries_by_id]


### PR DESCRIPTION
## Summary

This PR fixes a bug in `image_utils.py` where the `compute_required_images` function was not changing to the swt-bench directory before calling `load_swebench_dataset`. This caused `swtbench-list-images` to fail with `FileNotFoundError` because the swt-bench code expects to find `dataset/filter_cases_verified.txt` relative to its own directory.

## Root Cause

The `build_eval_env_images.py` correctly changes directory to `swt_bench_dir` before calling `load_swebench_dataset` (lines 62-69), but `image_utils.py` did NOT do this. This inconsistency caused the `swtbench-list-images` command to fail silently (due to `|| true` in the shell script), which prevented prebaked eval images from being pulled during evaluation.

## Impact

This bug prevented prebaked eval images from being pulled during evaluation, causing the evaluation to fall back to building images on-the-fly with conda. This is the root cause of the infinite conda dependency resolution loops described in OpenHands/evaluation#224.

## Changes

1. Added `import os` to `image_utils.py`
2. Added the same `os.chdir(swt_bench_dir)` pattern that is already used in `build_eval_env_images.py`
3. Added tests to verify the fix and prevent regression

## Testing

- All 3 new tests pass
- Manually verified that `swtbench-list-images` now correctly returns image tags

## Fixes

Fixes OpenHands/evaluation#224

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/109c2a13b8334a9582910ffa065ee3e3)