### PR TITLE
fix(commit0): use shallow clone to prevent reward hacking

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -238,8 +238,10 @@ class Commit0Evaluation(Evaluation):
             )
 
         # Clone the repository to the specific directory
+        # Use --depth 1 for shallow clone to prevent agents from accessing git history
+        # and exploiting it to retrieve original implementations (reward hacking prevention)
         workspace_dir_name = instance.data["repo"].split("/")[1]
-        clone_cmd = f"cd /workspace/ && git clone -b commit0_combined https://github.com/{instance.data['repo']}.git {workspace_dir_name}"
+        clone_cmd = f"cd /workspace/ && git clone --depth 1 -b commit0_combined https://github.com/{instance.data['repo']}.git {workspace_dir_name}"
         res = workspace.execute_command(clone_cmd, timeout=600)
         if res.exit_code != 0:
             raise RuntimeError(f"Failed to clone repo: {res.stderr}")


### PR DESCRIPTION
## Summary
Uses `--depth 1` when cloning commit0 repositories to prevent agents from accessing git history and exploiting it to retrieve original function implementations.

## Problem
The commit0 benchmark works by providing repositories where the bulk of the code has been stripped out ("commit 0") and agents are instructed to implement the functions. However, the current setup clones repositories with full git history, allowing agents to:
1. Run `git log` to see commit history
2. Run `git diff` or `git show` to see the original implementations
3. Copy-paste the original code instead of implementing from scratch

This undermines the validity of benchmark results.

## Solution
Use shallow clone (`--depth 1`) to only fetch the latest commit, preventing agents from accessing historical commits that contain the original implementations.

## Evidence
This was reported by @fjzzq2002 who observed an agent on the "portalocker" repository using `git log` at turn 121 to retrieve original implementations.

Fixes #421

## Testing
The change is minimal - adding `--depth 1` to the git clone command. This is a well-established git feature that works reliably.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)