### PR TITLE
feat: content-hash eval-base image tags to auto-rebuild on Dockerfile changes

### DIFF
--- a/benchmarks/swebench/build_base_images.py
+++ b/benchmarks/swebench/build_base_images.py
@@ -104,7 +104,8 @@ def build_base_image(
     image: str = EVAL_BASE_IMAGE,
     push: bool = False,
     platform: str = "linux/amd64",
-    content_hash: str = "",
+    *,
+    content_hash: str,
 ) -> BuildOutput:
     """Build a single base image using the SDK Dockerfile's base-image-minimal target."""
     dockerfile = _get_sdk_dockerfile()
@@ -165,7 +166,8 @@ def _build_base_with_logging(
     image: str = EVAL_BASE_IMAGE,
     push: bool = False,
     max_retries: int = 3,
-    content_hash: str = "",
+    *,
+    content_hash: str,
 ) -> BuildOutput:
     """Build a single base image with logging and retry support."""
     import time
@@ -530,7 +532,8 @@ def _assemble_with_logging(
     push: bool = False,
     max_retries: int = 3,
     force_build: bool = False,
-    content_hash: str = "",
+    *,
+    content_hash: str,
 ) -> BuildOutput:
     """Assemble a single agent image with logging and retry."""
     import time

--- a/tests/test_phased_build.py
+++ b/tests/test_phased_build.py
@@ -54,7 +54,9 @@ class TestBuildBaseImage:
     def test_skips_when_remote_exists(self, _exists, _dockerfile):
         from benchmarks.swebench.build_base_images import build_base_image
 
-        result = build_base_image("ubuntu:22.04", "custom-tag", push=False)
+        result = build_base_image(
+            "ubuntu:22.04", "custom-tag", push=False, content_hash="abc1234"
+        )
         assert result.error is None
         assert len(result.tags) == 1
         assert "custom-tag" in result.tags[0]
@@ -73,7 +75,9 @@ class TestBuildBaseImage:
     def test_success(self, _exists, _dockerfile, mock_run):
         from benchmarks.swebench.build_base_images import build_base_image
 
-        result = build_base_image("ubuntu:22.04", "custom-tag", push=True)
+        result = build_base_image(
+            "ubuntu:22.04", "custom-tag", push=True, content_hash="abc1234"
+        )
         assert result.error is None
         assert len(result.tags) == 1
         cmd = mock_run.call_args[0][0]
@@ -94,7 +98,7 @@ class TestBuildBaseImage:
     def test_failure_returns_error(self, _exists, _dockerfile, _run):
         from benchmarks.swebench.build_base_images import build_base_image
 
-        result = build_base_image("ubuntu:22.04", "custom-tag")
+        result = build_base_image("ubuntu:22.04", "custom-tag", content_hash="abc1234")
         assert result.error is not None
         assert result.tags == []
 
@@ -124,6 +128,7 @@ class TestBuildBaseWithLoggingRetry:
             base_image="img",
             custom_tag="tag",
             max_retries=3,
+            content_hash="abc1234",
         )
         assert result.error is None
         assert result.tags == ["tag:1"]
@@ -147,6 +152,7 @@ class TestBuildBaseWithLoggingRetry:
             base_image="img",
             custom_tag="tag",
             max_retries=2,
+            content_hash="abc1234",
         )
         assert result.error == "permanent error"
         assert mock_build.call_count == 2
@@ -168,6 +174,7 @@ class TestBuildBaseWithLoggingRetry:
             base_image="img",
             custom_tag="tag",
             max_retries=1,
+            content_hash="abc1234",
         )
         assert result.error is not None
         assert "docker crash" in result.error


### PR DESCRIPTION
## Summary

- Include a 7-char SHA-256 content hash of the SDK Dockerfile in eval-base image tags (`eval-base:{hash}-{instance_tag}`) so that Dockerfile changes automatically invalidate cached images and trigger rebuilds
- Extract `dockerfile_content_hash()` as a public helper, compute it once per phase in the orchestrator, and pass the result through to `ProcessPoolExecutor` workers — `base_image_tag()` stays a pure string formatter
- `content_hash` is a required keyword-only arg — no silent fallback to file I/O
- Covers swebench, swebench-multimodal, and swtbench (all go through the same 3-phase pipeline via `benchmarks/swebench/build_images.py`)

Closes #593

## Validation

Triggered real CI builds for `django__django-11099` on the feature branch:

| Run | Scenario | Base image | Result |
|-----|----------|-----------|--------|
| [#23869153028](https://github.com/OpenHands/benchmarks/actions/runs/23869153028) | Cold build (new tag format) | `eval-base:245a238-sweb.eval.x86_64.django_1776_django-11099` | **Built and pushed** |
| [#23869164900](https://github.com/OpenHands/benchmarks/actions/runs/23869164900) | Warm (same Dockerfile) | `eval-base:245a238-sweb.eval.x86_64.django_1776_django-11099` | **Skipped** (`already exists`) |

- Run 1 built the base image with content hash `245a238` in the tag
- Run 2 found the same tag in GHCR and skipped all 3 phases (builder, base, assembly)
- Both phases (1 and 2) produce matching tags — assembly correctly references the base image pushed in phase 1

## Test plan

- [x] All 22 `test_phased_build.py` tests pass (including new `test_dockerfile_content_hash_format`)
- [x] Pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright strict)
- [x] CI validation: cold build succeeds and pushes content-hashed tag
- [x] CI validation: warm build skips when Dockerfile unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)