### PR TITLE
fix(gaia): GAIA image build

### DIFF
--- a/benchmarks/gaia/build_images.py
+++ b/benchmarks/gaia/build_images.py
@@ -79,10 +79,10 @@ def main(argv: list[str]) -> int:
     # already exists in the registry it already includes the MCP layer from a
     # previous build, so re-running would stack a duplicate layer on top —
     # inflating the image and causing runtime OOM crashes.
-    git_ref, git_sha, sdk_version = _get_sdk_submodule_info()
-    final_image = f"{args.image}:{git_sha[:7]}-gaia-{args.target}"
-    if not args.dry_run and remote_image_exists(final_image):
-        logger.info("Image %s already exists. Skipping build.", final_image)
+    _, git_sha, _ = _get_sdk_submodule_info()
+    base_gaia_image = f"{args.image}:{git_sha[:7]}-gaia-{args.target}"
+    if not args.dry_run and remote_image_exists(base_gaia_image):
+        logger.info("Image %s already exists. Skipping build.", base_gaia_image)
         return 0
 
     # Build base GAIA image
@@ -104,9 +104,6 @@ def main(argv: list[str]) -> int:
         return exit_code
 
     # Build MCP-enhanced layer after base image succeeds
-    git_ref, git_sha, sdk_version = _get_sdk_submodule_info()
-    base_gaia_image = f"{args.image}:{git_sha[:7]}-gaia-{args.target}"
-
     logger.info("Building MCP-enhanced GAIA image from base: %s", base_gaia_image)
     mcp_result = build_gaia_mcp_layer(base_gaia_image, push=args.push)
 


### PR DESCRIPTION
The GAIA image build has a layer stacking bug. The build process has two steps:                                                                                                                                    
                                                                                                                                                                                                                  1. Build base image → tagged as {sha}-gaia-binary 
                                                                                                                                                                                                                  2. Apply MCP layer → uses {sha}-gaia-binary as input AND output tag                                                                                                                                                

When build_all_images detects the image already exists in the registry, it skips step 1 — but step 2 always runs, pulling the existing image (which already has the MCP layer from a previous build) and stacking another MCP layer on top.

The fix adds an early exit at the top of main() that checks if the final image (base + MCP) already exists in the registry. If it does, the entire build is skipped, preventing duplicate MCP layers from being stacked.

Ref of a run: https://openhands-ai.slack.com/archives/C09QGUDQVTL/p1773223047360769
