### PR TITLE
Remove double setting of default values in function signatures

### DIFF
--- a/benchmarks/swebench/eval_infer.py
+++ b/benchmarks/swebench/eval_infer.py
@@ -117,11 +117,11 @@ def convert_to_swebench_format(input_file: str, output_file: str) -> None:
 def run_swebench_evaluation(
     predictions_file: str,
     run_id: str,
-    dataset: str = EVAL_DEFAULTS["dataset"],
-    workers: int = EVAL_DEFAULTS["workers"],
-    split: str = EVAL_DEFAULTS["split"],
-    modal: bool = EVAL_DEFAULTS["modal"],
-    timeout: int = EVAL_DEFAULTS["timeout"],
+    dataset: str,
+    workers: int,
+    split: str,
+    modal: bool,
+    timeout: int,
 ) -> None:
     """
     Run SWE-Bench evaluation on the predictions file.

--- a/benchmarks/swtbench/eval_infer.py
+++ b/benchmarks/swtbench/eval_infer.py
@@ -69,7 +69,7 @@ def _load_prediction_instance_ids(predictions_file: Path) -> list[str]:
 def try_pull_prebaked_images(
     predictions_file: Path,
     dataset: str,
-    split: str = EVAL_DEFAULTS["split"],
+    split: str,
     registry: str = PREBAKED_REGISTRY,
 ) -> None:
     """
@@ -418,6 +418,7 @@ Examples:
             try_pull_prebaked_images(
                 output_file,
                 args.dataset,
+                args.split,
             )
         else:
             logger.info(


### PR DESCRIPTION
## Summary

This PR removes the double setting of default values in function signatures. Default values should be read at args setting via `parser.set_defaults()`, not in function call signatures.

Fixes #398

## Changes

### `benchmarks/swebench/eval_infer.py`
- Removed `EVAL_DEFAULTS` from `run_swebench_evaluation()` function signature parameters

### `benchmarks/swtbench/eval_infer.py`
- Removed `EVAL_DEFAULTS["split"]` from `try_pull_prebaked_images()` function signature
- Updated the call site to explicitly pass `args.split`

## Consistency with Other Benchmarks

This change aligns with the pattern used by other benchmarks in the repository:
- `swebenchmultimodal/eval_infer.py` - uses only `parser.set_defaults(**EVAL_DEFAULTS)`
- `gaia/run_infer.py` - uses only `parser.set_defaults(**INFER_DEFAULTS)`
- `commit0/run_infer.py` - uses only `parser.set_defaults(**INFER_DEFAULTS)`
- `swtbench/run_infer.py` - uses only `parser.set_defaults(**INFER_DEFAULTS)`

## Testing Justification

**No new tests are required for this change because:**

1. **Pure refactoring**: This is a code cleanup that doesn't change behavior. The defaults are still applied via `parser.set_defaults(**EVAL_DEFAULTS)` in the `main()` function.

2. **No external callers**: The affected functions (`run_swebench_evaluation` and `try_pull_prebaked_images`) are only called from their respective `main()` functions, which always pass explicit arguments from the parsed args.

3. **Existing tests pass**: All 32 existing tests pass, confirming the refactoring doesn't break any functionality.

4. **Static type checking**: The pre-commit hooks include Pyright type checking which validates that all required arguments are passed correctly.

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8e0f85912bdf4699be1b7d6a1e91b596)