### PR TITLE
Increase SWT-Bench image build timeout to 9 hours

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -82,10 +82,11 @@ jobs:
     # TODO: Remove this once the SWT-Bench image build regressions are fixed:
     # https://github.com/OpenHands/benchmarks/issues/510
     # https://github.com/OpenHands/benchmarks/issues/504
-    # A full 433-instance SWT-Bench image build completed in 4:10:33 on run
-    # 23043936501, so 540 minutes leaves more than 2x headroom for the current
-    # degraded path without making the workaround permanent.
-    timeout-minutes: 540
+    # Issue #510 now tracks that the previously cited run 23043936501 was not a
+    # full cold build; it skipped many prebuilt images and understated the true
+    # cold-build duration. Current evidence points to roughly 8-8.5h for a full
+    # cold SWT-Bench build, so use a 10h operational timeout while degraded.
+    timeout-minutes: 600
 
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204


### PR DESCRIPTION
## Summary
- set the SWT-Bench image build job timeout to 540 minutes
- add a TODO pointing to #510 and #504 because this is only a temporary workaround
- document the observed full-run timing that motivated the 9 hour ceiling

## Validation
- uv run pre-commit run --files .github/workflows/build-swtbench-images.yml
- full SWT-Bench 433-instance image build on run `23043936501`: completed `433/433` in `4:10:33`

## Rationale
This is a stopgap for long-running SWT-Bench image builds that are timing out before completion. The workflow runs on a Blacksmith runner, so increasing the job-level `timeout-minutes` is the relevant lever in this repo.

The 540-minute limit is based on an observed full 433-instance SWT-Bench image build completing in 4:10:33 on run `23043936501`. That leaves more than 2x headroom for the currently degraded path while the underlying regressions tracked in #510 and #504 remain open.
