### PR TITLE
Fix Multi-SWE-Bench dataset name check

### DIFF
--- a/benchmarks/multiswebench/eval_infer.py
+++ b/benchmarks/multiswebench/eval_infer.py
@@ -59,8 +59,8 @@ def run_multi_swebench_evaluation(
         # Create config file for Multi-SWE-Bench
         config_file = work_dir / "config.json"
 
-        # Handle dataset path - download if it's a ByteDance-Seed/Multi-SWE-bench dataset
-        if dataset_name.startswith("ByteDance-Seed/Multi-SWE-bench"):
+        # Handle dataset path - download if it's Multi-SWE-Bench
+        if dataset_name.startswith("bytedance-research/Multi-SWE-Bench"):
             logger.info(f"Downloading Multi-SWE-bench dataset for language: {lang}")
             dataset_path = download_and_concat_dataset(dataset_name, lang)
         else:

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -121,9 +121,9 @@ class MultiSWEBenchEvaluation(Evaluation):
     def prepare_instances(self) -> List[EvalInstance]:
         logger.info("Setting up Multi-SWE-bench evaluation data")
 
-        # Check if this is a ByteDance-Seed/Multi-SWE-bench dataset that needs downloading
+        # Check if this is a Multi-SWE-Bench dataset that needs downloading
         dataset_path = self.metadata.dataset
-        if dataset_path.startswith("ByteDance-Seed/Multi-SWE-bench"):
+        if dataset_path.startswith("bytedance-research/Multi-SWE-Bench"):
             metadata = cast(MultiSWEBenchEvalMetadata, self.metadata)
             logger.info(
                 f"Downloading Multi-SWE-bench dataset for language: {metadata.lang}"


### PR DESCRIPTION
## Summary
- Fix dataset name check in `run_infer.py` and `eval_infer.py` that references the wrong HuggingFace organization

## The bug

Both `benchmarks/multiswebench/run_infer.py` and `benchmarks/multiswebench/eval_infer.py` check:
```python
if dataset_name.startswith("ByteDance-Seed/Multi-SWE-bench"):
```

But the actual HuggingFace dataset is `bytedance-research/Multi-SWE-Bench` — the org is `bytedance-research`, not `ByteDance-Seed`. This means the check **never matches**, so the dataset download-and-format logic is always skipped.

## Impact

When a user runs the benchmark with the default `--dataset bytedance-research/Multi-SWE-Bench`:

- **`run_infer.py`**: The download is skipped, `dataset_path` stays as the raw HuggingFace ID, and line 148 does `open("bytedance-research/Multi-SWE-Bench", "r")` → **crashes with `FileNotFoundError`**
- **`eval_infer.py`**: Falls to the else branch which does `Path("bytedance-research/Multi-SWE-Bench").resolve()` → passes a nonexistent local path to `update_multi_swe_config`

## Why the bug was never caught

There is no CI workflow that runs Multi-SWE-Bench inference or evaluation. The only workflow (`build-multiswebench-images.yml`) builds Docker images — it calls `build_images.py` which invokes `download_and_concat_dataset` directly, bypassing the broken `startswith` check entirely. The inference/eval code path with the default `--dataset` argument was never exercised in CI.

## Evidence that `ByteDance-Seed` is wrong

Every other reference in the codebase uses `bytedance-research/Multi-SWE-Bench`:

- **CLI defaults** (`eval_infer.py:49,114`): `default="bytedance-research/Multi-SWE-Bench"`
- **README.md**: all 13 CLI examples use `bytedance-research/Multi-SWE-Bench`
- **GitHub Actions** (`build-multiswebench-images.yml:11,56`): `bytedance-research/Multi-SWE-Bench`
- **Documentation** (`eval_infer.py:38`): `"bytedance-research/Multi-SWE-Bench"`
- **Upstream repo**: https://github.com/bytedance-research/Multi-SWE-Bench

## Fix
Replace `startswith("ByteDance-Seed/Multi-SWE-bench")` with `startswith("bytedance-research/Multi-SWE-Bench")` to match the actual HuggingFace dataset path.

## Test plan
- [ ] CI passes
- [ ] Run `multiswebench-infer` with `--dataset bytedance-research/Multi-SWE-Bench` and verify dataset download is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)