### PR TITLE
ci: increase SWT-Bench default parallelism to 16 workers / 50 batch

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -91,13 +91,9 @@ jobs:
       packages: write
       issues: write
 
-    # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
+    # Initialize vars that may be empty so set -euo pipefail won't fail on unset refs.
+    # All other defaults come from the workflow inputs above (single source of truth).
     env:
-      DATASET: eth-sri/SWT-bench_Verified_bm25_27k_zsp
-      SPLIT: test
-      MAX_WORKERS: '16'
-      BUILD_BATCH_SIZE: '50'
-      N_LIMIT: '0'
       INSTANCE_IDS: ''
       SELECT_FILE: ''
 


### PR DESCRIPTION
## Summary

Raises the default parallelism for the SWT-Bench image build workflow:
- `max-workers`: 4 → 16
- `build-batch-size`: 15 → 50

These were reduced to 4/15 as a safety measure during the image build regression investigation. With the 24-hour timeout (#528) and sdist caching (#515) now merged, higher parallelism can be restored.

The inputs remain fully configurable — manual `workflow_dispatch` runs can still override to any value (e.g., `max-workers=4` for debugging).

**What this PR does NOT change:**
- No SDK submodule bump
- No cache mode changes (`OPENHANDS_BUILDKIT_CACHE_MODE` is not set — SDK defaults apply)

## Test plan

- [ ] Pre-commit checks pass
- [ ] Trigger a manual SWT-bench build to verify the new defaults work

Related: #531