### PR TITLE
Set SWT-bench cache-mode default to max

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -64,9 +64,9 @@ on:
         default: '10'
         type: string
       cache-mode:
-        description: 'BuildKit cache export mode (max, min, off). Default: off'
+        description: 'BuildKit cache export mode (max, min, off). Default: max'
         required: false
-        default: 'off'
+        default: 'max'
         type: string
       force-build:
         description: 'Rebuild images even if matching remote tags already exist'


### PR DESCRIPTION
## Summary

Change the default `cache-mode` for SWT-bench image builds from `off` to `max`.

## Why

With the ARG ordering fix in [SDK PR #2522](https://github.com/OpenHands/software-agent-sdk/pull/2522), registry cache will provide cross-SDK-bump cache hits for `apt-get` and `npm install` layers. But this only works if cache is actually exported (`cache-mode=max`).

The `off` default was set in PR #541 because registry cache had a 100% miss rate — the ARG before apt-get made every layer hash SDK-specific. With the ARG moved after the expensive layers, the cache tags are stable across SDK bumps and registry cache becomes effective.

## Validated

A/B test ([#544](https://github.com/OpenHands/benchmarks/issues/544)): `cache-mode=max` + ARG fix → apt-get **CACHED** from registry, **2.1x faster** per image (154s vs 322s).

## Depends on

[SDK PR #2522](https://github.com/OpenHands/software-agent-sdk/pull/2522) (ARG ordering fix). Without it, `cache-mode=max` adds export overhead with no cache benefit.