### PR TITLE
fix: increase ACP prompt timeout for Gemini agents to 7200s

### DIFF
--- a/benchmarks/utils/acp.py
+++ b/benchmarks/utils/acp.py
@@ -159,9 +159,7 @@ def build_acp_agent(agent_type: str, llm_model: str) -> ACPAgent:
             if var.endswith("API_KEY"):
                 acp_env[var] = virtual_key
 
-    prompt_timeout = _ACP_PROMPT_TIMEOUT_OVERRIDES.get(
-        agent_type, ACP_PROMPT_TIMEOUT
-    )
+    prompt_timeout = _ACP_PROMPT_TIMEOUT_OVERRIDES.get(agent_type, ACP_PROMPT_TIMEOUT)
 
     return cast(Any, ACPAgent)(
         acp_command=get_acp_command(agent_type),

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from benchmarks.utils.acp import (
-    ACP_PROMPT_TIMEOUT,
     _ACP_PROMPT_TIMEOUT_OVERRIDES,
+    ACP_PROMPT_TIMEOUT,
     _get_acp_env,
     build_acp_agent,
     get_acp_command,


### PR DESCRIPTION
## Summary

Increases the ACP prompt timeout from 3600s (1h) to 7200s (2h) for `acp-gemini` agents, while keeping the existing 3600s default for `acp-claude` and `acp-codex`.

## Problem

During the first full-scale (n=500) `acp-gemini` evaluation batch, both GAIA and SWE-bench runs were extremely slow:

- **GAIA** (`eval-23925785249-gemini-3-f`): 55/165 instances (33%) hit the 14400s per-instance timeout after 18+ hours
- **SWE-bench** (`eval-23925785262-gemini-3-f`): 239/500 completed after 18+ hours, still running

Initial investigation pointed at Gemini API instability, but **Datadog agent-server logs revealed the real cause**: Gemini was actively working the entire time — not hanging — and being killed by the 3600s `ACP_PROMPT_TIMEOUT` before finishing.

## Evidence from agent-server pod logs (Datadog)

Timed-out instances were accumulating real tool calls right up to the cutoff:

| Runtime ID | Text chunks | Tool calls | Status at 3600s |
|---|---|---|---|
| `pookxbkeicueoyyt` | 37 | 22 | Still streaming |
| `czlxqashshqddipv` | 0 | 28 | Running bash commands, no text yet |
| `aqanojoeyidgjhtz` | 87 | 67 | Very active |
| `crjubjnnvmduosqt` | 162 | 88 | Near-max activity |
| `irlspxpcunbqvjbp` | 206 | 114 | Highest text volume seen |

Example log from a timed-out GAIA instance:
```
23:21:07 — Sending ACP prompt (timeout=3600s, msg=2170 chars)
00:21:07 — ACP prompt timed out after 3600.0s (limit=3600s).
           Accumulated 37 text chunks, 22 tool calls.
00:21:08 — Received signal SIGTERM (15), shutting down...
```

Successful instances showed a timing distribution with a fat tail:
- **Fastest**: 28s, 58s
- **Median**: ~400-700s (7-12 min)
- **Slow tail**: 2113s, 3371s, 3559s (approaching the 3600s limit)

## Why retries make it worse

Each timeout triggers a retry with a fresh runtime, where Gemini starts from scratch:
```
retry=1 → timeout at 3600s → SIGTERM
retry=2 → timeout at 3600s → SIGTERM
retry=3 → timeout at 3600s → SIGTERM
→ 3 × 3600s ≈ 10800s wasted, then 14400s instance timeout kills it
```

These retries **can never succeed** because the task genuinely requires more than 60 min.

## Changes

- Add `_ACP_PROMPT_TIMEOUT_OVERRIDES` dict for per-agent-type timeout configuration
- Set `acp-gemini` timeout to 7200s (2h)
- `build_acp_agent()` looks up the override before falling back to the default
- Added tests verifying Gemini gets the extended timeout and Claude keeps the default

## Test plan

- [x] `pytest tests/test_acp.py` — 33 tests pass (2 new)
- [ ] Re-run a GAIA `acp-gemini` batch to verify instances that previously timed out at 3600s now complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)