### PR TITLE
Add tests for solveable_accuracy component_scores in swebenchmultimodal

### DIFF
--- a/tests/test_swebenchmultimodal.py
+++ b/tests/test_swebenchmultimodal.py
@@ -2,8 +2,15 @@
 
 import json
 import tempfile
+from pathlib import Path
+from unittest.mock import patch
 
-from benchmarks.swebenchmultimodal.eval_infer import convert_to_swebench_format
+from benchmarks.swebenchmultimodal.eval_infer import (
+    calculate_component_scores,
+    convert_to_swebench_format,
+    load_ambiguity_annotations,
+    update_report_with_component_scores,
+)
 from benchmarks.utils.constants import MODEL_NAME_OR_PATH
 
 
@@ -55,3 +62,167 @@ class TestConvertToSwebenchFormat:
             result = json.loads(f.readline())
 
         assert result["model_name_or_path"] == MODEL_NAME_OR_PATH
+
+
+class TestLoadAmbiguityAnnotations:
+    """Tests for load_ambiguity_annotations function."""
+
+    def test_loads_annotations_from_file(self):
+        """Test that annotations are loaded correctly from the JSON file."""
+        annotations = load_ambiguity_annotations()
+
+        # Should return a non-empty dictionary
+        assert isinstance(annotations, dict)
+        assert len(annotations) > 0
+
+        # Check that annotations have expected structure
+        for instance_id, annotation in annotations.items():
+            assert "instance_id" in annotation
+            assert "keywords" in annotation
+            assert isinstance(annotation["keywords"], list)
+
+    def test_solveable_instances_have_solveable_keyword(self):
+        """Test that SOLVEABLE instances are correctly identified."""
+        annotations = load_ambiguity_annotations()
+
+        solveable_count = sum(
+            1
+            for annotation in annotations.values()
+            if "SOLVEABLE" in annotation.get("keywords", [])
+        )
+
+        # Based on the metadata, there should be 68 SOLVEABLE instances
+        assert solveable_count == 68
+
+    def test_returns_empty_dict_when_file_not_found(self):
+        """Test that empty dict is returned when annotations file doesn't exist."""
+        with patch(
+            "benchmarks.swebenchmultimodal.eval_infer.ANNOTATIONS_FILE",
+            Path("/nonexistent/path.json"),
+        ):
+            annotations = load_ambiguity_annotations()
+            assert annotations == {}
+
+
+class TestCalculateComponentScores:
+    """Tests for calculate_component_scores function."""
+
+    def test_calculates_scores_correctly(self):
+        """Test that component scores are calculated correctly."""
+        # Create a mock report.json with some resolved instances
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as report_file:
+            # Use real instance IDs from the annotations
+            # Automattic__wp-calypso-21648 is SOLVEABLE
+            # Automattic__wp-calypso-21769 is SOLVEABLE
+            # Automattic__wp-calypso-21409 is HIDDEN_FUNCTIONAL_REQUIREMENT (unsolveable)
+            report_data = {
+                "resolved_ids": [
+                    "Automattic__wp-calypso-21648",
+                    "Automattic__wp-calypso-21769",
+                    "Automattic__wp-calypso-21409",
+                ],
+                "total_instances": 102,
+            }
+            json.dump(report_data, report_file)
+            report_path = Path(report_file.name)
+
+        scores = calculate_component_scores(report_path)
+
+        # Should have all expected keys
+        assert "solveable_accuracy" in scores
+        assert "unsolveable_accuracy" in scores
+        assert "combined_accuracy" in scores
+        assert "solveable_resolved" in scores
+        assert "solveable_total" in scores
+        assert "unsolveable_resolved" in scores
+        assert "unsolveable_total" in scores
+
+        # Check counts
+        assert scores["solveable_resolved"] == 2  # Two SOLVEABLE instances resolved
+        assert scores["unsolveable_resolved"] == 1  # One unsolveable instance resolved
+        assert scores["solveable_total"] == 68
+        assert scores["unsolveable_total"] == 34
+
+        # Check accuracy calculations
+        assert scores["solveable_accuracy"] == round(2 / 68 * 100, 1)
+        assert scores["unsolveable_accuracy"] == round(1 / 34 * 100, 1)
+        assert scores["combined_accuracy"] == round(3 / 102 * 100, 1)
+
+    def test_returns_empty_dict_when_report_not_found(self):
+        """Test that empty dict is returned when report file doesn't exist."""
+        scores = calculate_component_scores(Path("/nonexistent/report.json"))
+        assert scores == {}
+
+    def test_handles_zero_resolved_instances(self):
+        """Test that zero resolved instances are handled correctly."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as report_file:
+            report_data = {
+                "resolved_ids": [],
+                "total_instances": 102,
+            }
+            json.dump(report_data, report_file)
+            report_path = Path(report_file.name)
+
+        scores = calculate_component_scores(report_path)
+
+        assert scores["solveable_accuracy"] == 0.0
+        assert scores["unsolveable_accuracy"] == 0.0
+        assert scores["combined_accuracy"] == 0.0
+        assert scores["solveable_resolved"] == 0
+        assert scores["unsolveable_resolved"] == 0
+
+
+class TestUpdateReportWithComponentScores:
+    """Tests for update_report_with_component_scores function."""
+
+    def test_updates_report_with_component_scores(self):
+        """Test that report.json is updated with component_scores section."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as report_file:
+            report_data = {
+                "resolved_ids": [
+                    "Automattic__wp-calypso-21648",
+                    "Automattic__wp-calypso-21769",
+                ],
+                "total_instances": 102,
+                "existing_field": "should_be_preserved",
+            }
+            json.dump(report_data, report_file)
+            report_path = Path(report_file.name)
+
+        scores = update_report_with_component_scores(report_path)
+
+        # Verify scores were returned
+        assert scores["solveable_resolved"] == 2
+        assert scores["solveable_total"] == 68
+
+        # Verify report was updated
+        with open(report_path, "r") as f:
+            updated_report = json.load(f)
+
+        assert "component_scores" in updated_report
+        assert updated_report["component_scores"]["solveable_resolved"] == 2
+        assert updated_report["component_scores"]["solveable_total"] == 68
+        # Verify existing fields are preserved
+        assert updated_report["existing_field"] == "should_be_preserved"
+
+    def test_returns_empty_dict_when_no_annotations(self):
+        """Test that empty dict is returned when annotations can't be loaded."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as report_file:
+            report_data = {"resolved_ids": [], "total_instances": 0}
+            json.dump(report_data, report_file)
+            report_path = Path(report_file.name)
+
+        with patch(
+            "benchmarks.swebenchmultimodal.eval_infer.ANNOTATIONS_FILE",
+            Path("/nonexistent/path.json"),
+        ):
+            scores = update_report_with_component_scores(report_path)
+            assert scores == {}


### PR DESCRIPTION
## Summary

This PR adds comprehensive tests for the `component_scores` functionality in the SWE-Bench Multimodal evaluation, which calculates solveable/unsolveable accuracy metrics.

Fixes #405

## Changes

Added the following test classes to `tests/test_swebenchmultimodal.py`:

### TestLoadAmbiguityAnnotations
- `test_loads_annotations_from_file`: Verifies annotations are loaded correctly from the JSON file with expected structure
- `test_solveable_instances_have_solveable_keyword`: Confirms there are 68 SOLVEABLE instances as per metadata
- `test_returns_empty_dict_when_file_not_found`: Tests graceful handling of missing annotation files

### TestCalculateComponentScores
- `test_calculates_scores_correctly`: Verifies correct calculation of solveable_accuracy, unsolveable_accuracy, combined_accuracy, and related counts
- `test_returns_empty_dict_when_report_not_found`: Tests handling of missing report files
- `test_handles_zero_resolved_instances`: Verifies correct handling when no instances are resolved

### TestUpdateReportWithComponentScores
- `test_updates_report_with_component_scores`: Confirms report.json is updated with component_scores section while preserving existing fields
- `test_returns_empty_dict_when_no_annotations`: Tests handling when annotations cannot be loaded

## Testing

All 10 tests pass:
```
tests/test_swebenchmultimodal.py::TestConvertToSwebenchFormat::test_empty_input_file_does_not_raise PASSED
tests/test_swebenchmultimodal.py::TestConvertToSwebenchFormat::test_model_name_or_path_uses_constant PASSED
tests/test_swebenchmultimodal.py::TestLoadAmbiguityAnnotations::test_loads_annotations_from_file PASSED
tests/test_swebenchmultimodal.py::TestLoadAmbiguityAnnotations::test_solveable_instances_have_solveable_keyword PASSED
tests/test_swebenchmultimodal.py::TestLoadAmbiguityAnnotations::test_returns_empty_dict_when_file_not_found PASSED
tests/test_swebenchmultimodal.py::TestCalculateComponentScores::test_calculates_scores_correctly PASSED
tests/test_swebenchmultimodal.py::TestCalculateComponentScores::test_returns_empty_dict_when_report_not_found PASSED
tests/test_swebenchmultimodal.py::TestCalculateComponentScores::test_handles_zero_resolved_instances PASSED
tests/test_swebenchmultimodal.py::TestUpdateReportWithComponentScores::test_updates_report_with_component_scores PASSED
tests/test_swebenchmultimodal.py::TestUpdateReportWithComponentScores::test_returns_empty_dict_when_no_annotations PASSED
```

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ef27457d189845529477ba070329872c)