### PR TITLE
Fix fork+threading deadlock by switching to spawn multiprocessing

### DIFF
--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -4,6 +4,7 @@ Evaluation orchestrator.
 
 import base64
 import json
+import multiprocessing
 import os
 import sys
 import time
@@ -369,7 +370,15 @@ class Evaluation(ABC, BaseModel):
                 attempt_outputs.append(out)
 
             # Run evaluation for this attempt
-            pool = ProcessPoolExecutor(max_workers=self.num_workers)
+            # Use 'spawn' instead of 'fork' to avoid deadlocks when the parent
+            # process has threads (e.g., WebSocket clients, log streamers).
+            # With 'fork', child processes inherit copies of locks that may be
+            # held by threads, causing deadlocks when those locks are needed.
+            # See: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+            mp_context = multiprocessing.get_context("spawn")
+            pool = ProcessPoolExecutor(
+                max_workers=self.num_workers, mp_context=mp_context
+            )
             futures: list[Future] = []
             # Consolidated tracking: maps future -> PendingInstance
             pending_instances: dict[Future, PendingInstance] = {}
@@ -715,7 +724,6 @@ class Evaluation(ABC, BaseModel):
                                 archive_error,
                             )
                         try:
-                            # Use the context manager protocol for cleanup
                             workspace.__exit__(None, None, None)
                             logger.debug(
                                 "[child] cleaned up workspace for id=%s", instance.id


### PR DESCRIPTION
## Summary

Fixes worker deadlock where evaluation jobs hang forever after partial completion.

## Problem

Evaluation job 22378330981 deadlocked after completing 84/500 instances ([Issue #276](https://github.com/OpenHands/evaluation/issues/276)):
- All 30 worker processes stuck in `futex_wait_queue` state for 9+ hours
- No progress after 12:56 UTC

## Root Cause: Fork + Threading Deadlock

**Evidence from Datadog logs:**
```
DeprecationWarning: This process (pid=4310) is multi-threaded, use of fork() may lead to deadlocks in the child.
```

**Mechanism:**
1. Parent process creates threads (WebSocket clients, log streamers, etc.)
2. `ProcessPoolExecutor` uses `fork()` by default on Linux
3. `fork()` copies the entire process, including locks in their current state
4. If a thread holds a lock at the moment of `fork()`, the child process inherits a locked mutex with no thread to unlock it
5. When the child tries to acquire that lock, it deadlocks forever
6. `futex_wait_queue` = waiting on mutex (exactly what we observed)

**Why 84 instances succeeded:** Fork+threading deadlock is timing-dependent. If no thread holds a lock at fork time, the child works fine.

## Solution

Use `multiprocessing.get_context("spawn")` when creating `ProcessPoolExecutor`. The spawn method starts fresh Python processes instead of forking, completely avoiding the fork+threads deadlock.

## Changes

```diff
+mp_context = multiprocessing.get_context("spawn")
+pool = ProcessPoolExecutor(max_workers=self.num_workers, mp_context=mp_context)
-pool = ProcessPoolExecutor(max_workers=self.num_workers)
```

## References

- [Python docs: Contexts and start methods](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods)
- Issue: OpenHands/evaluation#276