### PR TITLE
fix(swebench-multimodal): revert broken report.json copy that causes all evaluations to crash

### DIFF
--- a/benchmarks/swebenchmultimodal/eval_infer.py
+++ b/benchmarks/swebenchmultimodal/eval_infer.py
@@ -11,7 +11,6 @@ Usage:
 
 import argparse
 import json
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -431,12 +430,6 @@ Examples:
                         f"  Combined Accuracy:    {component_scores['combined_accuracy']:.1f}%"
                     )
                     logger.info("=" * 60)
-            # Copy report.json to output.report.json for consistency with other benchmarks
-            # SWE-Bench Multimodal creates report.json in the same directory as the predictions file
-            report_path = output_file.parent / "report.json"
-            dest_report_path = input_file.with_suffix(".report.json")
-            shutil.copy(str(report_path), str(dest_report_path))
-            logger.info(f"Copied report file to: {dest_report_path}")
 
         # Generate cost report as final step
         generate_cost_report(str(input_file))


### PR DESCRIPTION
## Problem

Since Feb 13, 2026, **100% of swebenchmultimodal evaluations crash** with:
```
ERROR Script failed: [Errno 2] No such file or directory: 'eval_outputs/.../report.json'
```

This affects all models including claude-sonnet-4-5, glm-5, etc.

## Root Cause

Commit 3129e12 introduced a bug that overwrites the correct report path with a non-existent filename:

```python
# Line 408: Gets correct path → OpenHands.{run_id}.json ✓
report_path = run_swebench_multimodal_evaluation(...)

# Line 413-433: Uses it successfully ✓
component_scores = update_report_with_component_scores(report_path)

# Line 436: BUG! Overwrites with non-existent file ✗
report_path = output_file.parent / "report.json"  # This file doesn't exist!

# Line 438: Crashes immediately ✗
shutil.copy(str(report_path), str(dest_report_path))
```

## Why It Fails

The SWE-bench harness creates:
- ✅ `OpenHands.{run_id}.json` (actual file)
- ❌ `report.json` (never created)

The buggy code assumes `report.json` exists, but it doesn't.

## Evidence from Datadog Logs

```
# File is created successfully:
Copying file://.../OpenHands.22329801801-claude-son.json

# Then crashes looking for wrong filename:
ERROR: [Errno 2] No such file or directory: '.../report.json'
```

## Solution

This PR reverts commit 3129e12, removing the 7 lines that cause the crash.

The evaluation itself works fine (converts 100 entries, calculates scores), but crashes during final post-processing.

## Impact

- **Before this fix:** 100% of swebenchmultimodal runs crash
- **After this fix:** Evaluations complete successfully

## Testing

After merge, run any swebenchmultimodal evaluation and verify:
1. No FileNotFoundError crash
2. Evaluation completes with exit code 0
3. Results are uploaded to GCS successfully

Fixes evaluation failures since Feb 13, 2026.

---

Investigation details in [Datadog logs](https://us5.datadoghq.com/logs?query=kube_namespace%3Aevaluation-jobs%20%22Script%20failed%22%20%22report.json%22&from_ts=1707609600000&to_ts=1708905600000&live=true)

Co-authored-by: openhands <openhands@all-hands.dev>

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)