### PR TITLE
fix(swtbench): prevent build workflow from hanging indefinitely

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -56,8 +56,8 @@ on:
         type: string
 
 concurrency:
-  group: build-swt-bench-${{ github.ref }}
-  cancel-in-progress: false
+  group: build-swt-bench-images
+  cancel-in-progress: true
 
 jobs:
   build-and-push:
@@ -130,7 +130,38 @@ jobs:
         run: |
           make build
 
+      - name: "Preflight: prune cache and verify BuildKit disk"
+        run: |
+          set -euo pipefail
+          KEEP_GB=60
+          echo "Pruning BuildKit cache (target max-storage ${KEEP_GB} GiB, no filters)..."
+          # Prefer newer max-storage flag; fall back to keep-storage if not supported.
+          if ! docker buildx prune --all --force --max-storage ${KEEP_GB}g; then
+            docker buildx prune --all --force --keep-storage ${KEEP_GB}g || true
+          fi
+
+          if df -B1 /var/lib/buildkit > /tmp/buildkit_df 2>/dev/null; then
+            LINE=$(tail -n1 /tmp/buildkit_df)
+            TOTAL=$(echo "$LINE" | awk '{print $2}')
+            USED=$(echo "$LINE" | awk '{print $3}')
+            FREE=$(echo "$LINE" | awk '{print $4}')
+            if [ -n "$TOTAL" ] && [ -n "$FREE" ]; then
+              PCT=$(( 100 * USED / TOTAL ))
+              echo "BuildKit disk: used ${USED} / ${TOTAL} bytes (${PCT}%); free ${FREE} bytes"
+              MIN=$((75 * 1024 * 1024 * 1024))
+              if [ "$FREE" -lt "$MIN" ]; then
+                echo "::error::Not enough free space on /var/lib/buildkit (${FREE} bytes free, need >= ${MIN})"
+                exit 1
+              fi
+            else
+              echo "Warning: unable to parse df output for /var/lib/buildkit"
+            fi
+          else
+            echo "Warning: /var/lib/buildkit not found; skipping disk check"
+          fi
+
       - name: Build and push SWT-Bench images
+        timeout-minutes: 30
         run: |
           set -euo pipefail
 
@@ -177,9 +208,11 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
+          BUILDKIT_RESET_ON_FAILURE: 1
 
       - name: Build prebaked eval env images
         if: ${{ inputs.build-eval-env == 'true' }}
+        timeout-minutes: 60
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

This PR addresses issue #400 where SWT-Bench image build workflows were hanging indefinitely (2+ hours) at the "Build and push SWT-Bench images" step, blocking evaluation runs.

## Problem

SWT-Bench builds after 14:12 UTC on 2026-02-06 were freezing with no progress updates, while earlier builds completed successfully in ~10 minutes. The builds were consuming runner resources indefinitely and blocking evaluation pods.

## Root Cause Analysis

Comparing the SWT-Bench workflow with the working SWE-Bench workflow revealed several missing safeguards:

1. **No preflight step** - SWE-Bench has a preflight step that prunes BuildKit cache and verifies disk space before building
2. **No BUILDKIT_RESET_ON_FAILURE** - SWE-Bench sets this env var to help recover from BuildKit failures
3. **No timeout** - Neither workflow had timeouts, but SWT-Bench was more susceptible to hangs
4. **Per-ref concurrency** - Concurrent builds on different refs could interfere with each other

## Changes

1. **Add preflight step to prune BuildKit cache and verify disk space**
   - Matches the existing safeguard in `build-swebench-images.yml`
   - Prunes cache to 60GB max and checks for 75GB free space
   - Fails early if disk space is insufficient

2. **Add timeout-minutes to build steps**
   - 30 minutes for main image build (expected ~10 min)
   - 60 minutes for prebaked eval env images
   - Prevents indefinite hangs from blocking runners

3. **Add BUILDKIT_RESET_ON_FAILURE=1 environment variable**
   - Helps recover from BuildKit failures/corruption

4. **Change concurrency group to global (not per-ref)**
   - Prevents concurrent builds from interfering with each other
   - Uses `cancel-in-progress: true` to cancel old runs when new ones start

## Testing

This is a workflow configuration change. The fix will be validated when the workflow runs in GitHub Actions. The changes align with the working SWE-Bench workflow configuration.

Fixes #400

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4f84181874c54b9083c77fa9c2b7a784)