### PR TITLE
Fix GAIA critic: use PassCritic instead of finish_with_patch

### DIFF
--- a/benchmarks/gaia/config.py
+++ b/benchmarks/gaia/config.py
@@ -10,6 +10,7 @@ INFER_DEFAULTS = {
     "split": "validation",
     "level": "2023_all",
     "num_workers": 30,
+    "critic": "pass",
 }
 
 # Build defaults (used by build_images.py)


### PR DESCRIPTION
## Summary

- GAIA uses the default `finish_with_patch` critic, which checks for a non-empty `git_patch` in `test_result`. Since GAIA is a Q&A benchmark that produces text answers (not git patches), the critic marks **every instance as failed**, triggering full retries on attempts 2 and 3.

## Impact

Verified on a real GAIA run (`litellm_proxy/jade-spark-2862`, run ID `21885619897`):

| | Correct | Total | Accuracy |
|---|---|---|---|
| Attempt 1 (temp=0.0) | 45 | 165 | **27.3%** |
| Attempt 2 (temp=0.1) | 51 | 165 | 30.9% |
| Attempt 3 (temp=0.1) | 39 | 165 | 23.6% |
| **Final reported** | **39** | **164** | **23.8%** |

All 3 attempt files (`output.critic_attempt_{1,2,3}.jsonl`) contain the same 165 instance IDs — confirming the critic failed every instance and triggered a complete re-run each time.

**Two problems:**
1. **3x compute wasted** — 495 inference runs instead of 165
2. **Score degradation** — the aggregator picks attempt 3 (worst), reporting 23.8% instead of the correct 27.3%

## Fix

Set `"critic": "pass"` in GAIA's `INFER_DEFAULTS`. The `PassCritic` always returns success, so no retries are triggered. This is the correct critic for a Q&A benchmark where iterative retry based on structural output properties doesn't apply.

## Test plan

- [ ] Run GAIA eval with 1 instance, verify only `output.critic_attempt_1.jsonl` is created (no attempt 2 or 3)
- [ ] Verify the final `output.jsonl` contains attempt 1 results


🤖 Generated with [Claude Code](https://claude.com/claude-code)