### PR TITLE
fix: reset BuildKit cache between retries for base/assembly builds

### DIFF
--- a/benchmarks/swebench/build_base_images.py
+++ b/benchmarks/swebench/build_base_images.py
@@ -30,6 +30,7 @@ from benchmarks.utils.build_utils import (
     capture_output,
     default_build_output_dir,
 )
+from benchmarks.utils.buildx_utils import maybe_reset_buildkit
 from benchmarks.utils.constants import EVAL_AGENT_SERVER_IMAGE
 from benchmarks.utils.image_utils import remote_image_exists
 from openhands.sdk import get_logger
@@ -298,6 +299,7 @@ def _build_base_with_logging(
             result.log_path = str(log_path)
             if result.error:
                 logger.error("Base build error for %s: %s", base_image, result.error)
+                maybe_reset_buildkit(base_image, image, attempt, max_retries)
                 if attempt == max_retries - 1:
                     return result
                 continue
@@ -673,6 +675,7 @@ def _assemble_with_logging(
             result.log_path = str(log_path)
             if result.error:
                 logger.error("Assembly error for %s: %s", base_image, result.error)
+                maybe_reset_buildkit(base_image, target_image, attempt, max_retries)
                 if attempt == max_retries - 1:
                     return result
                 continue
@@ -693,6 +696,7 @@ def _assemble_with_logging(
                         error=f"Wrapping failed: {wrap_result.error}",
                         log_path=str(log_path),
                     )
+                    maybe_reset_buildkit(base_image, target_image, attempt, max_retries)
                     if attempt == max_retries - 1:
                         return result
                     continue


### PR DESCRIPTION
## Summary
- Base image builds (`_build_base_with_logging`) and assembly builds (`_assemble_with_logging`) were missing the `maybe_reset_buildkit` call between retries
- Agent-server image builds (`_build_with_logging` in `build_utils.py`) already had this — so it was an inconsistency
- Without the cache reset, transient BuildKit failures (e.g. digest mismatches from Blacksmith remote builders) persist across all retry attempts, making retries useless

## Root cause
The swebench image build for `eval-23962693702-gpt-5-4` ([run 23962735301](https://github.com/All-Hands-AI/benchmarks/actions/runs/23962735301)) failed with 12/500 images failing due to:
1. **BuildKit cache corruption** (sphinx-doc images): `failed commit on ref ... unexpected commit digest ... failed precondition` — retries hit the same corrupted cache entry every time
2. **Transient HTTP/2 error** (sympy images): `curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR` — BuildKit cache reset between retries gives a clean slate for re-download

## Test plan
- [ ] Verify import: `python -c "from benchmarks.swebench.build_base_images import _build_base_with_logging"`
- [ ] Confirm `maybe_reset_buildkit` is called on failure in both `_build_base_with_logging` and `_assemble_with_logging`
- [ ] Next swebench image build with transient failures should recover via retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)