### PR TITLE
fix: remove redundant 'Apply workflow_dispatch overrides' step from build workflows

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -104,21 +104,11 @@ jobs:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
 
-      - name: Apply workflow_dispatch overrides (if any)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.repo-split }}" ]; then echo "REPO_SPLIT=${{ inputs.repo-split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.sdk-commit }}" ]; then echo "SDK_COMMIT=${{ inputs.sdk-commit }}" >> "$GITHUB_ENV"; fi
-
       - name: Build selected instances file
         run: |
           set -euo pipefail
 
+          INSTANCE_IDS="${{ inputs.instance-ids }}"
           if [ -z "${INSTANCE_IDS}" ]; then
             echo "No instance IDs provided; skipping select file creation."
             exit 0
@@ -133,6 +123,7 @@ jobs:
             | sed '/^$/d' > "${SELECT_FILE}"
 
           echo "SELECT_FILE=${SELECT_FILE}" >> "$GITHUB_ENV"
+          # Skip n-limit when explicit instance IDs are provided to avoid double filtering
           echo "N_LIMIT=" >> "$GITHUB_ENV"
 
           echo "Selected instance IDs:"
@@ -172,6 +163,13 @@ jobs:
         run: |
           set -euo pipefail
           FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+
+          # Use inputs with fallbacks for workflow_dispatch; for pull_request_target, inputs are empty so fallbacks apply
+          DATASET="${{ inputs.dataset || 'wentingzhao/commit0_combined' }}"
+          SPLIT="${{ inputs.split || 'test' }}"
+          REPO_SPLIT="${{ inputs.repo-split || 'lite' }}"
+          MAX_WORKERS="${{ inputs.max-workers || '16' }}"
+          N_LIMIT="${{ inputs.n-limit }}"
 
           CMD="uv run benchmarks/commit0/build_images.py \
             --dataset '${DATASET}' \

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -116,19 +116,6 @@ jobs:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
 
-      # If this was a manual dispatch, override defaults with provided inputs.
-      - name: Apply workflow_dispatch overrides (if any)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.language }}" ]; then echo "LANGUAGE=${{ inputs.language }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
-          # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
-
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -149,6 +136,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          INSTANCE_IDS="${{ inputs.instance-ids }}"
           if [ -z "${INSTANCE_IDS}" ]; then
             echo "No instance IDs provided; skipping select file creation."
             exit 0
@@ -237,6 +225,22 @@ jobs:
           set -euo pipefail
           FORCE_BUILD="${{ inputs.force-build || 'false' }}"
 
+          # Use inputs with fallbacks for workflow_dispatch; for pull_request_target, inputs are empty so fallbacks apply
+          DATASET="${{ inputs.dataset || 'bytedance-research/Multi-SWE-Bench' }}"
+          SPLIT="${{ inputs.split || 'test' }}"
+          MAX_WORKERS="${{ inputs.max-workers || '12' }}"
+          MAX_RETRIES="${{ inputs.max-retries || '5' }}"
+          LANGUAGE="${{ inputs.language || 'java' }}"
+
+          # N_LIMIT handling:
+          # - For workflow_dispatch: use input value (empty string = no limit, otherwise use provided value)
+          # - For pull_request_target: use value from "Set N_LIMIT based on label" step (via GITHUB_ENV)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            N_LIMIT="${{ inputs.n-limit }}"
+          fi
+          # If N_LIMIT is still not set (e.g., pull_request_target without label override), use default
+          N_LIMIT="${N_LIMIT:-50}"
+
           CMD="uv run benchmarks/multiswebench/build_images.py \
             --dataset '${DATASET}' \
             --split '${SPLIT}' \
@@ -262,7 +266,7 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
           BUILDKIT_RESET_ON_FAILURE: 1
-          LANGUAGE: ${{ env.LANGUAGE }}
+          LANGUAGE: ${{ inputs.language || 'java' }}
 
       - name: Archive build logs
         if: always()

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -124,19 +124,6 @@ jobs:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
 
-      # If this was a manual dispatch, override defaults with provided inputs.
-      - name: Apply workflow_dispatch overrides (if any)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.build-batch-size }}" ]; then echo "BUILD_BATCH_SIZE=${{ inputs.build-batch-size }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
-          # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
-
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -157,6 +144,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          INSTANCE_IDS="${{ inputs.instance-ids }}"
           if [ -z "${INSTANCE_IDS}" ]; then
             echo "No instance IDs provided; skipping select file creation."
             exit 0
@@ -243,7 +231,24 @@ jobs:
       - name: Build and push SWE-Bench images
         run: |
           set -euo pipefail
+
+          # Use inputs with fallbacks for workflow_dispatch; for pull_request_target, inputs are empty so fallbacks apply
+          DATASET="${{ inputs.dataset || 'princeton-nlp/SWE-bench_Verified' }}"
+          SPLIT="${{ inputs.split || 'test' }}"
+          MAX_WORKERS="${{ inputs.max-workers || '12' }}"
+          MAX_RETRIES="${{ inputs.max-retries || '5' }}"
+          BUILD_BATCH_SIZE="${{ inputs.build-batch-size || '15' }}"
           FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          AGENT_TYPE="${{ inputs.agent-type || 'default' }}"
+
+          # N_LIMIT handling:
+          # - For workflow_dispatch: use input value (empty string = no limit, otherwise use provided value)
+          # - For pull_request_target: use value from "Set N_LIMIT based on label" step (via GITHUB_ENV)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            N_LIMIT="${{ inputs.n-limit }}"
+          fi
+          # If N_LIMIT is still not set (e.g., pull_request_target without label override), use default
+          N_LIMIT="${N_LIMIT:-500}"
 
           CMD="uv run benchmarks/swebench/build_images.py \
             --dataset '${DATASET}' \
@@ -272,7 +277,6 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
           BUILDKIT_RESET_ON_FAILURE: 1
-          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Archive build logs
         if: always()
@@ -304,6 +308,10 @@ jobs:
       - name: Comment on tracker issue
         if: success()
         run: |
+          # Use inputs with fallbacks
+          DATASET="${{ inputs.dataset || 'princeton-nlp/SWE-bench_Verified' }}"
+          SPLIT="${{ inputs.split || 'test' }}"
+
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
           

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -114,18 +114,6 @@ jobs:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
 
-      # If this was a manual dispatch, override defaults with provided inputs.
-      - name: Apply workflow_dispatch overrides (if any)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
-          # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
-
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -146,6 +134,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          INSTANCE_IDS="${{ inputs.instance-ids }}"
           if [ -z "${INSTANCE_IDS}" ]; then
             echo "No instance IDs provided; skipping select file creation."
             exit 0
@@ -233,6 +222,21 @@ jobs:
         run: |
           set -euo pipefail
           FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+
+          # Use inputs with fallbacks for workflow_dispatch; for pull_request_target, inputs are empty so fallbacks apply
+          DATASET="${{ inputs.dataset || 'princeton-nlp/SWE-bench_Multimodal' }}"
+          SPLIT="${{ inputs.split || 'dev' }}"
+          MAX_WORKERS="${{ inputs.max-workers || '12' }}"
+          MAX_RETRIES="${{ inputs.max-retries || '5' }}"
+
+          # N_LIMIT handling:
+          # - For workflow_dispatch: use input value (empty string = no limit, otherwise use provided value)
+          # - For pull_request_target: use value from "Set N_LIMIT based on label" step (via GITHUB_ENV)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            N_LIMIT="${{ inputs.n-limit }}"
+          fi
+          # If N_LIMIT is still not set (e.g., pull_request_target without label override), use default
+          N_LIMIT="${N_LIMIT:-500}"
 
           CMD="uv run benchmarks/swebenchmultimodal/build_images.py \
             --dataset '${DATASET}' \

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -110,18 +110,6 @@ jobs:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
 
-      # If this was a manual dispatch, override defaults with provided inputs.
-      - name: Apply workflow_dispatch overrides (if any)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
-          # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
-
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -142,6 +130,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          INSTANCE_IDS="${{ inputs.instance-ids }}"
           if [ -z "${INSTANCE_IDS}" ]; then
             echo "No instance IDs provided; skipping select file creation."
             exit 0
@@ -229,6 +218,21 @@ jobs:
         run: |
           set -euo pipefail
           FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+
+          # Use inputs with fallbacks for workflow_dispatch; for pull_request_target, inputs are empty so fallbacks apply
+          DATASET="${{ inputs.dataset || 'SWE-Gym/SWE-Gym' }}"
+          SPLIT="${{ inputs.split || 'train' }}"
+          MAX_WORKERS="${{ inputs.max-workers || '12' }}"
+          MAX_RETRIES="${{ inputs.max-retries || '5' }}"
+
+          # N_LIMIT handling:
+          # - For workflow_dispatch: use input value (empty string = no limit, otherwise use provided value)
+          # - For pull_request_target: use value from "Set N_LIMIT based on label" step (via GITHUB_ENV)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            N_LIMIT="${{ inputs.n-limit }}"
+          fi
+          # If N_LIMIT is still not set (e.g., pull_request_target without label override), use default
+          N_LIMIT="${N_LIMIT:-2438}"
 
           CMD="uv run benchmarks/swegym/build_images.py \
             --dataset '${DATASET}' \

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -110,18 +110,6 @@ jobs:
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
 
-      # If this was a manual dispatch, override defaults with provided inputs.
-      - name: Apply workflow_dispatch overrides (if any)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
-          # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
-
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
@@ -142,6 +130,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          INSTANCE_IDS="${{ inputs.instance-ids }}"
           if [ -z "${INSTANCE_IDS}" ]; then
             echo "No instance IDs provided; skipping select file creation."
             exit 0
@@ -229,6 +218,21 @@ jobs:
         run: |
           set -euo pipefail
           FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+
+          # Use inputs with fallbacks for workflow_dispatch; for pull_request_target, inputs are empty so fallbacks apply
+          DATASET="${{ inputs.dataset || 'SWE-bench/SWE-smith-py' }}"
+          SPLIT="${{ inputs.split || 'train' }}"
+          MAX_WORKERS="${{ inputs.max-workers || '12' }}"
+          MAX_RETRIES="${{ inputs.max-retries || '5' }}"
+
+          # N_LIMIT handling:
+          # - For workflow_dispatch: use input value (empty string = no limit, otherwise use provided value)
+          # - For pull_request_target: use value from "Set N_LIMIT based on label" step (via GITHUB_ENV)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            N_LIMIT="${{ inputs.n-limit }}"
+          fi
+          # If N_LIMIT is still not set (e.g., pull_request_target without label override), use default
+          N_LIMIT="${N_LIMIT:-51000}"
 
           CMD="uv run benchmarks/swesmith/build_images.py \
             --dataset '${DATASET}' \


### PR DESCRIPTION
## Summary

This PR removes the redundant 'Apply workflow_dispatch overrides' step from all build workflows and replaces it with direct input references using the `${{ inputs.X || 'default' }}` pattern.

## Problem

Several build workflows had a redundant pattern: an `env:` block with hardcoded defaults, followed by an "Apply workflow_dispatch overrides" step that copies `inputs.*` values into `GITHUB_ENV`. This override step is effectively a no-op because:

1. For `workflow_dispatch`: inputs always have defaults that match the env block
2. For `pull_request_target`: the step is skipped entirely (gated by `if: workflow_dispatch`)

The duplication is error-prone — if someone updates the input default without updating the env default (or vice versa), they silently diverge.

## Solution

Replace hardcoded env defaults with `${{ inputs.X || 'default' }}` expressions:
- For `workflow_dispatch`: the input value is used directly
- For `pull_request_target`: inputs are empty, so the `||` fallback applies

This was already done for `build-swtbench-images.yml` in PR #555. This PR applies the same cleanup to:

- [x] `build-swebench-images.yml`
- [x] `build-commit0-images.yml`
- [x] `build-multiswebench-images.yml`
- [x] `build-swebenchmultimodal-images.yml`
- [x] `build-swegym-images.yml`
- [x] `build-swesmith-images.yml`

## Changes

1. **Removed** the "Apply workflow_dispatch overrides" step from all 6 workflows
2. **Updated** "Build selected instances file" steps to use `inputs.instance-ids` directly
3. **Updated** "Build and push" steps to define variables inline with fallback defaults
4. **Preserved** label-based N_LIMIT logic for `pull_request_target` events (for workflows that have it)

## Testing

The workflows should behave identically to before:
- For `workflow_dispatch`: inputs are used directly with their defaults
- For `pull_request_target`: fallback defaults are used (same as the previous env block defaults)
- Label-based N_LIMIT adjustments continue to work via GITHUB_ENV

Fixes #565