### PR TITLE
docs: add resume run-infer documentation to all benchmark READMEs

### DIFF
--- a/benchmarks/commit0/README.md
+++ b/benchmarks/commit0/README.md
@@ -40,6 +40,8 @@ uv run python -m benchmarks.commit0.run_infer \
     --max-iterations 100
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 **Key Arguments:**
 
 - `--repo-split`: Choose between `lite`, `all`, or a specific repository name

--- a/benchmarks/gaia/README.md
+++ b/benchmarks/gaia/README.md
@@ -39,6 +39,8 @@ TAVILY_API_KEY=xxx uv run python -m benchmarks.gaia.run_infer \
     --num-workers 4
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 ### Step 2: Get Score
 
 After running inference, calculate the accuracy score:

--- a/benchmarks/multiswebench/README.md
+++ b/benchmarks/multiswebench/README.md
@@ -68,6 +68,8 @@ LANGUAGE=python uv run multi-swebench-infer path/to/llm_config.json \
     --workspace docker
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 **Selecting specific instances:**
 
 You can run evaluation on a specific subset by creating a text file with instance IDs:

--- a/benchmarks/openagentsafety/README.MD
+++ b/benchmarks/openagentsafety/README.MD
@@ -99,6 +99,8 @@ uv run openagentsafety-infer .llm_config/gpt-4o-mini.json \
   --critic pass
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 ### Command Line Arguments
 
 - `--dataset`: HuggingFace dataset identifier

--- a/benchmarks/swebench/README.md
+++ b/benchmarks/swebench/README.md
@@ -43,6 +43,8 @@ uv run swebench-infer path/to/llm_config.json \
     --workspace docker
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 **Selecting specific instances:**
 
 You can run evaluation on a specific subset by creating a text file with instance IDs:

--- a/benchmarks/swebenchmultilingual/README.md
+++ b/benchmarks/swebenchmultilingual/README.md
@@ -40,6 +40,8 @@ uv run swebenchmultilingual-infer path/to/llm_config.json \
     --workspace docker
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 **Selecting specific instances:**
 
 You can run evaluation on a specific subset by creating a text file with instance IDs:

--- a/benchmarks/swebenchmultimodal/README.md
+++ b/benchmarks/swebenchmultimodal/README.md
@@ -21,6 +21,8 @@ uv run swebenchmultimodal-infer \
   --output-dir ./output
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 ### Running Evaluation
 
 After running inference, you can evaluate the results using:

--- a/benchmarks/swefficiency/README.md
+++ b/benchmarks/swefficiency/README.md
@@ -29,6 +29,8 @@ uv run swefficiency-infer path/to/llm_config.json \
     --workspace docker
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 #### Resource Limits
 
 For parallel evaluation, CPU and memory limits can be configured:

--- a/benchmarks/swtbench/README.md
+++ b/benchmarks/swtbench/README.md
@@ -11,6 +11,8 @@ Before running any benchmarks, you need to set up the environment see main READM
 uv run swtbench-infer .llm_config/sonnet-4.json --n-critic-runs 3 --n-limit 500 --max-iterations 500 --critic finish_with_patch
 ```
 
+You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.
+
 ### 2. Selecting Specific Instances
 
 You can run evaluation on a specific subset of instances using the `--select` option:


### PR DESCRIPTION
## Summary

Fixes #560

This PR adds documentation about the run-infer resume capability to each benchmark's README.

## Changes

Added a single line to the run inference section of each benchmark README explaining that previous runs can be resumed:

> You can resume a previous run by re-running the same command with the same `--output-dir`. Previously completed instances are automatically skipped.

## Benchmarks Updated

- **swebench** – Step 2: Run Inference (Docker)
- **gaia** – Step 1: Run Inference
- **multiswebench** – Step 2: Run Inference
- **swebenchmultilingual** – Step 2: Run Inference
- **swebenchmultimodal** – Running Inference
- **swefficiency** – Docker Workspace section
- **swtbench** – Run SWT-Bench Evaluation
- **commit0** – Run Inference
- **openagentsafety** – Basic Command

## How Resume Works

All benchmarks using the base `Evaluation` class automatically track completed instances in per-attempt output files (`output.critic_attempt_1.jsonl`). When the same `--output-dir` is specified on a subsequent run, already-completed instances are skipped, enabling seamless resumption of interrupted evaluations.

## Benchmarks Excluded

- **terminalbench** – Uses Harbor directly and does not support the same automatic resume mechanism
- **swesmith** / **swegym** – No `run_infer.py` / run inference section
