### PR TITLE
fix: remove invalid --max-storage fallback in buildx prune

### DIFF
--- a/benchmarks/utils/buildx_utils.py
+++ b/benchmarks/utils/buildx_utils.py
@@ -181,12 +181,9 @@ def prune_buildkit_cache(
             logger.warning(proc.stderr.strip())
         return proc
 
-    # Prefer the newer --max-storage flag; fall back to --keep-storage if unsupported.
     storage_flag: list[str] = []
-    fallback_flag: list[str] = []
     if keep_storage_gb is not None and keep_storage_gb > 0:
-        storage_flag = ["--max-storage", f"{keep_storage_gb}g"]
-        fallback_flag = ["--keep-storage", f"{keep_storage_gb}g"]
+        storage_flag = ["--keep-storage", f"{keep_storage_gb}g"]
 
     filter_flags: list[str] = []
     if filters:
@@ -194,13 +191,6 @@ def prune_buildkit_cache(
             filter_flags += ["--filter", f]
 
     proc = _run(base_cmd + storage_flag + filter_flags)
-    if (
-        proc.returncode != 0
-        and fallback_flag
-        and "--max-storage" in " ".join(storage_flag)
-    ):
-        if "unknown flag: --max-storage" in proc.stderr:
-            proc = _run(base_cmd + fallback_flag + filter_flags)
 
     if proc.returncode != 0:
         raise RuntimeError(


### PR DESCRIPTION
## Summary

The `prune_buildkit_cache()` function in `buildx_utils.py` tried `docker buildx prune --max-storage` first, then fell back to `--keep-storage` when it failed.

The problem: **`--max-storage` was never released in any version of buildx.** It was an intermediate flag name considered during development ([docker/buildx#458](https://github.com/docker/buildx/issues/458)) that was renamed to `--reserved-space` before shipping. So the first attempt always fails, producing a warning log and an unnecessary subprocess call on every prune.

Confirmed in CI logs from runs [#23198839061](https://github.com/OpenHands/benchmarks/actions/runs/23198839061) and [#23198836788](https://github.com/OpenHands/benchmarks/actions/runs/23198836788):

```
Pruning BuildKit cache: docker buildx prune --all --force --max-storage 60g
unknown flag: --max-storage
Pruning BuildKit cache: docker buildx prune --all --force --keep-storage 60g
```

This PR removes the dead `--max-storage` path and uses `--keep-storage` directly.

## Test plan

- [x] Verified in CI logs that `--keep-storage` is the flag that actually executes
- [ ] Pre-commit and tests pass

Related: #531