### PR TITLE
Fix TypeError in swtbench when --note parameter is not provided

### DIFF
--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -372,7 +372,7 @@ def main() -> None:
         dataset_name=dataset_description,
         model_name=llm.model,
         max_iterations=args.max_iterations,
-        eval_note="SWT-" + args.note,
+        eval_note=f"SWT-{args.note}" if args.note else None,
     )
 
     critic = create_critic(args)


### PR DESCRIPTION
## Problem

The `swtbench-infer` command fails with a TypeError when run without the `--note` flag:

```
TypeError: can only concatenate str (not "NoneType") to str
  File "benchmarks/swtbench/run_infer.py", line 375, in main
    eval_note="SWT-" + args.note,
```

## Root Cause

Line 375 in `benchmarks/swtbench/run_infer.py` attempts to concatenate the string `"SWT-"` with `args.note`, but `args.note` is `None` when the `--note` flag is not provided on the command line.

## Solution

Changed the code to handle the `None` case properly using a conditional expression:

```python
# Before
eval_note="SWT-" + args.note,

# After
eval_note=f"SWT-{args.note}" if args.note else None,
```

This approach is consistent with how other benchmarks (e.g., swebench) handle the `eval_note` parameter.

## Testing

Verified the fix by running:
```bash
uv run swtbench-infer .llm_config/sonnet-4-5.json --max-iterations 100 --n-limit 1 --workspace docker
```

The command now completes successfully without the `--note` flag.

## Changes

- `benchmarks/swtbench/run_infer.py`: Fixed line 375 to handle None case

All pre-commit hooks passed (ruff format, ruff lint, pycodestyle, pyright).