### PR TITLE
Add agent-type input to all build workflows

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -54,6 +54,11 @@ on:
         required: false
         default: 'false'
         type: string
+      agent-type:
+        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
+        required: false
+        default: 'default'
+        type: string
 
 env:
   DATASET: wentingzhao/commit0_combined
@@ -190,12 +195,14 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
+          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
+          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Archive build logs
         if: always()

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: 'false'
         type: string
+      agent-type:
+        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
+        required: false
+        default: 'default'
+        type: string
 
 concurrency:
   group: build-gaia-${{ github.ref }}
@@ -103,6 +108,7 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
+          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
@@ -111,6 +117,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
+          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Archive build logs
         if: always()

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -55,6 +55,11 @@ on:
         required: false
         default: 'false'
         type: string
+      agent-type:
+        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
+        required: false
+        default: 'default'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -255,6 +260,7 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
+          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
@@ -263,6 +269,7 @@ jobs:
           BUILDKIT_PROGRESS: plain
           BUILDKIT_RESET_ON_FAILURE: 1
           LANGUAGE: ${{ env.LANGUAGE }}
+          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Archive build logs
         if: always()

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -54,6 +54,11 @@ on:
         required: false
         default: 'false'
         type: string
+      agent-type:
+        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
+        required: false
+        default: 'default'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -252,6 +257,7 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
+          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
@@ -259,6 +265,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
           BUILDKIT_RESET_ON_FAILURE: 1
+          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Archive build logs
         if: always()

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -50,6 +50,11 @@ on:
         required: false
         default: 'false'
         type: string
+      agent-type:
+        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
+        required: false
+        default: 'default'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -248,6 +253,7 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
+          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
@@ -255,6 +261,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
           BUILDKIT_RESET_ON_FAILURE: 1
+          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Archive build logs
         if: always()

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -50,6 +50,11 @@ on:
         required: false
         default: 'false'
         type: string
+      agent-type:
+        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
+        required: false
+        default: 'default'
+        type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
 env:
@@ -248,6 +253,7 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
+          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
@@ -255,6 +261,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
           BUILDKIT_RESET_ON_FAILURE: 1
+          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Archive build logs
         if: always()

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -16,6 +16,7 @@ from commit0.harness.constants import SPLIT
 from benchmarks.commit0.config import BUILD_DEFAULTS, INFER_DEFAULTS
 from benchmarks.utils.build_utils import (
     build_all_images,
+    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
 )
@@ -129,6 +130,7 @@ def main(argv: list[str]) -> int:
         force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
+        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 

--- a/benchmarks/gaia/build_images.py
+++ b/benchmarks/gaia/build_images.py
@@ -17,6 +17,7 @@ from benchmarks.utils.build_utils import (
     BuildOutput,
     _get_sdk_submodule_info,
     build_all_images,
+    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
     run_docker_build_layer,
@@ -105,6 +106,7 @@ def main(argv: list[str]) -> int:
         force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=tag_fn,
+        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
     if exit_code != 0:

--- a/benchmarks/multiswebench/build_images.py
+++ b/benchmarks/multiswebench/build_images.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from benchmarks.multiswebench.download_dataset import download_and_concat_dataset
 from benchmarks.utils.build_utils import (
     build_all_images,
+    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
 )
@@ -121,6 +122,7 @@ def main():
         build_batch_size=args.build_batch_size,
         dry_run=False,
         force_build=args.force_build,
+        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 

--- a/benchmarks/swebenchmultilingual/build_images.py
+++ b/benchmarks/swebenchmultilingual/build_images.py
@@ -17,6 +17,7 @@ from benchmarks.swebenchmultilingual.config import BUILD_DEFAULTS
 from benchmarks.utils.build_utils import (
     BuildOutput,
     build_all_images,
+    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
     run_docker_build_layer,
@@ -183,6 +184,7 @@ def main(argv: list[str]) -> int:
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=_wrap_if_needed,
+        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 

--- a/benchmarks/swebenchmultimodal/build_images.py
+++ b/benchmarks/swebenchmultimodal/build_images.py
@@ -13,6 +13,7 @@ import sys
 from benchmarks.swebenchmultimodal.config import BUILD_DEFAULTS
 from benchmarks.utils.build_utils import (
     build_all_images,
+    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
 )
@@ -88,6 +89,7 @@ def main(argv: list[str]) -> int:
         force_build=args.force_build,
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
+        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 

--- a/benchmarks/swegym/build_images.py
+++ b/benchmarks/swegym/build_images.py
@@ -11,6 +11,7 @@ import sys
 
 from benchmarks.utils.build_utils import (
     build_all_images,
+    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
 )
@@ -93,6 +94,7 @@ def main(argv: list[str]) -> int:
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=None,
+        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 

--- a/benchmarks/swesmith/build_images.py
+++ b/benchmarks/swesmith/build_images.py
@@ -12,6 +12,7 @@ import sys
 
 from benchmarks.utils.build_utils import (
     build_all_images,
+    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
 )
@@ -90,6 +91,7 @@ def main(argv: list[str]) -> int:
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=None,
+        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 


### PR DESCRIPTION
## Summary
- Adds the `agent-type` workflow dispatch input to all benchmark build workflows that were missing it: gaia, commit0, swebenchmultimodal, multiswebench, swegym, swesmith
- Adds `extra_build_args=build_args_for_agent_type(args.agent_type)` to all `build_images.py` scripts that were missing it: gaia, commit0, swebenchmultimodal, multiswebench, swegym, swesmith, swebenchmultilingual

Previously only swebench and swtbench supported the `agent-type` input. This meant ACP agent runs (`acp-claude`, `acp-codex`) on any other benchmark would build images with `INSTALL_ACP=false`, causing the `claude-agent-acp` binary to be missing from runtime images.

## Related
- Companion PR in evaluation repo: https://github.com/OpenHands/evaluation/pull/340 (forwards `AGENT_TYPE` env var to benchmark build dispatch)
- Failed run that surfaced this: [eval-23408402916-claude-4-6](https://github.com/OpenHands/software-agent-sdk/actions/runs/23408392925) — swtbench with `acp-claude`

## Changes

### Workflows (6 files)
Each gets the same 3 additions:
1. `agent-type` input definition (default: `'default'`)
2. `CMD="$CMD --agent-type ${AGENT_TYPE}"` in the build step
3. `AGENT_TYPE: ${{ inputs.agent-type || 'default' }}` env var

### Python scripts (7 files)
Each gets:
1. `build_args_for_agent_type` import from `benchmarks.utils.build_utils`
2. `extra_build_args=build_args_for_agent_type(args.agent_type)` in the `build_all_images()` call

## Test plan
- [ ] Merge companion evaluation PR first
- [ ] Trigger an ACP gaia eval to verify the previously-failing workflow now accepts `agent-type`
- [ ] Default behavior (`agent-type=default`) unchanged — `INSTALL_ACP=false` as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)