### PR TITLE
ci(swtbench): change cache-mode default from off to max

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -64,9 +64,9 @@ on:
         default: '10'
         type: string
       cache-mode:
-        description: 'BuildKit cache export mode (max, min, off). Default: off'
+        description: 'BuildKit cache export mode (max, min, off). Default: max'
         required: false
-        default: 'off'
+        default: 'max'
         type: string
       force-build:
         description: 'Rebuild images even if matching remote tags already exist'


### PR DESCRIPTION
## Summary

Change SWT-bench `cache-mode` default from `off` to `max` so that base image layers are exported to the registry cache.

## Why

This is the counterpart to the Dockerfile ARG reorder fix (SDK PR [software-agent-sdk#2522](https://github.com/OpenHands/software-agent-sdk/pull/2522)). That fix makes `base-image-minimal` layers SDK-independent, so they can be reused across SDK commits via `--cache-from`. But `--cache-from` only works if a previous build exported those layers with `--cache-to`.

The prior rationale for `off` (#540) was that registry cache had a 100% miss rate. That was because `OPENHANDS_BUILD_GIT_SHA` busted the base layers on every SDK change. With the ARG reorder, base layers become cache-stable and registry export becomes useful.

## Test plan

- [ ] Run SWT-bench build with this PR + SDK #2522 on SDK commit A
- [ ] Run again on SDK commit B — verify base layers are cache hits and build time drops from ~9h to ~30-45m

Closes #542
Related: #541, #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)