### PR TITLE
Make build throughput ignore skipped images

### DIFF
--- a/benchmarks/utils/build_manifest.py
+++ b/benchmarks/utils/build_manifest.py
@@ -34,8 +34,7 @@ class BuildManifestSummary(BaseModel):
     started_at: str | None = None
     finished_at: str | None = None
     wall_clock_seconds: float | None = None
-    processed_images_per_hour: float | None = None
-    built_images_per_hour: float | None = None
+    throughput_images_per_hour: float | None = None
     cumulative_duration_seconds: float = 0.0
     cumulative_remote_check_seconds: float = 0.0
     cumulative_build_seconds: float = 0.0
@@ -57,8 +56,6 @@ class BuildManifestSummary(BaseModel):
     skip_reasons: dict[str, int] = Field(default_factory=dict)
     slowest_builds: list[SlowBuild] = Field(default_factory=list)
     failed_builds: list[FailedBuild] = Field(default_factory=list)
-    throughput_notes: list[str] = Field(default_factory=list)
-    cache_metric_notes: list[str] = Field(default_factory=list)
 
 
 def _normalize_float(value: Any) -> float | None:
@@ -205,31 +202,9 @@ def summarize_build_records(
         wall_clock_seconds = (
             max(finished_at_candidates) - min(started_at_candidates)
         ).total_seconds()
-    processed_images_per_hour = None
-    built_images_per_hour = None
+    throughput_images_per_hour = None
     if wall_clock_seconds and wall_clock_seconds > 0:
-        processed_images_per_hour = (total / wall_clock_seconds) * 3600
-        built_images_per_hour = (built / wall_clock_seconds) * 3600
-
-    throughput_notes = [
-        "`processed_images_per_hour` counts every completed image outcome, including skips.",
-        "`built_images_per_hour` counts only images that were actually built.",
-    ]
-    if skipped:
-        throughput_notes.append(
-            "Prefer `built_images_per_hour` when comparing build throughput across skip-heavy runs."
-        )
-
-    cache_metric_notes = [
-        (
-            "`cumulative_sdk_cache_import_misses` counts missing registry cache "
-            "manifests, not expensive Dockerfile layer cache misses."
-        ),
-        (
-            "`cumulative_sdk_cached_steps` counts BuildKit `CACHED` steps from any "
-            "cache source; it does not prove registry cache reuse."
-        ),
-    ]
+        throughput_images_per_hour = (built / wall_clock_seconds) * 3600
 
     average_build_seconds = (
         statistics.mean(build_durations) if build_durations else None
@@ -253,8 +228,7 @@ def summarize_build_records(
         started_at=started_at,
         finished_at=finished_at,
         wall_clock_seconds=wall_clock_seconds,
-        processed_images_per_hour=processed_images_per_hour,
-        built_images_per_hour=built_images_per_hour,
+        throughput_images_per_hour=throughput_images_per_hour,
         cumulative_duration_seconds=cumulative_duration,
         cumulative_remote_check_seconds=_sum_float_field(
             records, "remote_check_seconds"
@@ -294,8 +268,6 @@ def summarize_build_records(
         skip_reasons=dict(skip_reasons),
         slowest_builds=slowest_builds,
         failed_builds=failed_builds,
-        throughput_notes=throughput_notes,
-        cache_metric_notes=cache_metric_notes,
     )
 
 
@@ -350,13 +322,9 @@ def render_build_summary_markdown(
             f"**Cumulative Image Time:** {format_duration(summary.cumulative_duration_seconds)}",
         ]
     )
-    if summary.processed_images_per_hour is not None:
+    if summary.throughput_images_per_hour is not None:
         lines.append(
-            f"**Processed Throughput:** {summary.processed_images_per_hour:.1f} images/hour"
-        )
-    if summary.built_images_per_hour is not None:
-        lines.append(
-            f"**Built Throughput:** {summary.built_images_per_hour:.1f} built images/hour"
+            f"**Throughput:** {summary.throughput_images_per_hour:.1f} built images/hour"
         )
 
     phase_lines = [
@@ -427,16 +395,6 @@ def render_build_summary_markdown(
             lines.append(
                 f"- `{build.base_image}`: {build.error} (attempts={build.attempt_count})"
             )
-
-    if summary.throughput_notes:
-        lines.extend(["", "### Throughput Notes", ""])
-        for note in summary.throughput_notes:
-            lines.append(f"- {note}")
-
-    if summary.cache_metric_notes:
-        lines.extend(["", "### Cache Metric Notes", ""])
-        for note in summary.cache_metric_notes:
-            lines.append(f"- {note}")
 
     return "\n".join(lines)
 

--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -915,22 +915,18 @@ def build_all_images(
                         prune_threshold_pct,
                     )
             batch_duration = time.monotonic() - batch_started_monotonic
-            batch_processed_throughput = (
-                (len(batch) / batch_duration) * 3600 if batch_duration else 0.0
-            )
-            batch_built_throughput = (
+            batch_throughput = (
                 (batch_built / batch_duration) * 3600 if batch_duration else 0.0
             )
             logger.info(
-                "Finished batch %d/%d in %.1fs: built=%d skipped=%d failed=%d processed_throughput=%.1f images/hour built_throughput=%.1f built images/hour",
+                "Finished batch %d/%d in %.1fs: built=%d skipped=%d failed=%d throughput=%.1f built images/hour",
                 batch_idx,
                 total_batches,
                 batch_duration,
                 batch_built,
                 batch_skipped,
                 batch_failures,
-                batch_processed_throughput,
-                batch_built_throughput,
+                batch_throughput,
             )
 
     summary_file = build_dir / "build-summary.json"
@@ -940,22 +936,18 @@ def build_all_images(
     )
     overall_duration = time.monotonic() - overall_started_monotonic
     summary.wall_clock_seconds = _round_duration(overall_duration)
-    summary.processed_images_per_hour = (
-        (len(base_images) / overall_duration) * 3600 if overall_duration else 0.0
-    )
-    summary.built_images_per_hour = (
+    summary.throughput_images_per_hour = (
         (built / overall_duration) * 3600 if overall_duration else 0.0
     )
     summary_file.write_text(summary.model_dump_json(indent=2), encoding="utf-8")
     logger.info(
-        "Done in %.1fs. Built=%d Skipped=%d Failed=%d Retried=%d ProcessedThroughput=%.1f images/hour BuiltThroughput=%.1f built images/hour Manifest=%s Summary=%s",
+        "Done in %.1fs. Built=%d Skipped=%d Failed=%d Retried=%d Throughput=%.1f built images/hour Manifest=%s Summary=%s",
         overall_duration,
         built,
         skipped,
         failures,
         summary.retried,
-        summary.processed_images_per_hour,
-        summary.built_images_per_hour,
+        summary.throughput_images_per_hour,
         str(manifest_file),
         str(summary_file),
     )

--- a/tests/test_build_manifest.py
+++ b/tests/test_build_manifest.py
@@ -1,7 +1,5 @@
 import json
 
-import pytest
-
 from benchmarks.utils.build_manifest import (
     format_duration,
     load_eval_env_summary,
@@ -89,8 +87,7 @@ def test_summarize_build_records_tracks_statuses_and_timings():
     assert summary.status_counts["built"] == 2
     assert summary.status_counts["skipped_remote_exists"] == 1
     assert summary.status_counts["failed"] == 1
-    assert summary.processed_images_per_hour == pytest.approx(124.13793103448276)
-    assert summary.built_images_per_hour == pytest.approx(62.06896551724138)
+    assert summary.throughput_images_per_hour == 62.06896551724138
     assert summary.average_build_seconds == 25.0
     assert summary.median_build_seconds == 25.0
     assert summary.max_build_seconds == 30.0
@@ -109,14 +106,6 @@ def test_summarize_build_records_tracks_statuses_and_timings():
     assert summary.cumulative_sdk_export_manifest_seconds == 2.0
     assert summary.cumulative_sdk_cache_import_misses == 1
     assert summary.cumulative_sdk_cached_steps == 3
-    assert any(
-        "counts every completed image outcome" in note
-        for note in summary.throughput_notes
-    )
-    assert any(
-        "missing registry cache manifests" in note
-        for note in summary.cache_metric_notes
-    )
     assert [build.base_image for build in summary.slowest_builds] == [
         "repo/image-a",
         "repo/image-d",
@@ -154,8 +143,7 @@ def test_render_build_summary_markdown_includes_profiling_fields():
     assert "## Example Build Summary" in markdown
     assert "**Built:** 1" in markdown
     assert "**Retried:** 1" in markdown
-    assert "**Processed Throughput:** 85.7 images/hour" in markdown
-    assert "**Built Throughput:** 85.7 built images/hour" in markdown
+    assert "**Throughput:** 85.7 built images/hour" in markdown
     assert "### Phase Totals" in markdown
     assert "**SDK Cache Imports:** 5s" in markdown
     assert "**SDK Cache Exports:** 7s" in markdown
@@ -163,8 +151,6 @@ def test_render_build_summary_markdown_includes_profiling_fields():
     assert "**Registry Cache Manifest Misses:** 2" in markdown
     assert "**BuildKit Cached Steps (Any Source):** 6" in markdown
     assert "### Slowest Built Images" in markdown
-    assert "### Throughput Notes" in markdown
-    assert "### Cache Metric Notes" in markdown
     assert "`repo/image-a`" in markdown
     assert "42s" in markdown
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -566,7 +566,7 @@ class TestCachedSdistReuse:
         "benchmarks.utils.build_utils.time.monotonic",
         side_effect=[100.0, 110.0, 130.0, 145.0],
     )
-    def test_build_all_images_writes_explicit_processed_and_built_throughput(
+    def test_build_all_images_uses_built_images_for_throughput(
         self,
         _mock_monotonic,
         mock_logger_info,
@@ -639,12 +639,7 @@ class TestCachedSdistReuse:
 
         summary = json.loads((tmp_path / "build-summary.json").read_text("utf-8"))
         assert summary["wall_clock_seconds"] == 45.0
-        assert summary["processed_images_per_hour"] == 240.0
-        assert summary["built_images_per_hour"] == 160.0
-        assert any(
-            "counts every completed image outcome" in note
-            for note in summary["throughput_notes"]
-        )
+        assert summary["throughput_images_per_hour"] == 160.0
 
         done_logs = [
             call.args[0] % call.args[1:]
@@ -654,7 +649,7 @@ class TestCachedSdistReuse:
             and call.args[0].startswith("Done in ")
         ]
         assert done_logs == [
-            "Done in 45.0s. Built=2 Skipped=1 Failed=0 Retried=0 ProcessedThroughput=240.0 images/hour BuiltThroughput=160.0 built images/hour "
+            "Done in 45.0s. Built=2 Skipped=1 Failed=0 Retried=0 Throughput=160.0 built images/hour "
             f"Manifest={tmp_path / 'manifest.jsonl'} Summary={tmp_path / 'build-summary.json'}"
         ]
 


### PR DESCRIPTION
## Summary
- make throughput mean built images/hour everywhere
- keep built/skipped/failed counts explicit in batch and final logs
- store a single built-only throughput metric in `build-summary.json`

## Why
Skipped images should not inflate throughput. The build logs and summary should show skips clearly, but any throughput number used to reason about build efficiency should be computed from non-skipped images only.

## Changes
- batch logs now print built, skipped, failed, and a single built-only throughput
- final logs now print built, skipped, failed, retried, and a single built-only throughput
- `build-summary.json` now stores `throughput_images_per_hour`, computed from built images only
- markdown summaries now show a single throughput value based on built images only

## Validation
- `python3 -m ruff check benchmarks/utils/build_manifest.py benchmarks/utils/build_utils.py tests/test_build_manifest.py tests/test_image_utils.py`
- `python3 -m ruff format benchmarks/utils/build_manifest.py benchmarks/utils/build_utils.py tests/test_build_manifest.py tests/test_image_utils.py --check`
- `PYTHONPATH=/Users/simonrosenberg/tmp/benchmarks-telemetry-clarity python3 -m pytest tests/test_build_manifest.py tests/test_image_utils.py -k 'build_manifest or built_images_for_throughput'`

## Notes
The repo's pre-commit hook could not run in this detached worktree because `uv` could not resolve the local `openhands-sdk` workspace member from this checkout shape. The targeted lint/tests above were run directly instead.
