### PR TITLE
Fix fork+threading deadlock in SWE-Bench image builds

### DIFF
--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -6,6 +6,7 @@ Shared utilities for batch building agent-server images.
 import argparse
 import contextlib
 import io
+import multiprocessing
 import os
 import subprocess
 import sys
@@ -528,7 +529,15 @@ def build_all_images(
             )
             in_progress: set[str] = set()
 
-            with ProcessPoolExecutor(max_workers=max_workers) as ex:
+            # Use 'spawn' instead of 'fork' to avoid deadlocks when the parent
+            # process has threads (e.g., from rich.logging.RichHandler).
+            # With 'fork', child processes inherit copies of locks that may be
+            # held by threads, causing deadlocks when those locks are needed.
+            # See: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+            mp_context = multiprocessing.get_context("spawn")
+            with ProcessPoolExecutor(
+                max_workers=max_workers, mp_context=mp_context
+            ) as ex:
                 futures = {}
                 for base in batch:
                     in_progress.add(base)


### PR DESCRIPTION
## Summary

This PR fixes the root cause of issue #476 where SWE-Bench image builds get stuck for 5+ hours during the batch build process.

## Root Cause

Commit `2bfcc6c` (#456) introduced the following import in `benchmarks/utils/image_utils.py`:
```python
from openhands.sdk import get_logger
logger = get_logger(__name__)
```

When this module is imported, the SDK logger auto-initializes with a `RichHandler` (from the `rich` library), which uses locks and potentially threads for console rendering. The issue occurs when:

1. `build_utils.py` imports `image_utils`, triggering logger initialization in the parent process
2. `build_all_images()` creates a `ProcessPoolExecutor` using **fork** (default on Linux)
3. Fork copies the parent process, including Rich logger's locks in their current state  
4. Child processes deadlock waiting for locks that will never be released

This is the **exact same fork+threading deadlock** that commit `744df225` (#459) fixed in `evaluation.py`, but that fix only applied to `evaluation.py` and not to `build_utils.py`.

## Evidence

From commit `744df225` (#459):
> Root cause: ProcessPoolExecutor uses fork() by default on Linux, which is unsafe when the parent process has threads. When fork() copies a process, it copies locks in their current state. If a thread holds a lock during fork(), the child process deadlocks waiting for that lock forever.
>
> Evidence from Datadog logs:
> - Warning: 'This process is multi-threaded, use of fork() may lead to deadlocks'
> - Workers stuck in futex_wait_queue (mutex wait)
> - 84/500 instances succeeded before deadlock (timing-dependent)

The same pattern applies to image building:
- Multiple workers (12 by default) get stuck in deadlock
- The number of images built before deadlock is timing-dependent
- Builds hang for hours without completing

## Solution

Use `spawn` multiprocessing context instead of `fork` in `build_all_images()`, matching the fix from commit `744df225` for `evaluation.py`.

The spawn method starts fresh Python processes instead of forking, avoiding the fork+threads deadlock entirely.

## Changes

- Added `import multiprocessing` to `build_utils.py`
- Modified `ProcessPoolExecutor` instantiation to use `mp_context=multiprocessing.get_context("spawn")`
- Added explanatory comments matching the pattern from `evaluation.py`

## Testing

✅ All pre-commit checks pass  
✅ Type checking passes  
✅ Linting passes

The fix should be verified by running a full 500-image build on GitHub Actions, which was previously getting stuck.

## Related

- Fixes #476
- Follows the same pattern as commit `744df225` (#459)
- Related to PR #481 (which addressed symptoms but not the root cause)