### PR TITLE
Add structured error tracing to evaluation outputs

### DIFF
--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -8,6 +8,7 @@ import multiprocessing
 import os
 import sys
 import time
+import traceback
 from abc import ABC, abstractmethod
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from contextlib import contextmanager
@@ -133,12 +134,23 @@ class Evaluation(ABC, BaseModel):
         raise NotImplementedError
 
     def _create_error_output(
-        self, instance: EvalInstance, error: Exception, retry_count: int
+        self,
+        instance: EvalInstance,
+        error: Exception,
+        retry_count: int,
+        *,
+        stack: str | None = None,
     ) -> EvalOutput:
         """Create an EvalOutput object for a failed instance."""
+        err_type = error.__class__.__name__
+        err_msg = str(error)
         return EvalOutput(
             instance_id=instance.id,
-            test_result={},
+            test_result={
+                "error_type": err_type,
+                "error_message": err_msg,
+                "error_stack": stack,
+            },
             instruction=None,
             error=(
                 f"Instance failed after {retry_count} retries. Last error: {str(error)}"
@@ -470,6 +482,7 @@ class Evaluation(ABC, BaseModel):
                                     f"{self.instance_timeout}s timeout"
                                 ),
                                 attempt,
+                                stack=None,
                             )
                             if error_output.metadata is None:
                                 error_output.metadata = self.metadata.model_copy(
@@ -596,6 +609,7 @@ class Evaluation(ABC, BaseModel):
             retry_count = 0
             runtime_failure_count = 0
             last_error = None
+            last_error_stack: str | None = None
             max_retries = self.metadata.max_retries
             runtime_runs: list[RemoteRuntimeAllocation] = []
 
@@ -663,6 +677,7 @@ class Evaluation(ABC, BaseModel):
                     return instance, out
                 except Exception as e:
                     last_error = e
+                    last_error_stack = traceback.format_exc()
                     retry_count += 1
                     lmnr_span.record_exception(e)
 
@@ -707,7 +722,10 @@ class Evaluation(ABC, BaseModel):
                         )
                         # Create error output for final failure
                         error_output = self._create_error_output(
-                            instance, last_error, max_retries
+                            instance,
+                            last_error,
+                            max_retries,
+                            stack=last_error_stack,
                         )
                         if runtime_runs:
                             error_output.runtime_runs = runtime_runs
@@ -737,7 +755,10 @@ class Evaluation(ABC, BaseModel):
 
             # This should never be reached, but added for type safety
             error_output = self._create_error_output(
-                instance, Exception("Unexpected error: no attempts made"), max_retries
+                instance,
+                Exception("Unexpected error: no attempts made"),
+                max_retries,
+                stack=None,
             )
             if runtime_runs:
                 error_output.runtime_runs = runtime_runs


### PR DESCRIPTION
## Summary
- Include `error_type`, `error_message`, and `error_stack` in the `test_result` dict when creating error outputs for failed evaluation instances
- Capture `traceback.format_exc()` at the point of failure and propagate it through to the JSONL output

## Motivation
When instances fail, diagnosing the root cause requires digging through per-instance log files. This change surfaces structured error information directly in the evaluation output, making it easier to triage failures at scale.

## Test plan
- [ ] CI passes
- [ ] Run an evaluation with a known-failing instance and verify the error fields appear in `output.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)