### PR TITLE
Increase SWT-Bench image build timeout to 10 hours

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -82,10 +82,11 @@ jobs:
     # TODO: Remove this once the SWT-Bench image build regressions are fixed:
     # https://github.com/OpenHands/benchmarks/issues/510
     # https://github.com/OpenHands/benchmarks/issues/504
-    # A full 433-instance SWT-Bench image build completed in 4:10:33 on run
-    # 23043936501, so 540 minutes leaves more than 2x headroom for the current
-    # degraded path without making the workaround permanent.
-    timeout-minutes: 540
+    # Issue #510 now tracks that the previously cited run 23043936501 was not a
+    # full cold build; it skipped many prebuilt images and understated the true
+    # cold-build duration. Current evidence points to roughly 8-8.5h for a full
+    # cold SWT-Bench build, so use a 10h operational timeout while degraded.
+    timeout-minutes: 600
 
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204


### PR DESCRIPTION
## Summary
- set the SWT-Bench image build job timeout to 600 minutes
- keep the TODO pointing to #510 and #504 because this is still a temporary workaround
- replace the old timeout rationale with a reference to #510, which now documents the corrected cold-build estimate

## Validation
- not run; workflow-only change
- timeout evidence documented in https://github.com/OpenHands/benchmarks/issues/510#issuecomment-4068143755

## Rationale
This remains a stopgap for long-running SWT-Bench image builds while the underlying regressions tracked in #510 and #504 are still open.

The previous timeout rationale was based on run `23043936501`, but that run was not a full cold build: it skipped many prebuilt images and understated the true cold-build duration. The current evidence collected in #510 points to roughly `8` to `8.5` hours for a full cold SWT-Bench build on the degraded path, so `10` hours is a safer operational timeout.
