### PR TITLE
Make build log throughput ignore skipped images

### DIFF
--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -391,14 +391,6 @@ def _round_duration(seconds: float) -> float:
     return round(seconds, 3)
 
 
-def _calculate_throughput_images_per_hour(
-    built_count: int, duration_seconds: float
-) -> float:
-    if duration_seconds <= 0:
-        return 0.0
-    return (built_count / duration_seconds) * 3600
-
-
 def _force_build_enabled(force_build: bool = False) -> bool:
     env_force_build = os.getenv("FORCE_BUILD", "0").lower() in ("1", "true", "yes")
     return force_build or env_force_build
@@ -923,8 +915,8 @@ def build_all_images(
                         prune_threshold_pct,
                     )
             batch_duration = time.monotonic() - batch_started_monotonic
-            batch_throughput = _calculate_throughput_images_per_hour(
-                batch_built, batch_duration
+            batch_throughput = (
+                (batch_built / batch_duration) * 3600 if batch_duration else 0.0
             )
             logger.info(
                 "Finished batch %d/%d in %.1fs: built=%d skipped=%d failed=%d throughput=%.1f built images/hour",
@@ -944,7 +936,7 @@ def build_all_images(
     )
     summary_file.write_text(summary.model_dump_json(indent=2), encoding="utf-8")
     overall_duration = time.monotonic() - overall_started_monotonic
-    throughput = _calculate_throughput_images_per_hour(built, overall_duration)
+    throughput = (built / overall_duration) * 3600 if overall_duration else 0.0
     logger.info(
         "Done in %.1fs. Built=%d Skipped=%d Failed=%d Retried=%d Throughput=%.1f built images/hour Manifest=%s Summary=%s",
         overall_duration,

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -562,13 +562,6 @@ class TestCachedSdistReuse:
 
 
 class TestBuildAllImagesThroughputLogging:
-    def test_calculate_throughput_images_per_hour(self):
-        from benchmarks.utils.build_utils import _calculate_throughput_images_per_hour
-
-        assert _calculate_throughput_images_per_hour(2, 20.0) == 360.0
-        assert _calculate_throughput_images_per_hour(2, 45.0) == 160.0
-        assert _calculate_throughput_images_per_hour(2, 0.0) == 0.0
-
     @patch("benchmarks.utils.build_utils.logger.info")
     @patch(
         "benchmarks.utils.build_utils.time.monotonic",


### PR DESCRIPTION
## Summary
- make batch log throughput count only built images
- make final log throughput count only built images
- leave structured telemetry and `build-summary.json` unchanged

## Why
Current logs print throughput using all scheduled/processed images, which makes skip-heavy runs look faster than they actually are from a build-efficiency perspective. The logs already print built and skipped counts separately, so the throughput number should align with built images only.

## Validation
- `python3 -m ruff check benchmarks/utils/build_utils.py tests/test_image_utils.py`
- `python3 -m ruff format benchmarks/utils/build_utils.py tests/test_image_utils.py --check`
- `PYTHONPATH=/Users/simonrosenberg/tmp/benchmarks-log-throughput-fix python3 -m pytest tests/test_image_utils.py -k throughput_logs_count_only_built_images`

## Notes
This PR intentionally does not change structured telemetry or `build-summary.json` semantics. It fixes only the incorrect printed throughput in the build logs.
