### PR TITLE
Fix commit0 evaluation for cachetools and parsel

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -440,10 +440,15 @@ class Commit0Evaluation(Evaluation):
         # Run tests
         test_cmd = instance.data["test"]["test_cmd"]
         test_dir = instance.data["test"]["test_dir"]
-        # Use python -m pytest instead of pytest command to avoid permission issues
-        if test_cmd.strip() == "pytest":
-            test_cmd = "python -m pytest"
-        full_test_cmd = f"cd {repo_path} && {test_cmd} --json-report --json-report-file=report.json --continue-on-collection-errors {test_dir} > test_output.txt 2>&1"
+        # Always use `python -m pytest` instead of bare `pytest` to avoid
+        # PATH issues after agent execution (see #526).
+        if "pytest" in test_cmd and "python -m pytest" not in test_cmd:
+            test_cmd = test_cmd.replace("pytest", "python -m pytest", 1)
+        # Set PYTHONPATH for src-layout repos so pytest can find the package
+        # (e.g. cachetools with src_dir="src/cachetools/", see #526).
+        src_dir = instance.data["test"].get("src_dir", "")
+        env_prefix = "PYTHONPATH=src " if src_dir and "src/" in src_dir else ""
+        full_test_cmd = f"cd {repo_path} && {env_prefix}{test_cmd} --json-report --json-report-file=report.json --continue-on-collection-errors {test_dir} > test_output.txt 2>&1"
         logger.info(f"Running test command: {full_test_cmd}")
         test_result = workspace.execute_command(full_test_cmd, timeout=600)
         logger.info(f"Test command exit code: {test_result.exit_code}")

--- a/tests/test_commit0_test_cmd.py
+++ b/tests/test_commit0_test_cmd.py
@@ -1,0 +1,68 @@
+"""Tests for test command construction fixes in commit0 evaluate_instance.
+
+Validates Bug #526 fixes:
+  1. Bare `pytest` is always replaced with `python -m pytest`
+  2. src-layout repos get `PYTHONPATH=src` prepended
+"""
+
+import pytest
+
+
+def _build_test_cmd(test_cmd: str, src_dir: str) -> str:
+    """Reproduce the test-command construction logic from evaluate_instance."""
+    if "pytest" in test_cmd and "python -m pytest" not in test_cmd:
+        test_cmd = test_cmd.replace("pytest", "python -m pytest", 1)
+    env_prefix = "PYTHONPATH=src " if src_dir and "src/" in src_dir else ""
+    repo_path = "/workspace/repo"
+    test_dir = "tests/"
+    return (
+        f"cd {repo_path} && {env_prefix}{test_cmd} "
+        f"--json-report --json-report-file=report.json "
+        f"--continue-on-collection-errors {test_dir} > test_output.txt 2>&1"
+    )
+
+
+# --- Bug 2: pytest -> python -m pytest replacement ---
+
+
+@pytest.mark.parametrize(
+    "test_cmd, expected_fragment",
+    [
+        ("pytest", "python -m pytest"),
+        ("pytest -x", "python -m pytest -x"),
+        ("python -m pytest", "python -m pytest"),
+    ],
+    ids=["bare_pytest", "pytest_with_args", "already_python_m"],
+)
+def test_pytest_replacement(test_cmd: str, expected_fragment: str) -> None:
+    result = _build_test_cmd(test_cmd, src_dir="")
+    assert expected_fragment in result
+    # Ensure no double replacement
+    assert "python -m python -m pytest" not in result
+
+
+# --- Bug 1: PYTHONPATH=src for src-layout repos ---
+
+
+@pytest.mark.parametrize(
+    "src_dir, should_have_pythonpath",
+    [
+        ("src/cachetools/", True),
+        ("src/some_pkg/", True),
+        ("cachetools/", False),
+        ("", False),
+    ],
+    ids=["src_layout", "src_layout_other", "flat_layout", "empty"],
+)
+def test_pythonpath_for_src_layout(src_dir: str, should_have_pythonpath: bool) -> None:
+    result = _build_test_cmd("pytest", src_dir)
+    if should_have_pythonpath:
+        assert "PYTHONPATH=src " in result
+    else:
+        assert "PYTHONPATH=src " not in result
+
+
+def test_combined_fix() -> None:
+    """Simulates cachetools: bare pytest + src-layout."""
+    result = _build_test_cmd("pytest", "src/cachetools/")
+    assert "PYTHONPATH=src python -m pytest" in result


### PR DESCRIPTION
Fixes #526

## Summary

Two minimal fixes in `benchmarks/commit0/run_infer.py` for the test command construction in `evaluate_instance()`:

### Bug 1: `parsel` — bare `pytest` not on `$PATH` (exit code 127)

The previous exact-match check (`test_cmd.strip() == "pytest"`) only caught the bare `pytest` command. If `test_cmd` contained `pytest` with arguments, the substitution wouldn't fire and the bare `pytest` binary could be missing from `$PATH` after agent execution.

**Fix:** Replace any bare `pytest` with `python -m pytest` using a substring check:
```python
if "pytest" in test_cmd and "python -m pytest" not in test_cmd:
    test_cmd = test_cmd.replace("pytest", "python -m pytest", 1)
```

### Bug 2: `cachetools` — missing `PYTHONPATH=src` for src-layout repo

`cachetools` uses a src-layout (`src/cachetools/`). Without `PYTHONPATH=src`, pytest can't find the package and all tests fail at import.

**Fix:** Read the existing `src_dir` field from the dataset and prepend `PYTHONPATH=src` when appropriate:
```python
src_dir = instance.data["test"].get("src_dir", "")
env_prefix = "PYTHONPATH=src " if src_dir and "src/" in src_dir else ""
```

### Tests

Added `tests/test_commit0_test_cmd.py` with 8 parametrized tests covering both fixes.