### PR TITLE
Optimize SWE-Bench image builds: add local Docker check before remote registry

### DIFF
--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -303,16 +303,12 @@ def build_image(
         sdk_version=sdk_version,
     )
     for t in opts.all_tags:
-        # Check local Docker first (fast), then remote registry (slow)
-        # This avoids overwhelming the registry with 500+ concurrent HTTP requests
-        # when building large batches (e.g., all SWE-Bench images)
+        # Check local Docker first (fast ~100ms), then remote registry (slow HTTP)
         if local_image_exists(t):
             logger.info("Image %s already exists locally. Skipping build.", t)
             return BuildOutput(base_image=base_image, tags=[t], error=None)
         if remote_image_exists(t):
-            logger.info(
-                "Image %s already exists in remote registry. Skipping build.", t
-            )
+            logger.info("Image %s already exists in registry. Skipping build.", t)
             return BuildOutput(base_image=base_image, tags=[t], error=None)
     tags = build(opts)
     return BuildOutput(base_image=base_image, tags=tags, error=None)


### PR DESCRIPTION
## Summary

This PR adds a local Docker image check **before** the remote registry check in `build_image()`. This is a **performance optimization** that can reduce HTTP requests when building images that already exist locally.

## Investigation Update

After further investigation based on reviewer feedback:

1. **PR #471 only renamed functions** - it did not remove any local Docker check
2. **There was never a local check in `build_image()`** - the `image_exists()` function has always been a remote-only HTTP check
3. **The March 3rd stuck builds were transient** - builds before and after the stuck ones succeeded without any code changes
4. **Builds are now working** - the issue resolved without this PR being merged

## What This PR Actually Does

Adds an optimization to check local Docker images before making remote HTTP requests:

```python
# Check local Docker first (fast), then remote registry (slow)
if local_image_exists(t):
    logger.info("Image %s already exists locally. Skipping build.", t)
    return BuildOutput(base_image=base_image, tags=[t], error=None)
if remote_image_exists(t):
    logger.info("Image %s already exists in remote registry. Skipping build.", t)
    return BuildOutput(base_image=base_image, tags=[t], error=None)
```

**Benefits:**
- Skips HTTP requests for images that already exist locally
- Useful for local development and re-runs on the same machine
- Fast local Docker check (~100ms) vs slow HTTP request

**Limitations:**
- In CI environments with fresh runners, images typically don't exist locally, so the remote check will still be needed
- This is an optimization, not a fix for the transient stuck builds

## Recommendation

Given that:
1. The stuck builds were transient and resolved without this change
2. CI runners typically don't have pre-built images locally
3. The change adds complexity without fixing the root cause (which remains unknown)

**I recommend closing this PR.** If the team believes the local check optimization is valuable for local development workflows, we can keep it. Otherwise, this PR can be closed as the issue was transient.

## Testing

✅ All tests pass  
✅ Pre-commit checks pass

Related to #476 (but does not fix the root cause)
