### PR TITLE
Increase image build timeout to 24 hours

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -74,6 +74,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'build-commit0')
 
+    timeout-minutes: 1440
+
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -30,6 +30,8 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        github.event.label.name == 'build-gaia')
 
+    timeout-minutes: 1440
+
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -83,6 +83,8 @@ jobs:
         github.event.label.name == 'build-multiswebench-50' ||
         github.event.label.name == 'build-multiswebench-200'))
 
+    timeout-minutes: 1440
+
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -86,6 +86,8 @@ jobs:
         github.event.label.name == 'build-swebench-50' ||
         github.event.label.name == 'build-swebench-200'))
 
+    timeout-minutes: 1440
+
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -81,6 +81,8 @@ jobs:
         github.event.label.name == 'build-swebenchmultimodal-50' ||
         github.event.label.name == 'build-swebenchmultimodal-200'))
 
+    timeout-minutes: 1440
+
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -77,6 +77,8 @@ jobs:
         github.event.label.name == 'build-swegym-50' ||
         github.event.label.name == 'build-swegym-200'))
 
+    timeout-minutes: 1440
+
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -77,6 +77,8 @@ jobs:
         github.event.label.name == 'build-swesmith-50' ||
         github.event.label.name == 'build-swesmith-200'))
 
+    timeout-minutes: 1440
+
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204
 

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -79,14 +79,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' &&
        github.event.label.name == 'build-swt-bench')
-    # TODO: Remove this once the SWT-Bench image build regressions are fixed:
-    # https://github.com/OpenHands/benchmarks/issues/510
-    # https://github.com/OpenHands/benchmarks/issues/504
-    # Issue #510 now tracks that the previously cited run 23043936501 was not a
-    # full cold build; it skipped many prebuilt images and understated the true
-    # cold-build duration. Current evidence points to roughly 8-8.5h for a full
-    # cold SWT-Bench build, so use a 10h operational timeout while degraded.
-    timeout-minutes: 600
+    # TODO(#527): Temporarily increased to 24h to unblock large benchmark builds.
+    # Revert once image build times are optimized.
+    timeout-minutes: 1440
 
     runs-on:
       labels: blacksmith-32vcpu-ubuntu-2204


### PR DESCRIPTION
## Summary

Temporarily increase `timeout-minutes` for all `build-*-images` GitHub Actions workflows to **1440 minutes (24 hours)** to unblock evaluation of large benchmarks that currently time out at the default 6-hour limit.

Fixes #527

## Changes

- Added `timeout-minutes: 1440` to 7 build workflows that relied on the GitHub Actions default (360 min / 6h):
  - `build-commit0-images.yml`
  - `build-gaia-images.yml`
  - `build-multiswebench-images.yml`
  - `build-swebench-images.yml`
  - `build-swebenchmultimodal-images.yml`
  - `build-swegym-images.yml`
  - `build-swesmith-images.yml`
- Updated `build-swtbench-images.yml` from 600 min (10h) → 1440 min (24h) for consistency

## Context

Large benchmark image builds exceed the 6-hour default timeout, requiring double builds that rely on cache. This temporary increase to 24h ensures builds complete in a single run while optimizations are being worked on.