### PR TITLE
Add split, run_id, modal, timeout parameters to swebench-eval CLI

### DIFF
--- a/benchmarks/swebench/eval_infer.py
+++ b/benchmarks/swebench/eval_infer.py
@@ -116,16 +116,24 @@ def convert_to_swebench_format(
 
 def run_swebench_evaluation(
     predictions_file: str,
+    run_id: str,
     dataset: str = constants.DEFAULT_DATASET,
     workers: int = constants.DEFAULT_EVAL_WORKERS,
+    split: str | None = None,
+    modal: bool = False,
+    timeout: int | None = None,
 ) -> None:
     """
     Run SWE-Bench evaluation on the predictions file.
 
     Args:
         predictions_file: Path to the SWE-Bench format predictions file
+        run_id: Unique identifier for this evaluation run
         dataset: SWE-Bench dataset to evaluate against
         workers: Number of workers to use for evaluation
+        split: Dataset split to evaluate (e.g., 'test', 'dev')
+        modal: Whether to use Modal for evaluation
+        timeout: Timeout in seconds for evaluation
     """
     logger.info(f"Running SWE-Bench evaluation on {predictions_file}")
 
@@ -150,8 +158,16 @@ def run_swebench_evaluation(
             "--max_workers",
             str(workers),
             "--run_id",
-            f"eval_{predictions_path.stem}",
+            run_id,
         ]
+
+        # Add optional parameters
+        if split:
+            cmd.extend(["--split", split])
+        if modal:
+            cmd.extend(["--modal", "true"])
+        if timeout is not None:
+            cmd.extend(["--timeout", str(timeout)])
 
         logger.info(f"Running command: {' '.join(cmd)}")
         logger.info(f"Working directory: {predictions_dir}")
@@ -191,6 +207,7 @@ Examples:
     uv run swebench-eval output.jsonl
     uv run swebench-eval /path/to/output.jsonl --dataset princeton-nlp/SWE-bench_Lite
     uv run swebench-eval output.jsonl --model-name "MyModel-v1.0"
+    uv run swebench-eval output.jsonl --split test --run-id my_eval --modal --timeout 1800
         """,
     )
 
@@ -227,6 +244,29 @@ Examples:
         help=f"Number of workers to use when evaluating (default: {constants.DEFAULT_EVAL_WORKERS})",
     )
 
+    parser.add_argument(
+        "--split",
+        help="Dataset split to evaluate (e.g., 'test', 'dev')",
+    )
+
+    parser.add_argument(
+        "--run-id",
+        required=True,
+        help="Unique identifier for this evaluation run",
+    )
+
+    parser.add_argument(
+        "--modal",
+        action="store_true",
+        help="Use Modal for evaluation",
+    )
+
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        help="Timeout in seconds for evaluation",
+    )
+
     args = parser.parse_args()
 
     # Validate input file
@@ -255,13 +295,19 @@ Examples:
 
         if not args.skip_evaluation:
             # Run evaluation
-            run_swebench_evaluation(str(output_file), args.dataset, args.workers)
+            run_swebench_evaluation(
+                str(output_file),
+                args.run_id,
+                args.dataset,
+                args.workers,
+                split=args.split,
+                modal=args.modal,
+                timeout=args.timeout,
+            )
 
             # Move report file to input file directory with .report.json extension
-            # SWE-Bench creates: {model_name.replace("/", "__")}.eval_{output_file.stem}.json
-            report_filename = (
-                f"{args.model_name.replace('/', '__')}.eval_{output_file.stem}.json"
-            )
+            # SWE-Bench creates: {model_name.replace("/", "__")}.{run_id}.json
+            report_filename = f"{args.model_name.replace('/', '__')}.{args.run_id}.json"
             report_path = output_file.parent / report_filename
             dest_report_path = input_file.with_suffix(".report.json")
 


### PR DESCRIPTION
## Summary

This PR adds the missing parameters to the `swebench-eval` CLI that are needed to run SWE-bench evaluation in a single call instead of two separate calls.

Fixes #383

## Changes

### New CLI parameters for `swebench-eval`:
- `--split`: Dataset split to evaluate (e.g., 'test', 'dev')
- `--run-id`: Unique identifier for this evaluation run
- `--modal`: Use Modal for evaluation
- `--timeout`: Timeout in seconds for evaluation

### Updated `run_swebench_evaluation` function:
Added support for the new parameters: `split`, `run_id`, `modal`, and `timeout`.

### Tests:
Added comprehensive tests for the new parameters in `tests/test_swebench_eval.py`.

## Usage

Before (two calls):
```bash
uv run swebench-eval "$OUTPUT_JSONL" \
  --dataset "$DATASET" \
  --model-name "$MODEL_NAME" \
  --workers "$NUM_EVAL_WORKERS" \
  --skip-evaluation \
  --output-file "$CONVERTED_PATH"

uv run python -m swebench.harness.run_evaluation \
  --dataset_name "$DATASET" \
  --split "$DATASET_SPLIT" \
  --predictions_path "$(basename "$CONVERTED_PATH")" \
  --max_workers "$NUM_EVAL_WORKERS" \
  --run_id "$UNIQUE_EVAL_NAME" \
  --modal true \
  --timeout "$EVAL_TIMEOUT"
```

After (single call):
```bash
uv run swebench-eval "$OUTPUT_JSONL" \
  --dataset "$DATASET" \
  --model-name "$MODEL_NAME" \
  --workers "$NUM_EVAL_WORKERS" \
  --split "$DATASET_SPLIT" \
  --run-id "$UNIQUE_EVAL_NAME" \
  --modal \
  --timeout "$EVAL_TIMEOUT"
```

## Testing

All new tests pass:
```
tests/test_swebench_eval.py::TestConvertToSwebenchFormat::test_empty_input_file_raises_value_error PASSED
tests/test_swebench_eval.py::TestRunSwebenchEvaluation::test_basic_evaluation_command PASSED
tests/test_swebench_eval.py::TestRunSwebenchEvaluation::test_evaluation_with_split PASSED
tests/test_swebench_eval.py::TestRunSwebenchEvaluation::test_evaluation_with_run_id PASSED
tests/test_swebench_eval.py::TestRunSwebenchEvaluation::test_evaluation_with_modal PASSED
tests/test_swebench_eval.py::TestRunSwebenchEvaluation::test_evaluation_with_timeout PASSED
tests/test_swebench_eval.py::TestRunSwebenchEvaluation::test_evaluation_with_all_parameters PASSED
tests/test_swebench_eval.py::TestRunSwebenchEvaluation::test_evaluation_without_optional_parameters PASSED
```

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6999c3cacef84985b98d0432054f33d3)