### PR TITLE
chore: remove build arg plumbing for INSTALL_BOTO3/ACP/BROWSER

### DIFF
--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -17,7 +17,6 @@ from benchmarks.swebench.config import BUILD_DEFAULTS
 from benchmarks.utils.build_utils import (
     BuildOutput,
     build_all_images,
-    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
     run_docker_build_layer,
@@ -184,7 +183,6 @@ def main(argv: list[str]) -> int:
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=_wrap_if_needed,
-        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 

--- a/benchmarks/swtbench/build_images.py
+++ b/benchmarks/swtbench/build_images.py
@@ -19,7 +19,6 @@ from benchmarks.swebench.build_images import (
 from benchmarks.swtbench.config import BUILD_DEFAULTS
 from benchmarks.utils.build_utils import (
     build_all_images,
-    build_args_for_agent_type,
     default_build_output_dir,
     get_build_parser,
 )
@@ -51,7 +50,6 @@ def main(argv: list[str]) -> int:
         max_retries=args.max_retries,
         base_image_to_custom_tag_fn=extract_custom_tag,
         post_build_fn=_wrap_if_needed,
-        extra_build_args=build_args_for_agent_type(args.agent_type),
     )
 
 

--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -359,40 +359,7 @@ def get_build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Rebuild images even if matching remote tags already exist",
     )
-    parser.add_argument(
-        "--agent-type",
-        type=str,
-        default="default",
-        choices=["default", "acp-claude", "acp-codex"],
-        help=(
-            "Agent type determines which deps to include: "
-            "'default' skips ACP, 'acp-*' keeps ACP installed"
-        ),
-    )
     return parser
-
-
-# Build args for lightweight benchmark images: skip deps benchmarks don't use.
-# These correspond to ARGs in the SDK Dockerfile that default to "true".
-LIGHTWEIGHT_BUILD_ARGS: dict[str, str] = {
-    "INSTALL_ACP": "false",
-    "INSTALL_BOTO3": "false",
-    "INSTALL_BROWSER": "false",
-}
-
-# Build args for ACP benchmark images: keep ACP but skip the rest.
-ACP_BUILD_ARGS: dict[str, str] = {
-    "INSTALL_ACP": "true",
-    "INSTALL_BOTO3": "false",
-    "INSTALL_BROWSER": "false",
-}
-
-
-def build_args_for_agent_type(agent_type: str) -> dict[str, str]:
-    """Select build args based on agent type."""
-    if agent_type.startswith("acp-"):
-        return ACP_BUILD_ARGS
-    return LIGHTWEIGHT_BUILD_ARGS
 
 
 def _utcnow_iso() -> str:
@@ -439,7 +406,6 @@ def build_image(
     push: bool = False,
     force_build: bool = False,
     cached_sdist: Path | None = None,
-    extra_build_args: dict[str, str] = LIGHTWEIGHT_BUILD_ARGS,
 ) -> BuildOutput:
     # Importing here because openhands.agent_server.docker.build runs git checks
     # which fails when installed as a package outside the git repo
@@ -462,7 +428,6 @@ def build_image(
         git_sha=git_sha,
         prebuilt_sdist=cached_sdist,
         sdk_version=sdk_version,
-        extra_build_args=extra_build_args,
     )
     if _force_build_enabled(force_build):
         logger.info(
@@ -564,7 +529,6 @@ def _build_with_logging(
     max_retries: int = 3,
     post_build_fn: Callable[[BuildOutput, bool], BuildOutput] | None = None,
     cached_sdist: Path | None = None,
-    extra_build_args: dict[str, str] | None = None,
 ) -> BuildOutput:
     """
     Module-level function for building a single image with output capture.
@@ -612,11 +576,6 @@ def _build_with_logging(
                     push,
                     force_build=force_build,
                     cached_sdist=cached_sdist,
-                    extra_build_args=(
-                        extra_build_args
-                        if extra_build_args is not None
-                        else LIGHTWEIGHT_BUILD_ARGS
-                    ),
                 )
             except Exception as e:
                 result = BuildOutput(
@@ -721,7 +680,6 @@ def build_all_images(
     force_build: bool = False,
     max_retries: int = 3,
     post_build_fn: Callable[[BuildOutput, bool], BuildOutput] | None = None,
-    extra_build_args: dict[str, str] | None = None,
 ) -> int:
     """
     Build all specified base images concurrently, logging output and
@@ -830,7 +788,6 @@ def build_all_images(
                         max_retries=max_retries,
                         post_build_fn=post_build_fn,
                         cached_sdist=cached_sdist,
-                        extra_build_args=extra_build_args,
                     )
                     futures[fut] = base
 


### PR DESCRIPTION
## Summary
- Remove `LIGHTWEIGHT_BUILD_ARGS` and `ACP_BUILD_ARGS` dicts
- Remove `build_args_for_agent_type()` function
- Remove `--agent-type` CLI arg from build parser (only used for build arg selection)
- Remove `extra_build_args` parameter from `build_image`, `_build_with_logging`, and `build_all_images`
- Remove corresponding imports and call-site arguments in `swebench/build_images.py` and `swtbench/build_images.py`

The SDK Dockerfile no longer supports conditional dep installation (OpenHands/software-agent-sdk#2569) — all deps are always included. This removes the benchmarks-side plumbing that passed those build args.

## Test plan
- [ ] `build_images.py` runs without errors (no missing imports or args)
- [ ] Trigger a small ACP Claude SWE-bench eval (limit=1) to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)