### PR TITLE
fix: copy Python 3.13 runtime into eval images for venv compatibility

### DIFF
--- a/benchmarks/utils/Dockerfile.agent-layer
+++ b/benchmarks/utils/Dockerfile.agent-layer
@@ -28,7 +28,7 @@ ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 # image doesn't have Python 3.13, so we bring the interpreter and stdlib along.
 COPY --from=builder /usr/local/bin/python3.13 /usr/local/bin/python3.13
 COPY --from=builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
-COPY --from=builder /usr/local/lib/libpython3.13* /usr/local/lib/
+COPY --from=builder /usr/local/lib/libpython3.13.so* /usr/local/lib/
 # The venv's python symlinks to /usr/local/bin/python3 (not python3.13),
 # so we need the python3 symlink to exist as well. Use COPY instead of
 # RUN ln because the base image may not be running as root.


### PR DESCRIPTION
## Summary

- SDK v1.15.0 (PR OpenHands/software-agent-sdk#2567) changed the agent-server Dockerfile builder from `--managed-python` to `--python-preference only-system`, making the venv's `bin/python` a symlink to `/usr/local/bin/python3.13` instead of a self-contained managed Python
- `Dockerfile.agent-layer` copies `/agent-server` (including the venv) from the builder into the eval-base image, but the eval-base image doesn't have Python 3.13 at `/usr/local/bin/` — so the symlink is broken
- Every runtime pod on `eval-runtime` cluster fails with: `exec: "/agent-server/.venv/bin/python": stat /agent-server/.venv/bin/python: no such file or directory`
- **All eval runs using SDK >= v1.15.0 are broken** (53 pods in `CreateContainerError` right now)

Fix: copy the Python 3.13 binary, stdlib, shared library, **and the `python3` symlink** from the builder stage into the final eval image so the venv symlinks resolve correctly.

### Symlink chain

The venv creates this symlink chain:
```
/agent-server/.venv/bin/python → /usr/local/bin/python3 → /usr/local/bin/python3.13
```

Both the `python3` symlink and the `python3.13` binary must be copied from the builder.

## Verification

### ❌ Failed runs (before fix / incomplete fix)

| Run | SDK SHA | Issue |
|-----|---------|-------|
| [`eval-23626200448-claude-4-6`](https://github.com/OpenHands/evaluation/actions/runs/23626200448) | `c89a214` | 0% success — all instances `CreateContainerError` (missing `python3` symlink) |
| [`eval-23638731475-claude-4-6`](https://github.com/OpenHands/evaluation/actions/runs/23638731475) | `efe731c` | Image build failed — `RUN ln` permission denied (base image runs as non-root) |

### ✅ Successful run (with complete fix)

| Run | SDK SHA | Result |
|-----|---------|--------|
| [`eval-23645135869-claude-4-6`](https://github.com/OpenHands/evaluation/actions/runs/23645135869) | `87d792d` | **5/5 instances completed** — swtbench, ACP Claude Opus 4.6, eval_limit=5 |

- Benchmarks build: [#23646748469](https://github.com/OpenHands/benchmarks/actions/runs/23646748469) ✅
- No `CreateContainerError` — all runtime pods started and ran successfully
- Inference completed in ~5 minutes, evaluation report uploaded to GCS

## Test plan

- [x] Trigger a test eval with `eval_limit=5` using this branch and a fresh SDK SHA
- [x] Verify runtime pods start successfully (no `CreateContainerError`)
- [x] Verify `/agent-server/.venv/bin/python` resolves and runs inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)