### PR TITLE
fix(ci): rename PAT secret to PAT_TOKEN

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -46,5 +46,5 @@ jobs:
                   # Review style: roasted (other option: standard)
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Dispatch run-eval workflow in software-agent-sdk
         env:
-          PAT_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           SDK_REPO: OpenHands/software-agent-sdk
           SDK_WORKFLOW: run-eval.yml
           SDK_WORKFLOW_REF: main
@@ -108,7 +108,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$PAT_TOKEN" ]; then
-            echo "Missing ALLHANDS_BOT_GITHUB_PAT secret" >&2
+            echo "Missing PAT_TOKEN secret" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ File logging (`logs/instance_<id>.log`) is unaffected by this setting.
 This repo exposes a manual GitHub Actions workflow that dispatches the `run-eval.yml` workflow in the Software Agent SDK. It is useful when you want to launch evals from the benchmarks repo without switching to the SDK repo.
 
 Requirements:
-- The `ALLHANDS_BOT_GITHUB_PAT` secret must be available in this repository with permission to dispatch workflows in `OpenHands/software-agent-sdk`.
+- The `PAT_TOKEN` secret must be available in this repository with permission to dispatch workflows in `OpenHands/software-agent-sdk`.
 
 Run it with `gh`:
 


### PR DESCRIPTION
## Summary
- Renames `ALLHANDS_BOT_GITHUB_PAT` → `PAT_TOKEN` across 3 files:
  - `.github/workflows/pr-review-by-openhands.yml` (1 reference)
  - `.github/workflows/run-eval.yml` (2 references + error message)
  - `README.md` (1 documentation reference)
- Aligns with the secret rename in software-agent-sdk (PR #2561, merged)

