### PR TITLE
fix: enable LiteLLM virtual key cost tracking for default agent

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -33,6 +33,7 @@ from benchmarks.utils.evaluation_utils import (
     get_default_on_result_writer,
 )
 from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -393,7 +394,7 @@ class Commit0Evaluation(Evaluation):
                     keep_first=self.metadata.condenser_keep_first,
                 )
             agent = Agent(
-                llm=self.metadata.llm,
+                llm=apply_virtual_key(self.metadata.llm),
                 tools=tools,
                 system_prompt_kwargs={"cli_mode": True},
                 condenser=condenser,

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -36,6 +36,7 @@ from benchmarks.utils.evaluation_utils import (
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
 from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
@@ -336,7 +337,7 @@ class GAIAEvaluation(Evaluation):
                     keep_first=self.metadata.condenser_keep_first,
                 )
             agent = Agent(
-                llm=self.metadata.llm,
+                llm=apply_virtual_key(self.metadata.llm),
                 tools=tools,
                 system_prompt_kwargs={"cli_mode": True},
                 condenser=condenser,

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -26,6 +26,7 @@ from benchmarks.utils.evaluation_utils import (
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
 from benchmarks.utils.image_utils import remote_image_exists
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -294,7 +295,7 @@ class MultiSWEBenchEvaluation(Evaluation):
             )
 
         agent = Agent(
-            llm=self.metadata.llm,
+            llm=apply_virtual_key(self.metadata.llm),
             tools=tools,
             system_prompt_kwargs={"cli_mode": True},
             condenser=condenser,

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -25,6 +25,7 @@ from benchmarks.utils.dataset import get_dataset
 from benchmarks.utils.evaluation import Evaluation
 from benchmarks.utils.evaluation_utils import construct_eval_output_dir
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
 from openhands.sdk import Agent, Conversation, Tool, get_logger
@@ -455,7 +456,7 @@ class OpenAgentSafetyEvaluation(Evaluation):
             tools.append(Tool(name=DelegateTool.name))
 
         # Create agent
-        agent = Agent(llm=self.metadata.llm, tools=tools)
+        agent = Agent(llm=apply_virtual_key(self.metadata.llm), tools=tools)
 
         # Collect events
         received_events = []

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -20,6 +20,7 @@ from benchmarks.utils.acp import (
     setup_acp_workspace,
     workspace_keepalive,
 )
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.args_parser import add_prompt_path_argument, get_parser
 from benchmarks.utils.build_utils import ensure_local_image
 from benchmarks.utils.console_logging import summarize_instance
@@ -268,12 +269,10 @@ class SWEBenchEvaluation(Evaluation):
                     keep_first=self.metadata.condenser_keep_first,
                 )
             agent = Agent(
-                llm=self.metadata.llm,
+                llm=apply_virtual_key(self.metadata.llm),
                 tools=tools,
                 system_prompt_kwargs={"cli_mode": True},
                 condenser=condenser,
-                # TODO: we can enable security analyzer later
-                # security_analyzer=LLMSecurityAnalyzer(),
             )
 
         assert isinstance(workspace, RemoteWorkspace)

--- a/benchmarks/swebenchmultilingual/run_infer.py
+++ b/benchmarks/swebenchmultilingual/run_infer.py
@@ -26,6 +26,7 @@ from benchmarks.utils.evaluation_utils import (
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
 from benchmarks.utils.image_utils import remote_image_exists
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -250,7 +251,7 @@ class SWEBenchEvaluation(Evaluation):
         if self.metadata.enable_delegation:
             tools.append(Tool(name=DelegateTool.name))
         agent = Agent(
-            llm=self.metadata.llm,
+            llm=apply_virtual_key(self.metadata.llm),
             tools=tools,
             system_prompt_kwargs={"cli_mode": True},
             # TODO: we can enable condenser and security analyzer later

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -32,6 +32,7 @@ from benchmarks.utils.evaluation_utils import (
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
 from benchmarks.utils.image_utils import remote_image_exists
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -254,7 +255,7 @@ class SWEBenchEvaluation(Evaluation):
                     keep_first=self.metadata.condenser_keep_first,
                 )
             agent = Agent(
-                llm=self.metadata.llm,
+                llm=apply_virtual_key(self.metadata.llm),
                 tools=tools,
                 system_prompt_kwargs={"cli_mode": True},
                 condenser=condenser,

--- a/benchmarks/swefficiency/run_infer.py
+++ b/benchmarks/swefficiency/run_infer.py
@@ -22,6 +22,7 @@ from benchmarks.utils.evaluation_utils import (
 )
 from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
 from benchmarks.utils.image_utils import remote_image_exists
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.models import (
     EvalInstance,
     EvalMetadata,
@@ -308,7 +309,7 @@ class SWEfficiencyEvaluation(Evaluation):
         """
         tools = get_default_tools(enable_browser=False)
         agent = Agent(
-            llm=self.metadata.llm,
+            llm=apply_virtual_key(self.metadata.llm),
             tools=tools,
             system_prompt_kwargs={"cli_mode": True},
         )

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -29,6 +29,7 @@ from benchmarks.utils.image_utils import (
     create_docker_workspace,
     remote_image_exists,
 )
+from benchmarks.utils.litellm_proxy import apply_virtual_key
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import (
     EvalInstance,
@@ -263,7 +264,7 @@ class SWTBenchEvaluation(Evaluation):
                     keep_first=self.metadata.condenser_keep_first,
                 )
             agent = Agent(
-                llm=self.metadata.llm,
+                llm=apply_virtual_key(self.metadata.llm),
                 tools=tools,
                 system_prompt_kwargs={"cli_mode": True},
                 condenser=condenser,

--- a/benchmarks/utils/litellm_proxy.py
+++ b/benchmarks/utils/litellm_proxy.py
@@ -155,3 +155,22 @@ def set_current_virtual_key(key: str | None) -> None:
 def get_current_virtual_key() -> str | None:
     """Return the virtual key for the current worker thread, or None."""
     return getattr(_thread_local, "virtual_key", None)
+
+
+def apply_virtual_key(llm):  # type: ignore[no-untyped-def]
+    """Return an LLM config copy with the per-instance virtual key as api_key.
+
+    If no virtual key is active for this thread, returns the original config
+    unchanged.  This is thread-safe: ``model_copy`` creates a new instance
+    and ``get_current_virtual_key`` reads from ``threading.local``.
+
+    Use this when creating a default (non-ACP) ``Agent`` so that all LLM
+    calls go through the proxy with the per-instance virtual key, enabling
+    accurate per-instance cost tracking.
+    """
+    virtual_key = get_current_virtual_key()
+    if virtual_key is None:
+        return llm
+    from pydantic import SecretStr
+
+    return llm.model_copy(update={"api_key": SecretStr(virtual_key)})


### PR DESCRIPTION
## Summary
- Add `apply_virtual_key()` helper to `litellm_proxy.py` that returns an LLM config copy with the per-instance virtual key as `api_key`
- Update all 9 benchmarks to use it when creating the default (non-ACP) `Agent`
- Thread-safe: uses `model_copy()` + `threading.local` (no shared state mutation)

## Why

The evaluation orchestrator already creates per-instance LiteLLM virtual keys for every run (`evaluation.py:850`), but only ACP agents injected them into their LLM client (via `build_acp_agent()` in `acp.py`). The default OpenHands agent used the master API key directly, so `proxy_cost` was always `$0.00` for non-ACP runs.

This was discovered during PR validation runs for OpenHands/software-agent-sdk#2656 (eval_limit=5, 3 benchmarks × 3 agent types). The evidence:

| Agent Type | SDK Cost | Proxy Cost | Issue |
|-----------|----------|-----------|-------|
| acp-claude | $0.21 | $0.20 | Both work |
| acp-gemini | $0.00 | $7.08 | SDK blind (separate issue) |
| **default** | **$0.20** | **$0.00** | **Proxy blind (this fix)** |

## Test plan
- [ ] Run a default-agent evaluation and verify `test_result.proxy_cost` is non-zero
- [ ] Run an ACP evaluation and verify behavior is unchanged (no regression)
- [ ] Verify `apply_virtual_key()` is a no-op when no virtual key is active (returns original LLM unchanged)

Fixes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)