### PR TITLE
fix: bump swebenchmultimodal api_timeout to 600s

### DIFF
--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -207,6 +207,7 @@ class SWEBenchEvaluation(Evaluation):
                 f"(tag prefix: {IMAGE_TAG_PREFIX}, resource_factor: {resource_factor})"
             )
             startup_timeout = float(os.getenv("REMOTE_RUNTIME_STARTUP_TIMEOUT", "600"))
+            api_timeout = float(os.getenv("REMOTE_API_TIMEOUT", "600"))
             workspace = APIRemoteWorkspace(
                 runtime_api_url=os.getenv(
                     "RUNTIME_API_URL", "https://runtime.eval.all-hands.dev"
@@ -215,6 +216,7 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,
+                api_timeout=api_timeout,
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
                 resource_factor=resource_factor,


### PR DESCRIPTION
## Summary

- Add `api_timeout=600` (via `REMOTE_API_TIMEOUT` env var) to the `APIRemoteWorkspace` constructor in `swebenchmultimodal/run_infer.py`
- Matches the existing `startup_timeout` of 600s for consistency

## Problem

Large SWE-bench Multimodal images consistently fail on first attempt because cold-pull runtime initialization exceeds the default 300s `api_timeout`. These instances only succeed on retry (when the image is cached).

## Evidence

Measured from eval run [23669973803](https://github.com/OpenHands/evaluation/actions/runs/23669973803) (Codex GPT-5.4 ACP, `api_timeout=300`):

| Instance | Runtime init time | Result at 300s |
|----------|------------------|----------------|
| wp-calypso-22026 | ~385s | ❌ Timeout |
| p5.js-5915 | ~407s | ❌ Timeout |
| wp-calypso-31830 | ~454s | ❌ Timeout |

These are the largest images in the benchmark (wp-calypso, react-pdf, p5.js). On cold-pull nodes, the runtime-api needs 385–454s to pull and start the container — well above 300s.

With `api_timeout=300`, these instances **always** fail on first attempt and only succeed on retry if the node has cached the image. Bumping to 600s (matching `startup_timeout`) gives sufficient headroom for cold-pull scenarios while retries still handle transient failures.

## Test plan

- [ ] Verify `REMOTE_API_TIMEOUT` defaults to 600 when env var is not set
- [ ] Run swebenchmultimodal with this change and confirm wp-calypso / p5.js instances succeed on first attempt with cold-pull nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)