### PR TITLE
Remove double setting of timeout default in swebench eval_infer.py

### DIFF
--- a/benchmarks/swebench/eval_infer.py
+++ b/benchmarks/swebench/eval_infer.py
@@ -261,11 +261,10 @@ Examples:
     parser.add_argument(
         "--timeout",
         type=int,
-        default=EVAL_DEFAULTS["timeout"],
-        help=f"Timeout in seconds for evaluation (default: {EVAL_DEFAULTS['timeout']})",
+        help="Timeout in seconds for evaluation",
     )
 
-    # Apply EVAL_DEFAULTS from config (for dataset, split, workers)
+    # Apply EVAL_DEFAULTS from config (for dataset, split, workers, modal, timeout)
     parser.set_defaults(**EVAL_DEFAULTS)
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

This PR removes the double setting of the `timeout` default value in `benchmarks/swebench/eval_infer.py`.

Similar to PR #399, this fixes a case where a default value was being set twice:
1. In the `add_argument()` call with `default=EVAL_DEFAULTS["timeout"]`
2. In `parser.set_defaults(**EVAL_DEFAULTS)`

## Changes

### `benchmarks/swebench/eval_infer.py`
- Removed `default=EVAL_DEFAULTS["timeout"]` from the `--timeout` argument definition
- Updated the help text to remove the redundant default value display
- Updated the comment to reflect that `timeout` is now included in the defaults applied by `set_defaults()`

## Consistency with Other Benchmarks

This change aligns with the pattern used by other benchmarks in the repository where defaults are only set via `parser.set_defaults()`:
- `swebenchmultimodal/eval_infer.py` - uses only `parser.set_defaults(**EVAL_DEFAULTS)`
- `gaia/run_infer.py` - uses only `parser.set_defaults(**INFER_DEFAULTS)`
- `commit0/run_infer.py` - uses only `parser.set_defaults(**INFER_DEFAULTS)`
- `swtbench/run_infer.py` - uses only `parser.set_defaults(**INFER_DEFAULTS)`

## Testing

All 35 existing tests pass, confirming the refactoring doesn't break any functionality.

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/53cf04c021474e45ab14c85520cda9cb)