### PR TITLE
build: add opt-in force rebuild for image workflows

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -49,6 +49,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 env:
   DATASET: wentingzhao/commit0_combined
@@ -164,6 +169,7 @@ jobs:
       - name: Build and push Commit0 images
         run: |
           set -euo pipefail
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           CMD="uv run benchmarks/commit0/build_images.py \
             --dataset '${DATASET}' \
@@ -178,6 +184,9 @@ jobs:
           fi
           if [ -n "${SELECT_FILE}" ]; then
             CMD="$CMD --select '${SELECT_FILE}'"
+          fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
           fi
 
           echo "Running: $CMD"

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -13,6 +13,11 @@ on:
         description: 'Software Agent SDK commit/ref to use'
         required: true
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 concurrency:
   group: build-gaia-${{ github.ref }}
@@ -83,6 +88,7 @@ jobs:
       - name: Build and push GAIA image with MCP layer
         run: |
           set -euo pipefail
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           # GAIA requires 'binary' target to include Chromium for browser operations
           TARGET="binary"
@@ -91,6 +97,10 @@ jobs:
             --image ghcr.io/openhands/eval-agent-server \
             --target ${TARGET} \
             --push"
+
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
+          fi
 
           echo "Running: $CMD"
           eval "$CMD"

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -50,6 +50,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -228,6 +233,7 @@ jobs:
       - name: Build and push Multi-SWE-Bench images
         run: |
           set -euo pipefail
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           CMD="uv run benchmarks/multiswebench/build_images.py \
             --dataset '${DATASET}' \
@@ -243,6 +249,9 @@ jobs:
           fi
           if [ -n "${SELECT_FILE}" ]; then
             CMD="$CMD --select '${SELECT_FILE}'"
+          fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
           fi
 
           echo "Running: $CMD"

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -49,6 +49,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -225,6 +230,7 @@ jobs:
       - name: Build and push SWE-Bench images
         run: |
           set -euo pipefail
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           CMD="uv run benchmarks/swebench/build_images.py \
             --dataset '${DATASET}' \
@@ -240,6 +246,9 @@ jobs:
           fi
           if [ -n "${SELECT_FILE}" ]; then
             CMD="$CMD --select '${SELECT_FILE}'"
+          fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
           fi
 
           echo "Running: $CMD"

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -49,6 +49,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -225,6 +230,7 @@ jobs:
       - name: Build and push SWE-Bench Multimodal images
         run: |
           set -euo pipefail
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           CMD="uv run benchmarks/swebenchmultimodal/build_images.py \
             --dataset '${DATASET}' \
@@ -240,6 +246,9 @@ jobs:
           fi
           if [ -n "${SELECT_FILE}" ]; then
             CMD="$CMD --select '${SELECT_FILE}'"
+          fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
           fi
 
           echo "Running: $CMD"

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -221,6 +226,7 @@ jobs:
       - name: Build and push SWE-Gym images
         run: |
           set -euo pipefail
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           CMD="uv run benchmarks/swegym/build_images.py \
             --dataset '${DATASET}' \
@@ -236,6 +242,9 @@ jobs:
           fi
           if [ -n "${SELECT_FILE}" ]; then
             CMD="$CMD --select '${SELECT_FILE}'"
+          fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
           fi
 
           echo "Running: $CMD"

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -221,6 +226,7 @@ jobs:
       - name: Build and push SWE-Smith images
         run: |
           set -euo pipefail
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           CMD="uv run benchmarks/swesmith/build_images.py \
             --dataset '${DATASET}' \
@@ -236,6 +242,9 @@ jobs:
           fi
           if [ -n "${SELECT_FILE}" ]; then
             CMD="$CMD --select '${SELECT_FILE}'"
+          fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
           fi
 
           echo "Running: $CMD"

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -58,6 +58,11 @@ on:
         required: false
         default: '10'
         type: string
+      force-build:
+        description: 'Rebuild images even if matching remote tags already exist'
+        required: false
+        default: 'false'
+        type: string
 
 concurrency:
   group: build-swt-bench-${{ github.ref }}
@@ -144,6 +149,7 @@ jobs:
           MAX_WORKERS="${{ inputs.max-workers || '4' }}"
           N_LIMIT="${{ inputs.n-limit || '0' }}"
           INSTANCE_IDS="${{ inputs.instance-ids }}"
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           # SWT-Bench uses source-minimal target (same as SWE-bench)
           TARGET="source-minimal"
@@ -175,6 +181,9 @@ jobs:
           if [ -n "${SELECT_FILE}" ]; then
             CMD="$CMD --select ${SELECT_FILE}"
           fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            CMD="$CMD --force-build"
+          fi
 
           echo "Running: $CMD"
           eval "$CMD"
@@ -202,6 +211,7 @@ jobs:
           BUILD_MODE="${{ inputs.build-mode || 'cli' }}"
           MAX_RETRIES="${{ inputs.max-retries || '2' }}"
           BUILD_BATCH_SIZE="${{ inputs.build-batch-size || '10' }}"
+          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
           echo "N_LIMIT=${N_LIMIT}" >> "$GITHUB_ENV"
           echo "MAX_RETRIES=${MAX_RETRIES}" >> "$GITHUB_ENV"
@@ -228,6 +238,9 @@ jobs:
             ARGS+=(--instance-ids "${INSTANCE_IDS}")
           else
             ARGS+=(--eval-limit "${N_LIMIT}")
+          fi
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            ARGS+=(--force-build)
           fi
 
           echo "Running prebaked eval image build: uv run swtbench-build-eval-images ${ARGS[*]}"

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -125,6 +125,7 @@ def main(argv: list[str]) -> int:
         push=args.push,
         max_workers=args.max_workers,
         dry_run=args.dry_run,
+        force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
     )

--- a/benchmarks/gaia/build_images.py
+++ b/benchmarks/gaia/build_images.py
@@ -81,9 +81,15 @@ def main(argv: list[str]) -> int:
     # inflating the image and causing runtime OOM crashes.
     _, git_sha, _ = _get_sdk_submodule_info()
     base_gaia_image = f"{args.image}:{git_sha[:7]}-gaia-{args.target}"
-    if not args.dry_run and remote_image_exists(base_gaia_image):
+    if (
+        not args.dry_run
+        and not args.force_build
+        and remote_image_exists(base_gaia_image)
+    ):
         logger.info("Image %s already exists. Skipping build.", base_gaia_image)
         return 0
+    if args.force_build and not args.dry_run:
+        logger.info("FORCE_BUILD set, rebuilding GAIA image %s", base_gaia_image)
 
     # Build base GAIA image
     build_dir = default_build_output_dir("gaia", "validation")
@@ -95,6 +101,7 @@ def main(argv: list[str]) -> int:
         push=args.push,
         max_workers=1,  # Only building one image
         dry_run=args.dry_run,
+        force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=tag_fn,
     )

--- a/benchmarks/multiswebench/build_images.py
+++ b/benchmarks/multiswebench/build_images.py
@@ -119,6 +119,7 @@ def main():
         base_image_to_custom_tag_fn=extract_custom_tag,
         max_workers=args.num_workers,
         dry_run=False,
+        force_build=args.force_build,
     )
 
 

--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -178,6 +178,7 @@ def main(argv: list[str]) -> int:
         push=args.push,
         max_workers=args.max_workers,
         dry_run=args.dry_run,
+        force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=_wrap_if_needed,

--- a/benchmarks/swebenchmultimodal/build_images.py
+++ b/benchmarks/swebenchmultimodal/build_images.py
@@ -84,6 +84,7 @@ def main(argv: list[str]) -> int:
         push=args.push,
         max_workers=args.max_workers,
         dry_run=args.dry_run,
+        force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
     )

--- a/benchmarks/swegym/build_images.py
+++ b/benchmarks/swegym/build_images.py
@@ -88,6 +88,7 @@ def main(argv: list[str]) -> int:
         push=args.push,
         max_workers=args.max_workers,
         dry_run=args.dry_run,
+        force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=None,

--- a/benchmarks/swesmith/build_images.py
+++ b/benchmarks/swesmith/build_images.py
@@ -85,6 +85,7 @@ def main(argv: list[str]) -> int:
         push=args.push,
         max_workers=args.max_workers,
         dry_run=args.dry_run,
+        force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=None,

--- a/benchmarks/swtbench/build_eval_env_images.py
+++ b/benchmarks/swtbench/build_eval_env_images.py
@@ -96,6 +96,7 @@ def build_env_images(
     max_retries: int,
     batch_size: int,
     image_prefix: str | None,
+    force_build: bool = False,
 ) -> None:
     """
     Build base + environment images required by the provided ExecSpecs.
@@ -125,7 +126,7 @@ def build_env_images(
         base_spec_by_key.setdefault(key, spec)
         remote_tag = prefixed(key)
 
-        if remote_tag and remote_image_exists(remote_tag):
+        if remote_tag and not force_build and remote_image_exists(remote_tag):
             logger.info("Base image %s already in registry; reusing", remote_tag)
             try:
                 img = client.images.pull(remote_tag)
@@ -152,7 +153,10 @@ def build_env_images(
             skipped_base,
         )
         build_base_images(
-            client, missing_base_specs, force_rebuild=False, build_mode=build_mode
+            client,
+            missing_base_specs,
+            force_rebuild=force_build,
+            build_mode=build_mode,
         )
         base_built = {spec.base_image_key for spec in missing_base_specs}
         if image_prefix:
@@ -168,7 +172,7 @@ def build_env_images(
         key = spec.env_image_key
         remote_tag = prefixed(key)
 
-        if remote_tag and remote_image_exists(remote_tag):
+        if remote_tag and not force_build and remote_image_exists(remote_tag):
             logger.info("Env image %s already in registry; skipping build", remote_tag)
             continue
 
@@ -196,7 +200,7 @@ def build_env_images(
                 build_envs(
                     client,
                     batch,
-                    force_rebuild=False,
+                    force_rebuild=force_build,
                     max_workers=max_workers,
                     build_mode=build_mode,
                 )
@@ -314,6 +318,11 @@ def main() -> None:
         action="store_true",
         help="Build images locally without pushing to the registry",
     )
+    parser.add_argument(
+        "--force-build",
+        action="store_true",
+        help="Rebuild images even if matching remote tags already exist",
+    )
     args = parser.parse_args()
 
     instance_ids = (
@@ -343,6 +352,7 @@ def main() -> None:
         max_retries=args.max_retries,
         batch_size=args.build_batch_size,
         image_prefix=None if args.no_push else args.image_prefix,
+        force_build=args.force_build,
     )
 
     base_images = {spec.base_image_key for spec in exec_specs}

--- a/benchmarks/swtbench/build_images.py
+++ b/benchmarks/swtbench/build_images.py
@@ -45,6 +45,7 @@ def main(argv: list[str]) -> int:
         push=args.push,
         max_workers=args.max_workers,
         dry_run=args.dry_run,
+        force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=_wrap_if_needed,

--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -272,7 +272,17 @@ def get_build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dry-run", action="store_true", help="List base images only, don’t build"
     )
+    parser.add_argument(
+        "--force-build",
+        action="store_true",
+        help="Rebuild images even if matching remote tags already exist",
+    )
     return parser
+
+
+def _force_build_enabled(force_build: bool = False) -> bool:
+    env_force_build = os.getenv("FORCE_BUILD", "0").lower() in ("1", "true", "yes")
+    return force_build or env_force_build
 
 
 def build_image(
@@ -281,6 +291,7 @@ def build_image(
     custom_tag: str,
     target: TargetType = "source-minimal",
     push: bool = False,
+    force_build: bool = False,
 ) -> BuildOutput:
     # Importing here because openhands.agent_server.docker.build runs git checks
     # which fails when installed as a package outside the git repo
@@ -302,11 +313,17 @@ def build_image(
         git_sha=git_sha,
         sdk_version=sdk_version,
     )
-    for t in opts.all_tags:
-        # Check if image exists or not
-        if remote_image_exists(t):
-            logger.info("Image %s already exists. Skipping build.", t)
-            return BuildOutput(base_image=base_image, tags=[t], error=None)
+    if _force_build_enabled(force_build):
+        logger.info(
+            "FORCE_BUILD set, rebuilding remote image for %s even if it exists.",
+            base_image,
+        )
+    else:
+        for t in opts.all_tags:
+            # Check if image exists or not
+            if remote_image_exists(t):
+                logger.info("Image %s already exists. Skipping build.", t)
+                return BuildOutput(base_image=base_image, tags=[t], error=None)
     tags = build(opts)
     return BuildOutput(base_image=base_image, tags=tags, error=None)
 
@@ -322,7 +339,7 @@ def ensure_local_image(
     Returns True if a build occurred, False if the image already existed.
     Set FORCE_BUILD=1 to skip auto-detection and always rebuild.
     """
-    force_build = os.getenv("FORCE_BUILD", "0").lower() in ("1", "true", "yes")
+    force_build = _force_build_enabled()
     if not force_build and local_image_exists(agent_server_image):
         logger.info(f"Using pre-built image {agent_server_image}")
         return False
@@ -356,6 +373,7 @@ def _build_with_logging(
     custom_tag: str = "",
     target: TargetType = "source-minimal",
     push: bool = False,
+    force_build: bool = False,
     max_retries: int = 3,
     post_build_fn: Callable[[BuildOutput, bool], BuildOutput] | None = None,
 ) -> BuildOutput:
@@ -379,7 +397,14 @@ def _build_with_logging(
                 )
                 time.sleep(2 + attempt * 2)
             try:
-                result = build_image(base_image, target_image, custom_tag, target, push)
+                result = build_image(
+                    base_image,
+                    target_image,
+                    custom_tag,
+                    target,
+                    push,
+                    force_build=force_build,
+                )
             except Exception as e:
                 result = BuildOutput(
                     base_image=base_image,
@@ -454,6 +479,7 @@ def build_all_images(
     base_image_to_custom_tag_fn: Callable[[str], str] | None = None,
     max_workers: int = 1,
     dry_run: bool = False,
+    force_build: bool = False,
     max_retries: int = 3,
     post_build_fn: Callable[[BuildOutput, bool], BuildOutput] | None = None,
 ) -> int:
@@ -471,6 +497,7 @@ def build_all_images(
             Evaluated before scheduling builds so it can safely be a closure.
         max_workers: Number of concurrent builds.
         dry_run: If True, only list base images without building.
+        force_build: If True, rebuild even when matching remote images already exist.
         max_retries: Number of times to retry each failed build (default: 3).
         post_build_fn: Optional callback called after each successful build.
             Receives (build_result, push) and returns modified BuildOutput.
@@ -545,6 +572,7 @@ def build_all_images(
                         custom_tag=resolved_tag,
                         target=target,
                         push=push,
+                        force_build=force_build,
                         max_retries=max_retries,
                         post_build_fn=post_build_fn,
                     )

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -255,3 +255,41 @@ class TestEnsureLocalImage:
         _, kwargs = mock_build.call_args
         assert kwargs["target"] == "binary"
         assert kwargs["push"] is False
+
+
+class TestRemoteForceBuild:
+    @patch("benchmarks.utils.build_utils.remote_image_exists", return_value=True)
+    def test_build_image_force_build_bypasses_remote_exists(self, mock_exists):
+        from benchmarks.utils.build_utils import build_image
+        from openhands.agent_server.docker import build as sdk_build_module
+
+        with (
+            patch(
+                "benchmarks.utils.build_utils._get_sdk_submodule_info",
+                return_value=("main", "abcdef0", "1.0.0"),
+            ),
+            patch.object(
+                sdk_build_module,
+                "build",
+                return_value=["ghcr.io/openhands/eval-agent-server:abcdef0-mytag"],
+            ) as mock_build,
+        ):
+            result = build_image(
+                base_image="base:latest",
+                target_image="ghcr.io/openhands/eval-agent-server",
+                custom_tag="mytag",
+                push=True,
+                force_build=True,
+            )
+
+        assert result.error is None
+        assert result.tags == ["ghcr.io/openhands/eval-agent-server:abcdef0-mytag"]
+        mock_exists.assert_not_called()
+        mock_build.assert_called_once()
+
+    def test_build_parser_accepts_force_build(self):
+        from benchmarks.utils.build_utils import get_build_parser
+
+        args = get_build_parser().parse_args(["--force-build"])
+
+        assert args.force_build is True


### PR DESCRIPTION
## Summary
- add an opt-in `--force-build` flag to shared image build tooling so existing remote GHCR tags no longer force a skip when explicitly rebuilding
- thread the flag through the benchmark image builders and SWT prebaked eval-env image builder
- add a `workflow_dispatch` `force-build` input to every image-building workflow and pass it through without changing default behavior

## Why
Manual reruns currently conflate `successful manifest entries` with `fresh builds` because any image that already exists in GHCR is skipped. This makes cold-build benchmarking misleading after a partially successful prior run. With this PR, maintainers can trigger a full rebuild explicitly while preserving the current skip-by-default behavior for normal workflows.

## Validation
- `make build`
- `uv run pytest tests/test_image_utils.py`
- `uv run pre-commit run --files .github/workflows/build-gaia-images.yml .github/workflows/build-commit0-images.yml .github/workflows/build-multiswebench-images.yml .github/workflows/build-swebench-images.yml .github/workflows/build-swebenchmultimodal-images.yml .github/workflows/build-swegym-images.yml .github/workflows/build-swesmith-images.yml .github/workflows/build-swtbench-images.yml benchmarks/gaia/build_images.py benchmarks/commit0/build_images.py benchmarks/multiswebench/build_images.py benchmarks/swebench/build_images.py benchmarks/swebenchmultimodal/build_images.py benchmarks/swegym/build_images.py benchmarks/swesmith/build_images.py benchmarks/swtbench/build_images.py benchmarks/swtbench/build_eval_env_images.py benchmarks/utils/build_utils.py tests/test_image_utils.py`
- `uv run pytest` currently still fails during collection because of pre-existing repo issues in `legacy/testgeneval`, `legacy/versicode`, and `vendor/software-agent-sdk/tests`
