### PR TITLE
fix(commit0): extract report summary inside container to avoid HTTP corruption 

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 from typing import Any, List
 
 from commit0.harness.constants import SPLIT
@@ -38,6 +39,17 @@ from openhands.workspace import APIRemoteWorkspace
 
 
 logger = get_logger(__name__)
+
+# Script run inside the container to extract summary + duration from
+# report.json.  Only the small summary dict (~200 bytes) is printed to
+# stdout, avoiding HTTP transfer corruption for large reports (see #511).
+EXTRACT_SUMMARY_SCRIPT = """
+import json
+r = json.load(open('report.json'))
+s = r.get('summary', {})
+s['duration'] = r.get('duration', 0)
+print(json.dumps(s))
+""".strip()
 
 
 def parse_report_summary(raw_json: str) -> dict:
@@ -450,17 +462,15 @@ class Commit0Evaluation(Evaluation):
         # This avoids transferring the full report (can be >1 MB) over HTTP,
         # which causes corruption for large files (see #511).
         summary_cmd = (
-            f'cd {repo_path} && python3 -c "'
-            "import json; "
-            "r = json.load(open('report.json')); "
-            "s = r.get('summary', {}); "
-            "s['duration'] = r.get('duration', 0); "
-            "print(json.dumps(s))"
-            '"'
+            f"cd {repo_path} && python3 -c {shlex.quote(EXTRACT_SUMMARY_SCRIPT)}"
         )
         report_result = workspace.execute_command(summary_cmd, timeout=600)
         logger.info(f"Report summary extraction exit code: {report_result.exit_code}")
 
+        # Intentionally let errors propagate here — do NOT add a try/except.
+        # Silent failures caused instances to be scored 0/0 even when all
+        # tests passed (see #511).  The framework's retry logic in
+        # evaluation.py handles the exception.
         if report_result.exit_code != 0:
             raise RuntimeError(
                 f"Report summary extraction failed (exit code {report_result.exit_code}): "

--- a/tests/test_commit0_report_summary.py
+++ b/tests/test_commit0_report_summary.py
@@ -10,18 +10,7 @@ import subprocess
 
 import pytest
 
-from benchmarks.commit0.run_infer import parse_report_summary
-
-
-# The same one-liner used in run_infer.py to extract the summary inside the
-# container.  Kept here so integration tests exercise the real command.
-_EXTRACTION_SCRIPT = (
-    "import json; "
-    "r = json.load(open('report.json')); "
-    "s = r.get('summary', {}); "
-    "s['duration'] = r.get('duration', 0); "
-    "print(json.dumps(s))"
-)
+from benchmarks.commit0.run_infer import EXTRACT_SUMMARY_SCRIPT, parse_report_summary
 
 
 @pytest.mark.parametrize(
@@ -178,7 +167,7 @@ def test_real_pytest_json_report_output():
 def _run_extraction(report_dir: str) -> subprocess.CompletedProcess:
     """Run the extraction one-liner against a report.json in *report_dir*."""
     return subprocess.run(
-        ["python3", "-c", _EXTRACTION_SCRIPT],
+        ["python3", "-c", EXTRACT_SUMMARY_SCRIPT],
         cwd=report_dir,
         capture_output=True,
         text=True,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -93,18 +93,23 @@ def mock_llm_with_metrics():
     return llm
 
 
+def _mock_execute_command(cmd, timeout=None):
+    """Return context-appropriate responses for workspace commands."""
+    result = MagicMock(exit_code=0, stderr="")
+    if "print(json.dumps(s))" in cmd:
+        # commit0 report summary extraction one-liner
+        result.stdout = '{"passed": 1, "total": 1, "collected": 1, "duration": 0.1}'
+    else:
+        result.stdout = "test output"
+    return result
+
+
 @pytest.fixture
 def mock_workspace():
     """Create a mock workspace."""
     workspace = MagicMock(spec=RemoteWorkspace)
     workspace.working_dir = "/workspace"
-    workspace.execute_command = MagicMock(
-        return_value=MagicMock(
-            exit_code=0,
-            stdout="test output",
-            stderr="",
-        )
-    )
+    workspace.execute_command = MagicMock(side_effect=_mock_execute_command)
     return workspace
 
 


### PR DESCRIPTION
## Problem

(ref #511 )

report.json files >1 MB get corrupted during HTTP transfer from the remote workspace, causing json.loads() to fail and silently scoring instances as 0/0 — even when all tests passed. This affected babel, cookiecutter, and chardet consistently across runs.

## Fix
Instead of cat report.json (transferring the full multi-MB file), run a Python one-liner inside the container that reads the JSON locally and prints only the summary dict (~200 bytes). The large file never crosses the HTTP boundary.

  - Eliminates the root cause (large file transfer) rather than working around the symptom (corrupt JSON)
  - The summary is extracted from the authoritative JSON report, not regex-parsed from stdout
  - Reduces transferred data from up to 9 MB to ~200 bytes
  - Simpler code: -73 lines, no Counter, no re, no per-test iteration, no fallback logic

## Note on Field Names

pytest-json-report uses different names at different levels:
- Per-test outcomes (report["tests"][*]["call"]["outcome"]): "xfail", "xpass"
- Summary counts (report["summary"]): "xfailed", "xpassed"

The old code iterated per-test outcomes (status_counts.get("xfail", 0)). The new code reads the summary dict (summary.get("xfailed", 0)). Both are correct for their respective contexts.

## Testing

Run eval: https://results.eval.all-hands.dev/commit0/litellm_proxy-claude-sonnet-4-5-20250929/23064025837/results.tar.gz

And analyzed with OH.

Results:

```text
 Here's the complete test output for all 10 projects:                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
  1. simpy (exit code 4 — no tests collected)                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                             
  ImportError while loading conftest '/workspace/simpy/tests/conftest.py'.                                                                                                                                                                                                   
  E   ModuleNotFoundError: No module named 'simpy'                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                             
  2. cachetools (exit code 1 — 0 collected, 12 import errors)                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                             
  All 12 test files failed with ModuleNotFoundError: No module named 'cachetools'. Package was never installed.                                                                                                                                                              
                                                                                                                                                                                                                                                                             
  3. jinja (exit code -1 — empty output)                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                             
  Completely empty test output file. Infrastructure failure (502 Bad Gateway).                                                                                                                                                                                               
                                                                                                                                                                                                                                                                             
  4. deprecated (exit code 0 — 171 passed)                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                             
  171 passed, 3 warnings in 0.21s ✓ RESOLVED

  5. marshmallow (exit code 0 — 1229 passed)

  1229 passed in 1.19s ✓ RESOLVED

  6. wcwidth (exit code 1 — 37 passed, 1 failed, 1 skipped)

  Single failure: test_package_version — PackageNotFoundError: No package metadata was found for wcwidth (package not installed with metadata).

  7. tinydb (exit code 1 — 191 passed, 10 failed)

  10 failures, mostly missing features (DID NOT RAISE, TypeError, JSONDecodeError).

  8. imapclient (exit code 1 — 82 passed, 185 failed)

  185 failures, mostly AttributeError — likely incomplete implementation.

  9. voluptuous (exit code 1 — 94 passed, 55 failed)

  55 failures, AttributeError and assertion errors.

  10. cookiecutter (exit code 1 — 177 passed, 190 failed, 4 skipped)

  190 failures, including SSL errors and logic failures.

  All test outputs are standard pytest output. The harness parsed them correctly — there's no test output parsing issue. The failures are genuine test failures in the code the agent produced.

```


