### PR TITLE
Rename image_exists to remote_image_exists

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -24,7 +24,7 @@ from benchmarks.utils.evaluation_utils import (
     construct_eval_output_dir,
     get_default_on_result_writer,
 )
-from benchmarks.utils.image_utils import create_docker_workspace, image_exists
+from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -213,7 +213,7 @@ class Commit0Evaluation(Evaluation):
                 f"{EVAL_AGENT_SERVER_IMAGE}:{sdk_short_sha}-{custom_tag}{suffix}"
             )
 
-            if not image_exists(agent_server_image):
+            if not remote_image_exists(agent_server_image):
                 raise RuntimeError(
                     f"Agent server image {agent_server_image} does not exist in container registry. "
                     "Run 'benchmarks/commit0/build_images.py --push' to build and push it first."

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -27,7 +27,7 @@ from benchmarks.utils.evaluation_utils import (
     get_default_on_result_writer,
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
-from benchmarks.utils.image_utils import create_docker_workspace, image_exists
+from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
 from benchmarks.utils.version import SDK_SHORT_SHA
@@ -182,7 +182,7 @@ class GAIAEvaluation(Evaluation):
                 f"{EVAL_AGENT_SERVER_IMAGE}:{sdk_short_sha}-gaia-binary"
             )
 
-            if not image_exists(agent_server_image):
+            if not remote_image_exists(agent_server_image):
                 raise RuntimeError(
                     f"Agent server image {agent_server_image} does not exist in container registry. "
                     f"Run 'benchmarks/gaia/build_images.py --push' to build and push it first."

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -26,7 +26,7 @@ from benchmarks.utils.evaluation_utils import (
     get_default_on_result_writer,
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
-from benchmarks.utils.image_utils import image_exists
+from benchmarks.utils.image_utils import remote_image_exists
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -234,7 +234,7 @@ class MultiSWEBenchEvaluation(Evaluation):
             agent_server_image = (
                 f"{EVAL_AGENT_SERVER_IMAGE}:{sdk_short_sha}-{custom_tag}{suffix}"
             )
-            if not image_exists(agent_server_image):
+            if not remote_image_exists(agent_server_image):
                 raise RuntimeError(
                     f"Agent server image {agent_server_image} does not exist in container registry, "
                     "make sure to build, push it, and make it public accessible before using remote workspace."

--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -22,7 +22,7 @@ from benchmarks.utils.build_utils import (
     run_docker_build_layer,
 )
 from benchmarks.utils.dataset import get_dataset
-from benchmarks.utils.image_utils import image_exists
+from benchmarks.utils.image_utils import remote_image_exists
 from openhands.sdk import get_logger
 
 
@@ -94,7 +94,7 @@ def wrap_image(agent_image: str, push: bool = False) -> BuildOutput:
     For pushes, verify the base tag exists in the registry. For local builds,
     assume the tag is available locally or resolvable by Docker during buildx.
     """
-    if push and not image_exists(agent_image):
+    if push and not remote_image_exists(agent_image):
         return BuildOutput(
             base_image=agent_image,
             tags=[],

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -26,7 +26,7 @@ from benchmarks.utils.evaluation_utils import (
     get_default_on_result_writer,
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
-from benchmarks.utils.image_utils import image_exists
+from benchmarks.utils.image_utils import remote_image_exists
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -195,7 +195,7 @@ class SWEBenchEvaluation(Evaluation):
             agent_server_image = (
                 f"{EVAL_AGENT_SERVER_IMAGE}:{sdk_short_sha}-{custom_tag}{suffix}"
             )
-            if not image_exists(agent_server_image):
+            if not remote_image_exists(agent_server_image):
                 raise RuntimeError(
                     f"Agent server image {agent_server_image} does not exist in container registry, "
                     "make sure to build, push it, and make it public accessible before using remote workspace."

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -24,7 +24,7 @@ from benchmarks.utils.evaluation_utils import (
     get_default_on_result_writer,
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
-from benchmarks.utils.image_utils import image_exists
+from benchmarks.utils.image_utils import remote_image_exists
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -187,7 +187,7 @@ class SWEBenchEvaluation(Evaluation):
             agent_server_image = (
                 f"{EVAL_AGENT_SERVER_IMAGE}:{sdk_short_sha}-{custom_tag}{suffix}"
             )
-            if not image_exists(agent_server_image):
+            if not remote_image_exists(agent_server_image):
                 raise RuntimeError(
                     f"Agent server image {agent_server_image} does not exist in container registry, "
                     "make sure to build, push it, and make it public accessible before using remote workspace."

--- a/benchmarks/swefficiency/run_infer.py
+++ b/benchmarks/swefficiency/run_infer.py
@@ -21,7 +21,7 @@ from benchmarks.utils.evaluation_utils import (
     get_default_on_result_writer,
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
-from benchmarks.utils.image_utils import image_exists
+from benchmarks.utils.image_utils import remote_image_exists
 from benchmarks.utils.models import (
     EvalInstance,
     EvalMetadata,
@@ -248,7 +248,7 @@ class SWEfficiencyEvaluation(Evaluation):
             remote_agent_image = (
                 f"{EVAL_AGENT_SERVER_IMAGE}:{sdk_short_sha}-{custom_tag}{suffix}"
             )
-            if not image_exists(remote_agent_image):
+            if not remote_image_exists(remote_agent_image):
                 raise RuntimeError(
                     f"Agent server image {remote_agent_image} does not exist in container registry, "
                     "make sure to build, push it, and make it public accessible before using remote workspace."

--- a/benchmarks/swtbench/build_eval_env_images.py
+++ b/benchmarks/swtbench/build_eval_env_images.py
@@ -12,7 +12,7 @@ import docker
 from benchmarks.swtbench.config import EVAL_DEFAULTS
 from benchmarks.swtbench.image_utils import ensure_swt_bench_repo
 from benchmarks.utils.dataset import get_dataset
-from benchmarks.utils.image_utils import image_exists as remote_image_exists
+from benchmarks.utils.image_utils import remote_image_exists
 from openhands.sdk import get_logger
 
 

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -18,7 +18,7 @@ from benchmarks.utils.evaluation_utils import (
     get_default_on_result_writer,
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
-from benchmarks.utils.image_utils import create_docker_workspace, image_exists
+from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -188,7 +188,7 @@ class SWTBenchEvaluation(Evaluation):
             agent_server_image = (
                 f"{EVAL_AGENT_SERVER_IMAGE}:{sdk_short_sha}-{custom_tag}{suffix}"
             )
-            if not image_exists(agent_server_image):
+            if not remote_image_exists(agent_server_image):
                 raise RuntimeError(
                     f"Agent server image {agent_server_image} does not exist in container registry, "
                     "make sure to build, push it, and make it public accessible before using remote workspace."

--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -27,7 +27,7 @@ from benchmarks.utils.buildx_utils import (
     maybe_reset_buildkit,
 )
 from benchmarks.utils.constants import EVAL_AGENT_SERVER_IMAGE
-from benchmarks.utils.image_utils import image_exists, local_image_exists
+from benchmarks.utils.image_utils import local_image_exists, remote_image_exists
 from openhands.agent_server.docker.build import BuildOptions, TargetType, build
 from openhands.sdk import get_logger
 
@@ -300,7 +300,7 @@ def build_image(
     )
     for t in opts.all_tags:
         # Check if image exists or not
-        if image_exists(t):
+        if remote_image_exists(t):
             logger.info("Image %s already exists. Skipping build.", t)
             return BuildOutput(base_image=base_image, tags=[t], error=None)
     tags = build(opts)

--- a/benchmarks/utils/image_utils.py
+++ b/benchmarks/utils/image_utils.py
@@ -120,12 +120,13 @@ def create_docker_workspace(
         )
 
 
-def image_exists(
+def remote_image_exists(
     image_ref: str,
     gh_username: str | None = None,
     gh_pat: str | None = None,  # GitHub PAT with read:packages for private GHCR
     docker_token: str | None = None,  # Docker Hub JWT if you already have one
 ) -> bool:
+    """Check if a Docker image exists in a remote registry."""
     registry, repo, ref = _parse(image_ref)
     headers = {"Accept": ACCEPT}
 
@@ -167,5 +168,5 @@ if __name__ == "__main__":
     gh_user = sys.argv[2] if len(sys.argv) > 2 else None
     gh_pat = sys.argv[3] if len(sys.argv) > 3 else None
 
-    ok = image_exists(image, gh_username=gh_user, gh_pat=gh_pat)
+    ok = remote_image_exists(image, gh_username=gh_user, gh_pat=gh_pat)
     print(f"{image} -> {'✅ exists' if ok else '❌ not found or unauthorized'}")


### PR DESCRIPTION
## Summary
- Renamed `image_exists` → `remote_image_exists` in `benchmarks/utils/image_utils.py` for clarity: the function only checks **remote registries**, while `local_image_exists` was already named correctly
- Updated all 10 import and call sites across the codebase
- Added a one-line docstring to the function

Split out from #455.

### CI validation
All benchmarks pass with this rename (validated in the parent PR):

| Benchmark | Status | Run |
|-----------|--------|-----|
| gaia | Pass | https://github.com/OpenHands/evaluation/actions/runs/22590769837 |
| swebench | Pass | https://github.com/OpenHands/evaluation/actions/runs/22590769394 |
| swtbench | Pass | https://github.com/OpenHands/evaluation/actions/runs/22590775404 |
| commit0 | Pass | https://github.com/OpenHands/evaluation/actions/runs/22590778789 |
| swebenchmultimodal | Pass | https://github.com/OpenHands/evaluation/actions/runs/22590785406 |

## Test plan
- [x] Verify no remaining references to the old `image_exists` name (`grep -r "image_exists" --include="*.py"` returns only `local_image_exists` and `remote_image_exists`)
- [x] All call sites updated with the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)