### PR TITLE
Revert spawn multiprocessing context to fix memory exhaustion

### DIFF
--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -715,7 +715,6 @@ class Evaluation(ABC, BaseModel):
                                 archive_error,
                             )
                         try:
-                            # Use the context manager protocol for cleanup
                             workspace.__exit__(None, None, None)
                             logger.debug(
                                 "[child] cleaned up workspace for id=%s", instance.id


### PR DESCRIPTION
## Summary

This PR reverts commit 744df225fe7a04775f5d755d07e9b5e363285628 which switched from `fork` to `spawn` multiprocessing context. While that change fixed a fork+threading deadlock issue, it caused severe memory exhaustion in evaluation pods.

## Problem

The `spawn` multiprocessing method creates entirely new Python processes, causing:
- Each worker process loads all modules and data from scratch (no memory sharing)
- Memory usage scales linearly with worker count (35+ workers observed)
- Each worker consuming ~427-440MB
- Total memory exceeding 12GB limit, causing OOM kills and pod evictions

## Evidence

### Failed Evaluation Run (with spawn)
- https://github.com/OpenHands/evaluation/actions/runs/22651717284

### Successful Evaluation Run (with fork, before the problematic commit)
- https://github.com/OpenHands/evaluation/actions/runs/22671170982

### Multiple pod failures with OOM:
- `eval-22606257355-gemini-3-1-62f69` - 11.4 GB used
- `eval-22614062017-claude-son-hgncz` - 10.7 GB used
- `eval-22621261417-claude-son-l5cpq` - 9.7 GB used
- `eval-22606290226-glm-5-rkfdj`
- `eval-22606290226-qwen3-5-fl-9fkxz`
- `eval-22606392060-gemini-3-1-x8fw8`
- `eval-22606392060-qwen3-5-fl-2snvr`
- `eval-22606414183-gemini-3-1-zcsrt`
- `eval-22606414183-qwen3-5-fl-x9mkh`
- `eval-22647760740-gemini-3-1-psbwk` - 11.7 GB used
- `eval-22628463356-glm-5-ljhm9` - 11.5 GB used (caught by monitoring)

All failed with Exit Code 137 (SIGKILL - OOM) or BackoffLimitExceeded.

## Impact

- Evaluation jobs failing after 1-3 hours (wasted compute)
- Multiple benchmarks affected: swebench, swebenchmultimodal, gaia
- Multiple models affected: gemini-3.1-pro, claude-sonnet-4-5, glm-5, qwen3.5-flash

## Next Steps

The original deadlock issue (#276) will need to be addressed through a different approach that doesn't cause memory exhaustion, such as:
1. Cleaning up threads before forking
2. Using thread-safe initialization
3. Implementing proper resource cleanup in worker processes
4. Adjusting worker count and memory limits if spawn is necessary

## Closes

- Fixes #483
- Fixes OpenHands/evaluation#287