### PR TITLE
Optimize SWT-bench build throughput: cache-mode=off, raise prune threshold

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -64,9 +64,9 @@ on:
         default: '10'
         type: string
       cache-mode:
-        description: 'BuildKit cache export mode (max, min, off). Default: max'
+        description: 'BuildKit cache export mode (max, min, off). Default: off'
         required: false
-        default: 'max'
+        default: 'off'
         type: string
       force-build:
         description: 'Rebuild images even if matching remote tags already exist'
@@ -213,6 +213,8 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
           OPENHANDS_BUILDKIT_CACHE_MODE: ${{ inputs.cache-mode }}
+          BUILDKIT_PRUNE_THRESHOLD_PCT: '85'
+          BUILDKIT_PRUNE_KEEP_GB: '20'
           AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Build prebaked eval env images


### PR DESCRIPTION
## Summary
- Switch default `cache-mode` from `max` to `off` — eliminates ~64s/image (16.4%) of cache export overhead. Registry cache *imports* still work; only export is skipped. Expensive cached layers (apt-get, npm install) persist in registry from previous runs.
- Raise `BUILDKIT_PRUNE_THRESHOLD_PCT` from 60% to 85% — delays first prune from ~163 to ~286 images, eliminating one of two prune events (~20 min saved).
- Lower `BUILDKIT_PRUNE_KEEP_GB` from 60 to 20 — maximizes post-prune headroom.

## Context
Analysis of run [#23382357696](https://github.com/OpenHands/benchmarks/actions/runs/23382357696) (9h04m, 47.8 img/h for 433 images) showed the Dockerfile ARG cache fix (#544) is working (12-13 cached steps/image), but two overheads dominate:
1. `cache-mode=max` cache export: avg 64s/image
2. Two BuildKit prune events at 60% threshold: ~40 min dead time + post-prune growth spike

Expected improvement: ~47.8 → ~65-70 img/h (~6h15m for 433 images), recovering the late-February baseline.

References: #530, #531, #544

## Test plan
- [ ] Trigger full SWT-bench build (433 images, force-build) and compare total time + throughput to run #23382357696
- [ ] Verify at most 1 prune event occurs (was 2 before)
- [ ] Verify per-image `cache_export_seconds` drops to near-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)