### PR TITLE
fix(swebench-eval): allow disabling Modal via --no-modal

### DIFF
--- a/benchmarks/swebench/eval_infer.py
+++ b/benchmarks/swebench/eval_infer.py
@@ -246,15 +246,16 @@ Examples:
 
     parser.add_argument(
         "--modal",
+        dest="modal",
         action="store_true",
-        help="Use Modal for evaluation (default: True)",
+        help="Use Modal for evaluation",
     )
 
     parser.add_argument(
         "--no-modal",
-        action="store_false",
         dest="modal",
-        help="Disable Modal for evaluation",
+        action="store_false",
+        help="Do not use Modal for evaluation",
     )
 
     parser.add_argument(


### PR DESCRIPTION
The current implementation always set `modal` as true.  This PR adds the `--no-modal` option to swebench-eval cli to allow user to disable `modal`.