### PR TITLE
Add hybridgym_funclocalize benchmark

### DIFF
--- a/benchmarks/hybridgym_depsearch/README.md
+++ b/benchmarks/hybridgym_depsearch/README.md
@@ -1,0 +1,50 @@
+# Hybrid-Gym dep_search Evaluation
+
+This module integrates the **dep_search** benchmark from [Hybrid-Gym](https://github.com/Hybrid-Gym/Hybrid-Gym). The agent must analyze a target function, identify all functions and classes it directly calls within the repository, and annotate each dependency with a comment above its definition.
+
+## Overview
+
+Each instance provides:
+- A Python repository (cloned at runtime from GitHub)
+- A target function name, file path, and line number
+
+The agent must read the target function, trace its calls, and add a comment (`# this function/class is called by the <name> function`) above each called module's definition. Success is measured by precision, recall, and F1 across the set of expected dependencies.
+
+## Usage
+
+### Running Inference
+
+```bash
+uv run hybridgym-depsearch-infer .llm_config/config.json
+uv run hybridgym-depsearch-infer .llm_config/config.json --n-limit 5
+uv run hybridgym-depsearch-infer .llm_config/config.json --workspace docker
+```
+
+### Evaluating Results
+
+```bash
+uv run hybridgym-depsearch-eval ./eval_outputs/.../output.jsonl --run-id my_run
+```
+
+## Dataset
+
+- **HuggingFace**: [`hybrid-gym/hybrid_gym_dep_search`](https://huggingface.co/datasets/hybrid-gym/hybrid_gym_dep_search)
+- **Default split**: `train`
+
+## Evaluation Criteria
+
+An instance is marked **fully resolved** when all conditions are met:
+
+| Criterion | Description |
+|-----------|-------------|
+| All dependencies annotated | Every expected dependency has a correctly placed comment (recall = 1.0) |
+| No false positives | No comments placed for non-dependencies |
+| No duplicates | Each dependency annotated exactly once |
+| Comments only | All changes are comments (no code modifications) |
+
+Partial credit is given via precision/recall/F1 scores.
+
+## References
+
+- [Hybrid-Gym Paper](https://arxiv.org/abs/2602.16819v1) -- "Hybrid-Gym: Training Coding Agents to Generalize Across Tasks"
+- [Hybrid-Gym GitHub](https://github.com/Hybrid-Gym/Hybrid-Gym)

--- a/benchmarks/hybridgym_depsearch/__init__.py
+++ b/benchmarks/hybridgym_depsearch/__init__.py
@@ -1,0 +1,1 @@
+"""Hybrid-Gym dep_search benchmark evaluation."""

--- a/benchmarks/hybridgym_depsearch/config.py
+++ b/benchmarks/hybridgym_depsearch/config.py
@@ -1,0 +1,24 @@
+"""
+Hybrid-Gym dep_search benchmark configuration.
+
+Task: Agent must find all functions/classes directly called by a target function
+and add a comment above each called module's definition.
+
+Dataset: hybrid-gym/hybrid_gym_dep_search on HuggingFace.
+"""
+
+CONDENSER_DEFAULTS = {
+    "enable_condenser": False,
+    "condenser_max_size": 240,
+    "condenser_keep_first": 2,
+}
+
+INFER_DEFAULTS = {
+    "dataset": "hybrid-gym/hybrid_gym_dep_search",
+    "split": "train",
+    "max_iterations": 30,
+    "tool_preset": "default",
+    "num_workers": 16,
+    "n_critic_runs": 1,
+    **CONDENSER_DEFAULTS,
+}

--- a/benchmarks/hybridgym_depsearch/eval_infer.py
+++ b/benchmarks/hybridgym_depsearch/eval_infer.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Hybrid-Gym dep_search evaluation script.
+
+Reads output.jsonl from run_infer.py, loads the ground truth dataset,
+and evaluates whether the agent correctly annotated all dependencies
+with comments. Computes precision, recall, F1 and full success rate.
+
+Usage:
+    uv run hybridgym-depsearch-eval output.jsonl --run-id my_run
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from datasets import load_dataset
+
+from benchmarks.utils.laminar import LaminarService
+from benchmarks.utils.report_costs import generate_cost_report
+from openhands.sdk import get_logger
+
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Patch parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_patch_with_details(patch_text: str) -> list[dict]:
+    """Parse a git patch, returning per-file added lines with line numbers and hunks."""
+    if not patch_text:
+        return []
+
+    lines = patch_text.split("\n")
+    files: list[dict] = []
+    current_file = None
+    added_lines: list[dict] = []
+    hunks: list[tuple] = []
+    file_pattern = re.compile(r"^diff --git a/(.+) b/(.+)$")
+    hunk_pattern = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+    current_line = 0
+
+    for line in lines:
+        if line.startswith("diff --git"):
+            if current_file is not None:
+                files.append(
+                    {
+                        "filename": current_file,
+                        "added_lines": added_lines,
+                        "hunks": hunks,
+                    }
+                )
+            current_file = None
+            added_lines = []
+            hunks = []
+            current_line = 0
+            match = file_pattern.match(line)
+            if match:
+                current_file = match.group(2)
+        elif line.startswith("@@"):
+            match = hunk_pattern.match(line)
+            if match:
+                old_start = int(match.group(1))
+                old_count = int(match.group(2)) if match.group(2) else 1
+                new_start = int(match.group(3))
+                new_count = int(match.group(4)) if match.group(4) else 1
+                hunks.append((old_start, old_count, new_start, new_count))
+                current_line = new_start
+        elif line.startswith("+") and not line.startswith("+++"):
+            if current_file is not None:
+                added_lines.append({"line_number": current_line, "content": line[1:]})
+            current_line += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            pass  # deleted lines don't advance new-file counter
+        elif current_file is not None and not line.startswith(
+            ("diff", "@@", "index", "---", "+++")
+        ):
+            current_line += 1
+
+    if current_file is not None:
+        files.append(
+            {"filename": current_file, "added_lines": added_lines, "hunks": hunks}
+        )
+    return files
+
+
+def compute_line_offset(hunks: list, original_line: int) -> int:
+    """Compute how much an original line shifted in the new file due to hunks."""
+    if not hunks:
+        return 0
+    cumulative_offset = 0
+    for old_start, old_count, new_start, new_count in sorted(hunks, key=lambda h: h[0]):
+        if original_line < old_start:
+            return cumulative_offset
+        old_end = old_start + old_count
+        if original_line < old_end:
+            return cumulative_offset + (new_count - old_count)
+        cumulative_offset = (new_start + new_count) - (old_start + old_count)
+    return cumulative_offset
+
+
+def is_lines_comment_only(lines: list[str]) -> bool:
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("#"):
+            return False
+    return True
+
+
+def check_comment_content(line: str, target_func_name: str) -> bool:
+    """Check if a comment mentions the target function as a caller."""
+    stripped = line.strip().lower()
+    if not stripped.startswith("#"):
+        return False
+    content = stripped[1:].strip().rstrip(".,;:!")
+    target_lower = target_func_name.lower()
+    if target_lower in content and (
+        "called by" in content or "used by" in content or "dependency" in content
+    ):
+        return True
+    acceptable = [
+        f"this function/class is called by the {target_lower} function",
+        f"this function is called by the {target_lower} function",
+        f"this class is called by the {target_lower} function",
+    ]
+    return content in acceptable
+
+
+# ---------------------------------------------------------------------------
+# Instance evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_instance(instance_data: dict, output_data: dict) -> dict:
+    target_func_name = instance_data["target_function_name"]
+    dependencies = instance_data["dependencies"]
+    num_deps = len(dependencies)
+
+    result = {
+        "instance_id": output_data.get("instance_id"),
+        "target_function": target_func_name,
+        "num_dependencies": num_deps,
+        "true_positives": 0,
+        "false_negatives": 0,
+        "false_positives": 0,
+        "duplicates": 0,
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": 0.0,
+        "full_success": False,
+        "comments_only": False,
+    }
+
+    git_patch = output_data.get("test_result", {}).get("git_patch", "")
+    if not git_patch:
+        result["false_negatives"] = num_deps
+        return result
+
+    patch_details = parse_patch_with_details(git_patch)
+
+    all_content = []
+    for pf in patch_details:
+        all_content.extend([line["content"] for line in pf["added_lines"]])
+    result["comments_only"] = is_lines_comment_only(all_content)
+
+    # Build expected-dependency map: (file, original_1idx_line) -> dep
+    expected_deps: dict[tuple, dict] = {}
+    for dep in dependencies:
+        expected_line = dep.get("decorator_line", dep["line_start"]) + 1
+        expected_deps[(dep["file_path"], expected_line)] = dep
+
+    found_deps: set[str] = set()
+    dep_counts: dict[str, int] = defaultdict(int)
+    all_comments: list[dict] = []
+
+    for file_info in patch_details:
+        filename = file_info["filename"]
+        hunks = file_info.get("hunks", [])
+        for added in file_info["added_lines"]:
+            if not check_comment_content(added["content"], target_func_name):
+                continue
+            line_num = added["line_number"]
+            matched = False
+            for (dep_file, orig_line), dep in expected_deps.items():
+                if dep_file != filename:
+                    continue
+                adjusted = orig_line + compute_line_offset(hunks, orig_line)
+                if abs(line_num - adjusted) <= 5:
+                    dep_counts[dep["name"]] += 1
+                    status = "duplicate" if dep["name"] in found_deps else "correct"
+                    if status == "correct":
+                        found_deps.add(dep["name"])
+                    all_comments.append({"status": status})
+                    matched = True
+                    break
+            if not matched:
+                all_comments.append({"status": "false_positive"})
+
+    tp = len(found_deps)
+    fp = sum(1 for c in all_comments if c["status"] == "false_positive")
+    dups = sum(1 for c in all_comments if c["status"] == "duplicate")
+
+    total_pos = tp + fp + dups
+    precision = tp / total_pos if total_pos > 0 else 0.0
+    recall = tp / num_deps if num_deps > 0 else 0.0
+    f1 = (
+        2 * precision * recall / (precision + recall)
+        if (precision + recall) > 0
+        else 0.0
+    )
+
+    result.update(
+        {
+            "true_positives": tp,
+            "false_negatives": num_deps - tp,
+            "false_positives": fp,
+            "duplicates": dups,
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "full_success": tp == num_deps
+            and fp == 0
+            and dups == 0
+            and result["comments_only"],
+        }
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def generate_report(
+    input_file: str,
+    output_file: str,
+    dataset_name: str,
+    split: str,
+) -> None:
+    instance_id2data: dict[str, dict] = {}
+    if dataset_name.endswith((".jsonl", ".json")):
+        with open(dataset_name) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    data = json.loads(line)
+                    instance_id2data[data["instance_id"]] = data
+    else:
+        dataset = load_dataset(dataset_name, split=split)
+        for row in dataset:  # type: ignore[union-attr]
+            row_dict = dict(row)  # type: ignore[call-overload]
+            instance_id2data[row_dict["instance_id"]] = row_dict
+    logger.info("Loaded %d ground truth instances", len(instance_id2data))
+
+    results: list[dict] = []
+    resolved_ids: list[str] = []
+    unresolved_ids: list[str] = []
+    error_ids: list[str] = []
+    empty_patch_ids: list[str] = []
+
+    with open(input_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            output_data = json.loads(line)
+            iid = output_data.get("instance_id", "")
+
+            if output_data.get("error"):
+                error_ids.append(iid)
+                continue
+
+            git_patch = output_data.get("test_result", {}).get("git_patch", "")
+            if not git_patch.strip():
+                empty_patch_ids.append(iid)
+                continue
+
+            if iid not in instance_id2data:
+                logger.warning("instance_id %s not found in ground truth", iid)
+                unresolved_ids.append(iid)
+                continue
+
+            eval_result = evaluate_instance(instance_id2data[iid], output_data)
+            results.append(eval_result)
+            if eval_result["full_success"]:
+                resolved_ids.append(iid)
+            else:
+                unresolved_ids.append(iid)
+
+    submitted_ids = resolved_ids + unresolved_ids + error_ids + empty_patch_ids
+    report = {
+        "schema_version": 2,
+        "total_instances": len(submitted_ids),
+        "submitted_instances": len(submitted_ids),
+        "submitted_ids": submitted_ids,
+        "completed_instances": len(resolved_ids) + len(unresolved_ids),
+        "completed_ids": resolved_ids + unresolved_ids,
+        "resolved_instances": len(resolved_ids),
+        "resolved_ids": resolved_ids,
+        "unresolved_instances": len(unresolved_ids),
+        "unresolved_ids": unresolved_ids,
+        "error_instances": len(error_ids),
+        "error_ids": error_ids,
+        "empty_patch_instances": len(empty_patch_ids),
+        "empty_patch_ids": empty_patch_ids,
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(report, f, indent=2)
+
+    total = len(resolved_ids) + len(unresolved_ids)
+    avg_p = sum(r["precision"] for r in results) / max(total, 1)
+    avg_r = sum(r["recall"] for r in results) / max(total, 1)
+    avg_f1 = sum(r["f1"] for r in results) / max(total, 1)
+    logger.info("=== Evaluation Results ===")
+    logger.info("Total evaluated: %d", total)
+    logger.info(
+        "Full success: %d/%d (%.1f%%)",
+        len(resolved_ids),
+        total,
+        100 * len(resolved_ids) / max(total, 1),
+    )
+    logger.info("Avg Precision: %.4f  Recall: %.4f  F1: %.4f", avg_p, avg_r, avg_f1)
+    logger.info("Empty patches: %d  Errors: %d", len(empty_patch_ids), len(error_ids))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate Hybrid-Gym dep_search outputs and generate report",
+    )
+    parser.add_argument("input_file", help="Path to output.jsonl from inference")
+    parser.add_argument("--run-id", required=True, help="Unique run identifier")
+    parser.add_argument(
+        "--dataset",
+        default="hybrid-gym/hybrid_gym_dep_search",
+        help="HuggingFace dataset name or local JSONL path for ground truth",
+    )
+    parser.add_argument("--split", default="train", help="Dataset split")
+    args = parser.parse_args()
+
+    input_path = Path(args.input_file)
+    if not input_path.exists():
+        logger.error("Input file does not exist: %s", input_path)
+        sys.exit(1)
+
+    report_path = input_path.with_suffix(".report.json")
+
+    try:
+        generate_report(str(input_path), str(report_path), args.dataset, args.split)
+        LaminarService.get().update_evaluation_scores(str(input_path), str(report_path))
+        generate_cost_report(str(input_path))
+        logger.info("Report saved to: %s", report_path)
+        print(json.dumps({"report_json": str(report_path)}))
+    except Exception as e:
+        logger.error("Evaluation failed: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybridgym_depsearch/prompts/default.j2
+++ b/benchmarks/hybridgym_depsearch/prompts/default.j2
@@ -1,0 +1,47 @@
+I've uploaded a Python code repository in the directory {{ workspace_dir_name }}.
+
+## Your Task
+
+Analyze the function `{{ target_function_name }}` located at **line {{ target_function_line }}** in file `{{ target_function_file }}` and find ALL modules (functions or classes) that are **directly called** by this function within this repository.
+
+For each called module that is defined within this repository (not Python built-ins or external libraries), you need to add a comment **right above its definition**:
+
+```python
+# this function/class is called by the {{ target_function_name }} function
+def some_called_function():
+    ...
+```
+
+## What Counts as a "Call"
+
+The following patterns all count as calling a module:
+- **Function calls**: `helper_function()`
+- **Class instantiation**: `MyClass()` - this counts as calling `MyClass`
+- **Exception raising**: `raise MyException()` - this counts as calling `MyException`
+
+## Important Rules
+
+1. **Only annotate modules that are DIRECTLY called** by `{{ target_function_name }}` (not transitive dependencies)
+2. **Only annotate modules defined WITHIN this repository** - ignore:
+   - Python built-ins (print, len, range, str, list, dict, etc.)
+   - Standard library functions
+   - External package functions
+3. **Place the comment on the line immediately ABOVE** the `def` or `class` keyword
+4. **If there are decorators**, place the comment ABOVE the decorators
+5. **Do NOT modify any code** other than adding these comments
+6. The comment must say exactly: `# this function/class is called by the {{ target_function_name }} function`
+7. **Do NOT add duplicate comments** - each dependency should be annotated exactly once
+
+## Recommended Steps
+
+1. **READ**: First, read the function `{{ target_function_name }}` in `{{ target_function_file }}` to understand what it does
+2. **ANALYZE**: Identify all function/class calls within the function body (typically 1-3 dependencies)
+3. **RESOLVE EACH CALL**: For each call, determine which definition is actually in scope:
+   - Check if it's defined locally in the same file (could be above OR below the target function)
+   - Check the imports at the top of `{{ target_function_file }}` to see if it's imported from another module
+   - Follow the import to find the actual definition
+4. **FILTER**: Exclude Python built-ins and external library calls
+5. **ANNOTATE**: Add the comment above each qualifying definition in the repository
+6. **VERIFY**: Double-check that all comments are correctly placed and there are no duplicates
+
+Be thorough in your analysis. It's fine if your thinking process is lengthy - quality and completeness are more important than brevity.

--- a/benchmarks/hybridgym_depsearch/run_infer.py
+++ b/benchmarks/hybridgym_depsearch/run_infer.py
@@ -1,0 +1,340 @@
+"""Run inference for the Hybrid-Gym dep_search benchmark.
+
+Task: Given a target function, find all modules (functions/classes) directly
+called by it and add a comment above each called module's definition.
+
+Dataset: hybrid-gym/hybrid_gym_dep_search on HuggingFace.
+"""
+
+import json
+import os
+from typing import Any, List
+
+from jinja2 import Environment, FileSystemLoader
+
+from benchmarks.hybridgym_depsearch.config import INFER_DEFAULTS
+from benchmarks.utils.args_parser import add_prompt_path_argument, get_parser
+from benchmarks.utils.console_logging import summarize_instance
+from benchmarks.utils.constants import EVAL_AGENT_SERVER_IMAGE
+from benchmarks.utils.conversation import build_event_persistence_callback
+from benchmarks.utils.critics import create_critic
+from benchmarks.utils.dataset import get_dataset
+from benchmarks.utils.evaluation import Evaluation
+from benchmarks.utils.evaluation_utils import (
+    construct_eval_output_dir,
+    get_default_on_result_writer,
+)
+from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
+from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
+from benchmarks.utils.litellm_proxy import build_eval_llm
+from benchmarks.utils.llm_config import load_llm_config
+from benchmarks.utils.models import (
+    EvalInstance,
+    EvalMetadata,
+    EvalOutput,
+    ToolPresetType,
+)
+from benchmarks.utils.version import IMAGE_TAG_PREFIX
+from openhands.sdk import Agent, Conversation, Tool, get_logger
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.workspace import RemoteWorkspace
+from openhands.tools.delegate import DelegateTool
+from openhands.tools.preset.default import get_default_tools
+from openhands.workspace import APIRemoteWorkspace
+
+
+logger = get_logger(__name__)
+
+BASE_DOCKER_IMAGE = "python:3.11-bookworm"
+
+
+def _get_workspace_dir_name(instance: dict) -> str:
+    repo = instance["repo"]
+    commit = instance.get("base_commit", "latest")[:8]
+    return f"{repo}__{commit}".replace("/", "__")
+
+
+def get_instruction(instance: dict, metadata: EvalMetadata, workspace_path: str) -> str:
+    workspace_dir_name = instance.get(
+        "_workspace_dir_name", _get_workspace_dir_name(instance)
+    )
+
+    assert metadata.prompt_path is not None
+    prompts_dir = os.path.dirname(metadata.prompt_path)
+    template_name = os.path.basename(metadata.prompt_path)
+    env = Environment(loader=FileSystemLoader(prompts_dir))
+    template = env.get_template(template_name)
+
+    context = {
+        "instance": instance,
+        "workspace_dir_name": workspace_dir_name,
+        "actual_workspace_path": workspace_path,
+        "target_function_name": instance["target_function_name"],
+        "target_function_file": instance["target_function_file"],
+        "target_function_line": instance["target_function_line_start"] + 1,
+        "metadata": metadata,
+    }
+
+    return template.render(context)
+
+
+class DepSearchEvaluation(Evaluation):
+    """Hybrid-Gym dep_search evaluation."""
+
+    def prepare_instances(self) -> List[EvalInstance]:
+        logger.info("Setting up dep_search evaluation data")
+
+        df = get_dataset(
+            dataset_name=self.metadata.dataset,
+            split=self.metadata.dataset_split,
+            eval_limit=self.metadata.eval_limit,
+            selected_instances_file=self.metadata.selected_instances_file,
+        )
+
+        instances: List[EvalInstance] = []
+        for _, row in df.iterrows():
+            inst_id = str(row["instance_id"])
+            instances.append(EvalInstance(id=inst_id, data=row.to_dict()))
+
+        logger.info("Total instances to process: %d", len(instances))
+        return instances
+
+    def prepare_workspace(
+        self,
+        instance: EvalInstance,
+        resource_factor: int = 1,
+        forward_env: list[str] | None = None,
+    ) -> RemoteWorkspace:
+        agent_server_image = (
+            f"{EVAL_AGENT_SERVER_IMAGE}:{IMAGE_TAG_PREFIX}-hybridgym-depsearch-binary"
+        )
+
+        if self.metadata.workspace_type == "docker":
+            workspace = create_docker_workspace(
+                agent_server_image=agent_server_image,
+                base_image=BASE_DOCKER_IMAGE,
+                build_target="binary",
+                forward_env=forward_env or [],
+            )
+        elif self.metadata.workspace_type == "remote":
+            runtime_api_key = os.getenv("RUNTIME_API_KEY")
+            if not runtime_api_key:
+                raise ValueError(
+                    "RUNTIME_API_KEY environment variable is not set for remote workspace"
+                )
+            if not remote_image_exists(agent_server_image):
+                raise RuntimeError(
+                    f"Agent server image {agent_server_image} does not exist in container registry."
+                )
+            startup_timeout = float(os.getenv("REMOTE_RUNTIME_STARTUP_TIMEOUT", "600"))
+            workspace = APIRemoteWorkspace(
+                runtime_api_url=os.getenv(
+                    "RUNTIME_API_URL", "https://runtime.eval.all-hands.dev"
+                ),
+                runtime_api_key=runtime_api_key,
+                server_image=agent_server_image,
+                target_type="binary",
+                resource_factor=resource_factor,
+                forward_env=forward_env or [],
+                init_timeout=startup_timeout,
+                startup_wait_timeout=startup_timeout,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported workspace_type: {self.metadata.workspace_type}"
+            )
+
+        return workspace
+
+    def evaluate_instance(
+        self, instance: EvalInstance, workspace: RemoteWorkspace
+    ) -> EvalOutput:
+        agent_llm = build_eval_llm(self.metadata.llm)
+        tools = self._get_tools(preset=self.metadata.tool_preset)
+        if self.metadata.enable_delegation:
+            tools.append(Tool(name=DelegateTool.name))
+        condenser = None
+        if self.metadata.enable_condenser:
+            condenser = LLMSummarizingCondenser(
+                llm=build_eval_llm(self.metadata.llm, usage_id="condenser"),
+                max_size=self.metadata.condenser_max_size,
+                keep_first=self.metadata.condenser_keep_first,
+            )
+        agent = Agent(
+            llm=agent_llm,
+            tools=tools,
+            system_prompt_kwargs={"cli_mode": True},
+            condenser=condenser,
+        )
+
+        assert isinstance(workspace, RemoteWorkspace)
+
+        workspace_dir_name = _get_workspace_dir_name(instance.data)
+        instance.data["_workspace_dir_name"] = workspace_dir_name
+        repo_path = f"/workspace/{workspace_dir_name}"
+
+        # Clone and checkout
+        res = workspace.execute_command(
+            f"git clone https://github.com/{instance.data['repo']}.git {repo_path}"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to clone repo: {res.stderr}")
+
+        res = workspace.execute_command(
+            f"cd {repo_path} && git checkout {instance.data['base_commit']} && git reset --hard"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to checkout base commit: {res.stderr}")
+
+        workspace.execute_command(
+            f"cd {repo_path} && for r in $(git remote); do git remote remove $r; done"
+        )
+
+        # Re-init git
+        workspace.execute_command(f"cd {repo_path} && rm -rf .git")
+        res = workspace.execute_command(
+            f"cd {repo_path} && git init . && git add -A && "
+            f"git config user.email 'eval@openhands.dev' && "
+            f"git config user.name 'OpenHands Eval' && "
+            f"git commit -m 'Initial commit'"
+        )
+        if res.exit_code != 0:
+            logger.warning("Git re-init failed: %s", res.stderr)
+
+        head_res = workspace.execute_command(f"cd {repo_path} && git rev-parse HEAD")
+        if head_res.exit_code == 0:
+            instance.data["base_commit"] = head_res.stdout.strip()
+
+        # Run agent
+        persist_callback = build_event_persistence_callback(
+            run_id=self.metadata.eval_output_dir,
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+        )
+
+        conversation = Conversation(
+            agent=agent,
+            workspace=workspace,
+            callbacks=[persist_callback],
+            max_iteration_per_run=self.metadata.max_iterations,
+            delete_on_close=True,
+        )
+
+        instruction = get_instruction(
+            instance=instance.data,
+            metadata=self.metadata,
+            workspace_path=workspace.working_dir,
+        )
+        conversation.send_message(instruction)
+        run_conversation_with_fake_user_response(conversation)
+
+        # Extract patch
+        workspace.execute_command(f"cd {repo_path} && git add -A")
+        workspace.execute_command(
+            f"cd {repo_path} && git commit --no-verify -m 'Agent changes' || true"
+        )
+
+        base_commit = instance.data["base_commit"]
+        git_patch_result = workspace.execute_command(
+            f"cd {repo_path} && git --no-pager diff --no-color {base_commit} HEAD"
+        )
+        git_patch = git_patch_result.stdout if git_patch_result.exit_code == 0 else ""
+
+        summarize_instance(
+            instance_id=instance.id,
+            conversation=conversation,
+            git_patch=git_patch,
+            logger=logger,
+        )
+
+        test_result: dict[str, Any] = {"git_patch": git_patch}
+
+        return EvalOutput(
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+            test_result=test_result,
+            instruction=instruction,
+            error=None,
+            history=list(conversation.state.events),
+            metrics=conversation.conversation_stats.get_combined_metrics(),
+        )
+
+    def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
+        """Get tools for the given preset."""
+        if preset == "gemini":
+            from openhands.tools.preset.gemini import get_gemini_tools
+
+            return get_gemini_tools(enable_browser=False)
+        elif preset == "planning":
+            from openhands.tools.preset.planning import get_planning_tools
+
+            return get_planning_tools()
+        else:
+            return get_default_tools(enable_browser=False)
+
+
+def main() -> None:
+    parser = get_parser()
+    add_prompt_path_argument(parser, __file__)
+    parser.set_defaults(**INFER_DEFAULTS)
+    args = parser.parse_args()
+
+    if args.n_critic_runs < 1:
+        raise ValueError(f"n_critic_runs must be >= 1, got {args.n_critic_runs}")
+
+    llm = load_llm_config(args.llm_config_path)
+    logger.info("Using LLM config: %s", llm.model_dump_json(indent=2))
+
+    dataset_description = (
+        args.dataset.replace("/", "__") + "-" + args.split.replace("/", "__")
+    )
+
+    structured_output_dir = construct_eval_output_dir(
+        base_dir=args.output_dir,
+        dataset_name=dataset_description,
+        model_name=llm.model,
+        max_iterations=args.max_iterations,
+        eval_note=args.note,
+    )
+
+    critic = create_critic(args)
+
+    enable_condenser = args.enable_condenser
+    if args.disable_condenser:
+        enable_condenser = False
+
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset=args.dataset,
+        dataset_split=args.split,
+        max_iterations=args.max_iterations,
+        eval_output_dir=structured_output_dir,
+        details={},
+        prompt_path=args.prompt_path,
+        eval_limit=args.n_limit,
+        n_critic_runs=args.n_critic_runs,
+        critic=critic,
+        selected_instances_file=args.select,
+        max_retries=args.max_retries,
+        workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
+        enable_delegation=args.enable_delegation,
+        agent_type=args.agent_type,
+        enable_condenser=enable_condenser,
+        condenser_max_size=args.condenser_max_size,
+        condenser_keep_first=args.condenser_keep_first,
+    )
+
+    evaluator = DepSearchEvaluation(
+        metadata=metadata,
+        num_workers=args.num_workers,
+    )
+
+    evaluator.run(on_result=get_default_on_result_writer(evaluator.output_path))
+
+    logger.info("Evaluation completed!")
+    print(json.dumps({"output_json": str(evaluator.output_path)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybridgym_funcgen/README.md
+++ b/benchmarks/hybridgym_funcgen/README.md
@@ -1,0 +1,48 @@
+# Hybrid-Gym func_gen Evaluation
+
+This module integrates the **func_gen** benchmark from [Hybrid-Gym](https://github.com/Hybrid-Gym/Hybrid-Gym). The agent is given a function with its body removed (replaced by a TODO stub) and must implement the function body based on the signature and docstring.
+
+## Overview
+
+Each instance provides:
+- A Python repository (cloned at runtime from GitHub)
+- A target function whose body has been replaced with `pass  # TODO: Implement this function`
+- The function's signature and docstring remain intact
+
+The agent must read the context, understand the specification from the docstring, and write a correct implementation. Evaluation uses RepoST's eval_script tests that compare the agent's implementation against the reference.
+
+## Prerequisites
+
+1. **Docker**: Required for workspace containers and evaluation (RepoST uses `yiqingxyq/repost:v0`).
+2. **LLM API Key**: Configure your LLM provider credentials.
+
+## Usage
+
+### Running Inference
+
+```bash
+uv run hybridgym-funcgen-infer .llm_config/config.json
+uv run hybridgym-funcgen-infer .llm_config/config.json --n-limit 5
+uv run hybridgym-funcgen-infer .llm_config/config.json --workspace docker
+```
+
+### Evaluating Results
+
+```bash
+uv run hybridgym-funcgen-eval ./eval_outputs/.../output.jsonl --run-id my_run
+uv run hybridgym-funcgen-eval ./eval_outputs/.../output.jsonl --run-id my_run --no-docker
+```
+
+## Dataset
+
+- **HuggingFace**: [`hybrid-gym/hybrid_gym_func_gen`](https://huggingface.co/datasets/hybrid-gym/hybrid_gym_func_gen)
+- **Default split**: `train`
+
+## Evaluation Criteria
+
+An instance is marked **resolved** when the generated implementation passes all tests in the RepoST eval_script. The eval_script renames the agent's function to `<name>_new_implementation` and compares its outputs against the reference implementation.
+
+## References
+
+- [Hybrid-Gym Paper](https://arxiv.org/abs/2602.16819v1) -- "Hybrid-Gym: Training Coding Agents to Generalize Across Tasks"
+- [Hybrid-Gym GitHub](https://github.com/Hybrid-Gym/Hybrid-Gym)

--- a/benchmarks/hybridgym_funcgen/__init__.py
+++ b/benchmarks/hybridgym_funcgen/__init__.py
@@ -1,0 +1,1 @@
+"""Hybrid-Gym func_gen benchmark evaluation."""

--- a/benchmarks/hybridgym_funcgen/config.py
+++ b/benchmarks/hybridgym_funcgen/config.py
@@ -1,0 +1,24 @@
+"""
+Hybrid-Gym func_gen benchmark configuration.
+
+Task: Agent is given a function signature and docstring (body removed)
+and must implement the function body.
+
+Dataset: hybrid-gym/hybrid_gym_func_gen on HuggingFace.
+"""
+
+CONDENSER_DEFAULTS = {
+    "enable_condenser": False,
+    "condenser_max_size": 240,
+    "condenser_keep_first": 2,
+}
+
+INFER_DEFAULTS = {
+    "dataset": "hybrid-gym/hybrid_gym_func_gen",
+    "split": "train",
+    "max_iterations": 30,
+    "tool_preset": "default",
+    "num_workers": 16,
+    "n_critic_runs": 1,
+    **CONDENSER_DEFAULTS,
+}

--- a/benchmarks/hybridgym_funcgen/eval_infer.py
+++ b/benchmarks/hybridgym_funcgen/eval_infer.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+Hybrid-Gym func_gen evaluation script.
+
+Reads output.jsonl from run_infer.py and evaluates generated functions
+using RepoST's eval_script tests. Each instance carries an eval_script
+that compares the agent's implementation against the reference.
+
+Usage:
+    uv run hybridgym-funcgen-eval output.jsonl --run-id my_run
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+
+from benchmarks.utils.laminar import LaminarService
+from benchmarks.utils.report_costs import generate_cost_report
+from openhands.sdk import get_logger
+
+
+logger = get_logger(__name__)
+
+DOCKER_IMAGE = "yiqingxyq/repost:v0"
+
+
+# ---------------------------------------------------------------------------
+# Docker helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def docker_container(image: str = DOCKER_IMAGE):
+    """Start a persistent Docker container; clean up on exit."""
+    container_id = None
+    try:
+        name = f"repost_eval_{uuid.uuid4().hex[:8]}"
+        result = subprocess.run(
+            ["docker", "run", "-d", "--name", name, image, "tail", "-f", "/dev/null"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to start container: {result.stderr}")
+        container_id = result.stdout.strip()
+        logger.info("Started container %s", name)
+        yield container_id
+    finally:
+        if container_id:
+            subprocess.run(
+                ["docker", "stop", container_id], capture_output=True, timeout=30
+            )
+            subprocess.run(
+                ["docker", "rm", container_id], capture_output=True, timeout=30
+            )
+
+
+def run_test_in_container(
+    test_content: str, container_id: str, timeout: int = 60
+) -> dict:
+    test_file = f"/tmp/test_{uuid.uuid4().hex[:8]}.py"
+    try:
+        write = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_id,
+                "bash",
+                "-c",
+                f"cat > {test_file} << 'EOFTEST'\n{test_content}\nEOFTEST",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if write.returncode != 0:
+            return {"success": False, "error": f"write failed: {write.stderr}"}
+
+        result = subprocess.run(
+            ["docker", "exec", container_id, "python", test_file],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return {
+            "success": result.returncode == 0,
+            "output": result.stdout,
+            "error": result.stderr,
+        }
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "timeout"}
+    finally:
+        subprocess.run(
+            ["docker", "exec", container_id, "rm", "-f", test_file],
+            capture_output=True,
+            timeout=10,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test construction
+# ---------------------------------------------------------------------------
+
+
+def rename_function(code: str, old_name: str, new_name: str) -> str:
+    return re.sub(rf"((?:async\s+)?def\s+){old_name}(\s*\()", rf"\1{new_name}\2", code)
+
+
+def construct_test_file(
+    generated_function: str, eval_script: str, func_name: str
+) -> str:
+    if "." in func_name:
+        return _construct_for_method(generated_function, eval_script, func_name)
+    return _construct_for_function(generated_function, eval_script, func_name)
+
+
+def _construct_for_function(gen: str, script: str, func_name: str) -> str:
+    new_name = f"{func_name}_new_implementation"
+    renamed = rename_function(gen, func_name, new_name)
+    lines = script.split("\n")
+    imports, rest = [], []
+    in_imports = True
+    for line in lines:
+        s = line.strip()
+        if in_imports and (
+            s.startswith("import ")
+            or s.startswith("from ")
+            or s.startswith("#")
+            or s == ""
+        ):
+            imports.append(line)
+        else:
+            in_imports = False
+            rest.append(line)
+    return "\n".join(imports) + f"\n\n{renamed}\n\n" + "\n".join(rest)
+
+
+def _construct_for_method(gen: str, script: str, func_name: str) -> str:
+    cls_name, method_name = func_name.rsplit(".", 1)
+    new_name = f"{method_name}_new_implementation"
+    renamed = re.sub(
+        rf"((?:async\s+)?def\s+){method_name}(\s*\()", rf"\1{new_name}\2", gen
+    )
+
+    # Ensure 4-space indent for class methods
+    first = renamed.split("\n")[0]
+    cur_indent = len(first) - len(first.lstrip())
+    if cur_indent != 4:
+        adjusted = []
+        for line in renamed.split("\n"):
+            if line.strip():
+                rel = (len(line) - len(line.lstrip())) - cur_indent
+                adjusted.append(" " * (4 + rel) + line.lstrip())
+            else:
+                adjusted.append(line)
+        renamed = "\n".join(adjusted)
+
+    # Find insertion point in eval_script
+    pattern = rf"((?:    @\w+.*\n)*)    def {method_name}\s*\("
+    match = re.search(pattern, script)
+    if match:
+        decorators = match.group(1)
+        if decorators.strip():
+            renamed = decorators + renamed
+        pos = match.start()
+    else:
+        fallback = re.search(rf"    def {method_name}\s*\(", script)
+        if fallback:
+            pos = fallback.start()
+        else:
+            return _construct_for_function(gen, script, func_name)
+
+    merged = script[:pos] + renamed + "\n\n" + script[pos:]
+    lines = merged.split("\n")
+    imports, rest = [], []
+    in_imports = True
+    for line in lines:
+        s = line.strip()
+        if in_imports and (
+            s.startswith("import ")
+            or s.startswith("from ")
+            or s.startswith("#")
+            or s == ""
+        ):
+            imports.append(line)
+        else:
+            in_imports = False
+            rest.append(line)
+    return "\n".join(imports) + "\n\n" + "\n".join(rest)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_instance(
+    entry: dict, container_id: str | None = None, timeout: int = 60
+) -> dict:
+    instance_id = entry.get("instance_id", "unknown")
+    test_result = entry.get("test_result", {})
+    instance = entry.get("instance", {})
+
+    gen_func = test_result.get("generated_function", "")
+    eval_script = instance.get("eval_script", "")
+    func_name = instance.get("func_name", "")
+
+    if not gen_func or not eval_script or not func_name:
+        reason = (
+            "no_generated_function"
+            if not gen_func
+            else ("no_eval_script" if not eval_script else "no_func_name")
+        )
+        return {"instance_id": instance_id, "success": False, "reason": reason}
+
+    test_content = construct_test_file(gen_func, eval_script, func_name)
+
+    if container_id:
+        result = run_test_in_container(test_content, container_id, timeout)
+    else:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(test_content)
+            tmp = f.name
+        try:
+            r = subprocess.run(
+                [sys.executable, tmp], capture_output=True, text=True, timeout=timeout
+            )
+            result = {
+                "success": r.returncode == 0,
+                "output": r.stdout,
+                "error": r.stderr,
+            }
+        except subprocess.TimeoutExpired:
+            result = {"success": False, "error": "timeout"}
+        finally:
+            Path(tmp).unlink(missing_ok=True)
+
+    return {
+        "instance_id": instance_id,
+        "success": result["success"],
+        "reason": "passed" if result["success"] else "test_failed",
+    }
+
+
+def generate_report(input_file: str, output_file: str, use_docker: bool) -> None:
+    entries = []
+    with open(input_file) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                entries.append(json.loads(line))
+
+    results: list[dict] = []
+    resolved_ids: list[str] = []
+    unresolved_ids: list[str] = []
+    error_ids: list[str] = []
+
+    def run_evals(cid=None):
+        for entry in entries:
+            iid = entry.get("instance_id", "")
+            if entry.get("error"):
+                error_ids.append(iid)
+                continue
+            r = evaluate_instance(entry, container_id=cid)
+            results.append(r)
+            if r["success"]:
+                resolved_ids.append(iid)
+            else:
+                unresolved_ids.append(iid)
+
+    if use_docker:
+        with docker_container() as cid:
+            run_evals(cid)
+    else:
+        run_evals()
+
+    submitted_ids = resolved_ids + unresolved_ids + error_ids
+    report = {
+        "schema_version": 2,
+        "total_instances": len(submitted_ids),
+        "submitted_instances": len(submitted_ids),
+        "resolved_instances": len(resolved_ids),
+        "resolved_ids": resolved_ids,
+        "unresolved_instances": len(unresolved_ids),
+        "unresolved_ids": unresolved_ids,
+        "error_instances": len(error_ids),
+        "error_ids": error_ids,
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(report, f, indent=2)
+
+    total = len(resolved_ids) + len(unresolved_ids)
+    logger.info("=== Evaluation Results ===")
+    logger.info("Total evaluated: %d", total)
+    logger.info(
+        "Passed: %d/%d (%.1f%%)",
+        len(resolved_ids),
+        total,
+        100 * len(resolved_ids) / max(total, 1),
+    )
+    logger.info("Errors: %d", len(error_ids))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate Hybrid-Gym func_gen outputs",
+    )
+    parser.add_argument("input_file", help="Path to output.jsonl from inference")
+    parser.add_argument("--run-id", required=True, help="Unique run identifier")
+    parser.add_argument(
+        "--no-docker", action="store_true", help="Run tests without Docker"
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input_file)
+    if not input_path.exists():
+        logger.error("Input file does not exist: %s", input_path)
+        sys.exit(1)
+
+    report_path = input_path.with_suffix(".report.json")
+
+    try:
+        generate_report(
+            str(input_path), str(report_path), use_docker=not args.no_docker
+        )
+        LaminarService.get().update_evaluation_scores(str(input_path), str(report_path))
+        generate_cost_report(str(input_path))
+        logger.info("Report saved to: %s", report_path)
+        print(json.dumps({"report_json": str(report_path)}))
+    except Exception as e:
+        logger.error("Evaluation failed: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybridgym_funcgen/prompts/default.j2
+++ b/benchmarks/hybridgym_funcgen/prompts/default.j2
@@ -1,0 +1,29 @@
+I've uploaded a python code repository in the directory {{ workspace_dir_name }}.
+
+Your task is to implement the body of the function `{{ func_name }}` in the file `{{ file_path }}`.
+
+The function signature and docstring are already in the file. The function body has been replaced with `pass  # TODO: Implement this function`.
+
+<function_info>
+- File: {{ file_path }}
+- Function: {{ func_name }}
+- Docstring: {{ docstring }}
+</function_info>
+
+Follow these steps:
+1. NAVIGATE: Open the file `{{ file_path }}` and locate the function `{{ func_name }}`
+2. CONTEXT: Read the surrounding code to understand:
+   - What imports are available
+   - What other functions/classes exist in the file
+   - The coding style and patterns used
+3. IMPLEMENT: Replace the `pass  # TODO: Implement this function` with a complete implementation that:
+   - Fulfills the description in the docstring
+   - Follows the function signature (parameters and return type if specified)
+   - Uses appropriate imports and dependencies from the file
+   - Handles edge cases appropriately
+4. VERIFY: Review your implementation for:
+   - Correctness (does it do what the docstring says?)
+   - Completeness (all code paths handled?)
+   - Style consistency (matches the rest of the codebase?)
+
+Write clean, working Python code. Your implementation will be tested for correctness.

--- a/benchmarks/hybridgym_funcgen/run_infer.py
+++ b/benchmarks/hybridgym_funcgen/run_infer.py
@@ -1,0 +1,441 @@
+"""Run inference for the Hybrid-Gym func_gen benchmark.
+
+Task: Agent is given a function with its body replaced by a TODO stub.
+It must implement the function body based on the signature and docstring.
+
+Dataset: hybrid-gym/hybrid_gym_func_gen on HuggingFace.
+"""
+
+import ast
+import json
+import os
+from typing import Any, List
+
+from jinja2 import Environment, FileSystemLoader
+
+from benchmarks.hybridgym_funcgen.config import INFER_DEFAULTS
+from benchmarks.utils.args_parser import add_prompt_path_argument, get_parser
+from benchmarks.utils.console_logging import summarize_instance
+from benchmarks.utils.constants import EVAL_AGENT_SERVER_IMAGE
+from benchmarks.utils.conversation import build_event_persistence_callback
+from benchmarks.utils.critics import create_critic
+from benchmarks.utils.dataset import get_dataset
+from benchmarks.utils.evaluation import Evaluation
+from benchmarks.utils.evaluation_utils import (
+    construct_eval_output_dir,
+    get_default_on_result_writer,
+)
+from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
+from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
+from benchmarks.utils.litellm_proxy import build_eval_llm
+from benchmarks.utils.llm_config import load_llm_config
+from benchmarks.utils.models import (
+    EvalInstance,
+    EvalMetadata,
+    EvalOutput,
+    ToolPresetType,
+)
+from benchmarks.utils.version import IMAGE_TAG_PREFIX
+from openhands.sdk import Agent, Conversation, Tool, get_logger
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.workspace import RemoteWorkspace
+from openhands.tools.delegate import DelegateTool
+from openhands.tools.preset.default import get_default_tools
+from openhands.workspace import APIRemoteWorkspace
+
+
+logger = get_logger(__name__)
+
+BASE_DOCKER_IMAGE = "python:3.11-bookworm"
+
+
+def _get_workspace_dir_name(instance: dict) -> str:
+    repo = instance["repo"]
+    commit = instance.get("base_commit", "latest")[:8]
+    return f"{repo}__{commit}".replace("/", "__")
+
+
+def _build_mask_script(file_path: str, func_name: str) -> str:
+    """Return a Python one-liner that masks the function body in-place,
+    keeping signature and docstring but replacing the body with a TODO stub."""
+    # The script is injected into the workspace via execute_command.
+    # It uses AST to find the function, then rewrites the file.
+    return f"""python3 -c '
+import ast, sys
+def find_func(tree, name):
+    if "." in name:
+        cls, meth = name.split(".", 1)
+        for n in ast.walk(tree):
+            if isinstance(n, ast.ClassDef) and n.name == cls:
+                for i in n.body:
+                    if isinstance(i, (ast.FunctionDef, ast.AsyncFunctionDef)) and i.name == meth:
+                        return i
+    else:
+        for n in ast.walk(tree):
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name:
+                return n
+    return None
+
+with open("{file_path}") as f:
+    src = f.read()
+lines = src.split("\\n")
+try:
+    tree = ast.parse(src)
+except SyntaxError:
+    sys.exit(0)
+fn = find_func(tree, "{func_name}")
+if fn is None:
+    sys.exit(0)
+fs = fn.lineno - 1
+fe = fn.end_lineno
+bs = fs + 1
+sig = lines[fs]
+while not sig.rstrip().endswith(":"):
+    bs += 1
+    sig = lines[bs - 1] if bs - 1 < len(lines) else ""
+if fn.body and isinstance(fn.body[0], ast.Expr) and isinstance(getattr(fn.body[0], "value", None), ast.Constant) and isinstance(fn.body[0].value.value, str):
+    bs = fn.body[0].end_lineno
+bl = lines[bs] if bs < len(lines) else lines[fs]
+ind = len(bl) - len(bl.lstrip())
+if ind == 0:
+    ind = len(lines[fs]) - len(lines[fs].lstrip()) + 4
+new = lines[:bs] + [" " * ind + "pass  # TODO: Implement this function"] + lines[fe:]
+with open("{file_path}", "w") as f:
+    f.write("\\n".join(new))
+print("Masked", "{func_name}")
+'"""
+
+
+def _extract_function_from_content(content: str, func_name: str) -> str:
+    """Extract a specific function's source from file content."""
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return ""
+    lines = content.split("\n")
+    if "." in func_name:
+        cls_name, method_name = func_name.split(".", 1)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == cls_name:
+                for item in node.body:
+                    if (
+                        isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                        and item.name == method_name
+                    ):
+                        return "\n".join(lines[item.lineno - 1 : item.end_lineno])
+    else:
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == func_name
+            ):
+                return "\n".join(lines[node.lineno - 1 : node.end_lineno])
+    return ""
+
+
+def get_instruction(instance: dict, metadata: EvalMetadata, workspace_path: str) -> str:
+    workspace_dir_name = instance.get(
+        "_workspace_dir_name", _get_workspace_dir_name(instance)
+    )
+
+    assert metadata.prompt_path is not None
+    prompts_dir = os.path.dirname(metadata.prompt_path)
+    template_name = os.path.basename(metadata.prompt_path)
+    env = Environment(loader=FileSystemLoader(prompts_dir))
+    template = env.get_template(template_name)
+
+    docstring = instance.get("func_docstring_raw") or "(No docstring available)"
+
+    context = {
+        "instance": instance,
+        "workspace_dir_name": workspace_dir_name,
+        "actual_workspace_path": workspace_path,
+        "file_path": instance["file_path"],
+        "func_name": instance["func_name"],
+        "docstring": docstring,
+        "metadata": metadata,
+    }
+
+    return template.render(context)
+
+
+class FuncGenEvaluation(Evaluation):
+    """Hybrid-Gym func_gen evaluation."""
+
+    def prepare_instances(self) -> List[EvalInstance]:
+        logger.info("Setting up func_gen evaluation data")
+
+        df = get_dataset(
+            dataset_name=self.metadata.dataset,
+            split=self.metadata.dataset_split,
+            eval_limit=self.metadata.eval_limit,
+            selected_instances_file=self.metadata.selected_instances_file,
+        )
+
+        instances: List[EvalInstance] = []
+        for _, row in df.iterrows():
+            inst_id = str(row["instance_id"])
+            instances.append(EvalInstance(id=inst_id, data=row.to_dict()))
+
+        logger.info("Total instances to process: %d", len(instances))
+        return instances
+
+    def prepare_workspace(
+        self,
+        instance: EvalInstance,
+        resource_factor: int = 1,
+        forward_env: list[str] | None = None,
+    ) -> RemoteWorkspace:
+        agent_server_image = (
+            f"{EVAL_AGENT_SERVER_IMAGE}:{IMAGE_TAG_PREFIX}-hybridgym-funcgen-binary"
+        )
+
+        if self.metadata.workspace_type == "docker":
+            workspace = create_docker_workspace(
+                agent_server_image=agent_server_image,
+                base_image=BASE_DOCKER_IMAGE,
+                build_target="binary",
+                forward_env=forward_env or [],
+            )
+        elif self.metadata.workspace_type == "remote":
+            runtime_api_key = os.getenv("RUNTIME_API_KEY")
+            if not runtime_api_key:
+                raise ValueError(
+                    "RUNTIME_API_KEY environment variable is not set for remote workspace"
+                )
+            if not remote_image_exists(agent_server_image):
+                raise RuntimeError(
+                    f"Agent server image {agent_server_image} does not exist in container registry."
+                )
+            startup_timeout = float(os.getenv("REMOTE_RUNTIME_STARTUP_TIMEOUT", "600"))
+            workspace = APIRemoteWorkspace(
+                runtime_api_url=os.getenv(
+                    "RUNTIME_API_URL", "https://runtime.eval.all-hands.dev"
+                ),
+                runtime_api_key=runtime_api_key,
+                server_image=agent_server_image,
+                target_type="binary",
+                resource_factor=resource_factor,
+                forward_env=forward_env or [],
+                init_timeout=startup_timeout,
+                startup_wait_timeout=startup_timeout,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported workspace_type: {self.metadata.workspace_type}"
+            )
+
+        return workspace
+
+    def evaluate_instance(
+        self, instance: EvalInstance, workspace: RemoteWorkspace
+    ) -> EvalOutput:
+        agent_llm = build_eval_llm(self.metadata.llm)
+        tools = self._get_tools(preset=self.metadata.tool_preset)
+        if self.metadata.enable_delegation:
+            tools.append(Tool(name=DelegateTool.name))
+        condenser = None
+        if self.metadata.enable_condenser:
+            condenser = LLMSummarizingCondenser(
+                llm=build_eval_llm(self.metadata.llm, usage_id="condenser"),
+                max_size=self.metadata.condenser_max_size,
+                keep_first=self.metadata.condenser_keep_first,
+            )
+        agent = Agent(
+            llm=agent_llm,
+            tools=tools,
+            system_prompt_kwargs={"cli_mode": True},
+            condenser=condenser,
+        )
+
+        assert isinstance(workspace, RemoteWorkspace)
+
+        workspace_dir_name = _get_workspace_dir_name(instance.data)
+        instance.data["_workspace_dir_name"] = workspace_dir_name
+        repo_path = f"/workspace/{workspace_dir_name}"
+
+        # Clone and checkout
+        res = workspace.execute_command(
+            f"git clone https://github.com/{instance.data['repo']}.git {repo_path}"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to clone repo: {res.stderr}")
+
+        res = workspace.execute_command(
+            f"cd {repo_path} && git checkout {instance.data['base_commit']} && git reset --hard"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to checkout base commit: {res.stderr}")
+
+        workspace.execute_command(
+            f"cd {repo_path} && for r in $(git remote); do git remote remove $r; done"
+        )
+
+        # Mask the function body
+        mask_cmd = _build_mask_script(
+            instance.data["file_path"], instance.data["func_name"]
+        )
+        res = workspace.execute_command(f"cd {repo_path} && {mask_cmd}")
+        if res.exit_code != 0:
+            logger.warning("Mask script failed: %s", res.stderr)
+
+        # Re-init git
+        workspace.execute_command(f"cd {repo_path} && rm -rf .git")
+        res = workspace.execute_command(
+            f"cd {repo_path} && git init . && git add -A && "
+            f"git config user.email 'eval@openhands.dev' && "
+            f"git config user.name 'OpenHands Eval' && "
+            f"git commit -m 'Initial commit with masked function'"
+        )
+        if res.exit_code != 0:
+            logger.warning("Git re-init failed: %s", res.stderr)
+
+        head_res = workspace.execute_command(f"cd {repo_path} && git rev-parse HEAD")
+        if head_res.exit_code == 0:
+            instance.data["base_commit"] = head_res.stdout.strip()
+
+        # Run agent
+        persist_callback = build_event_persistence_callback(
+            run_id=self.metadata.eval_output_dir,
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+        )
+
+        conversation = Conversation(
+            agent=agent,
+            workspace=workspace,
+            callbacks=[persist_callback],
+            max_iteration_per_run=self.metadata.max_iterations,
+            delete_on_close=True,
+        )
+
+        instruction = get_instruction(
+            instance=instance.data,
+            metadata=self.metadata,
+            workspace_path=workspace.working_dir,
+        )
+        conversation.send_message(instruction)
+        run_conversation_with_fake_user_response(conversation)
+
+        # Extract patch and generated function
+        workspace.execute_command(f"cd {repo_path} && git add -A")
+        workspace.execute_command(
+            f"cd {repo_path} && git commit --no-verify -m 'Agent changes' || true"
+        )
+
+        base_commit = instance.data["base_commit"]
+        git_patch_result = workspace.execute_command(
+            f"cd {repo_path} && git --no-pager diff --no-color {base_commit} HEAD"
+        )
+        git_patch = git_patch_result.stdout if git_patch_result.exit_code == 0 else ""
+
+        # Read the modified file to extract the generated function
+        file_path = instance.data["file_path"]
+        read_res = workspace.execute_command(f"cat {repo_path}/{file_path}")
+        generated_function = ""
+        if read_res.exit_code == 0:
+            generated_function = _extract_function_from_content(
+                read_res.stdout, instance.data["func_name"]
+            )
+
+        summarize_instance(
+            instance_id=instance.id,
+            conversation=conversation,
+            git_patch=git_patch,
+            logger=logger,
+        )
+
+        test_result: dict[str, Any] = {
+            "git_patch": git_patch,
+            "generated_function": generated_function,
+        }
+
+        return EvalOutput(
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+            test_result=test_result,
+            instruction=instruction,
+            error=None,
+            history=list(conversation.state.events),
+            metrics=conversation.conversation_stats.get_combined_metrics(),
+        )
+
+    def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
+        """Get tools for the given preset."""
+        if preset == "gemini":
+            from openhands.tools.preset.gemini import get_gemini_tools
+
+            return get_gemini_tools(enable_browser=False)
+        elif preset == "planning":
+            from openhands.tools.preset.planning import get_planning_tools
+
+            return get_planning_tools()
+        else:
+            return get_default_tools(enable_browser=False)
+
+
+def main() -> None:
+    parser = get_parser()
+    add_prompt_path_argument(parser, __file__)
+    parser.set_defaults(**INFER_DEFAULTS)
+    args = parser.parse_args()
+
+    if args.n_critic_runs < 1:
+        raise ValueError(f"n_critic_runs must be >= 1, got {args.n_critic_runs}")
+
+    llm = load_llm_config(args.llm_config_path)
+    logger.info("Using LLM config: %s", llm.model_dump_json(indent=2))
+
+    dataset_description = (
+        args.dataset.replace("/", "__") + "-" + args.split.replace("/", "__")
+    )
+
+    structured_output_dir = construct_eval_output_dir(
+        base_dir=args.output_dir,
+        dataset_name=dataset_description,
+        model_name=llm.model,
+        max_iterations=args.max_iterations,
+        eval_note=args.note,
+    )
+
+    critic = create_critic(args)
+
+    enable_condenser = args.enable_condenser
+    if args.disable_condenser:
+        enable_condenser = False
+
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset=args.dataset,
+        dataset_split=args.split,
+        max_iterations=args.max_iterations,
+        eval_output_dir=structured_output_dir,
+        details={},
+        prompt_path=args.prompt_path,
+        eval_limit=args.n_limit,
+        n_critic_runs=args.n_critic_runs,
+        critic=critic,
+        selected_instances_file=args.select,
+        max_retries=args.max_retries,
+        workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
+        enable_delegation=args.enable_delegation,
+        agent_type=args.agent_type,
+        enable_condenser=enable_condenser,
+        condenser_max_size=args.condenser_max_size,
+        condenser_keep_first=args.condenser_keep_first,
+    )
+
+    evaluator = FuncGenEvaluation(
+        metadata=metadata,
+        num_workers=args.num_workers,
+    )
+
+    evaluator.run(on_result=get_default_on_result_writer(evaluator.output_path))
+
+    logger.info("Evaluation completed!")
+    print(json.dumps({"output_json": str(evaluator.output_path)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybridgym_funclocalize/README.md
+++ b/benchmarks/hybridgym_funclocalize/README.md
@@ -1,0 +1,144 @@
+# Hybrid-Gym func_localize Evaluation
+
+This module integrates the **func_localize** benchmark from [Hybrid-Gym](https://github.com/Hybrid-Gym/Hybrid-Gym) ("Hybrid-Gym: Training Coding Agents to Generalize Across Tasks"). The agent must locate a function or class by its natural-language description and write a docstring for it.
+
+## Overview
+
+Each instance provides:
+- A Python repository (cloned at runtime from GitHub)
+- A description of a target function or class (the original docstring has been removed)
+
+The agent must search the codebase to find the target, understand its implementation, and insert an accurate docstring. Success requires that (1) a docstring was added within the target's line range and (2) all changes are comments or docstrings only (no code modifications).
+
+## Dataset
+
+- **HuggingFace**: [`hybrid-gym/hybrid_gym_func_localize`](https://huggingface.co/datasets/hybrid-gym/hybrid_gym_func_localize)
+- **Default split**: `train`
+- **Instance types**: Single-function and multi-function (agent must add docstrings to all targets)
+
+Each instance contains:
+
+| Field | Description |
+|-------|-------------|
+| `instance_id` | Unique identifier (e.g., `internetarchive__openlibrary-462_22`) |
+| `repo` | GitHub repository (e.g., `internetarchive/openlibrary`) |
+| `base_commit` | Commit SHA to check out |
+| `module_name` | Target function/class name |
+| `module_type` | `function` or `class` |
+| `function_description` | Natural-language description of the target |
+| `module_line_start/end` | Ground truth line range (0-indexed) |
+| `docstring_line_start/end` | Original docstring line range to remove |
+| `functions` | (Multi-function instances) List of targets |
+
+## Prerequisites
+
+1. **Docker**: Required for workspace containers.
+2. **LLM API Key**: Configure your LLM provider credentials.
+
+For local (Docker) workspace, the agent server image is built on-the-fly from `python:3.11-bookworm`. For remote workspace, the image must be pre-built and pushed (see below).
+
+## Usage
+
+### LLM Configuration
+
+Create an LLM configuration file (e.g., `.llm_config/config.json`):
+
+```json
+{
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "api_key": "YOUR_API_KEY"
+}
+```
+
+Or use a LiteLLM proxy:
+
+```json
+{
+  "model": "litellm_proxy/anthropic/claude-sonnet-4-20250514",
+  "base_url": "https://your-proxy.example.com",
+  "api_key": "YOUR_API_KEY"
+}
+```
+
+### Docker Workspace (Local)
+
+```bash
+# Run full evaluation
+uv run hybridgym-funclocalize-infer .llm_config/config.json --workspace docker
+
+# Limit to 5 instances
+uv run hybridgym-funclocalize-infer .llm_config/config.json --workspace docker --n-limit 5
+```
+
+### Remote Workspace
+
+The remote workspace requires a pre-built agent server image in a container registry. If the image has already been published to `ghcr.io/openhands/eval-agent-server` (the default), you only need:
+
+```bash
+export RUNTIME_API_KEY="<your-openhands-runtime-api-key>"
+export IMAGE_TAG_PREFIX="<tag-prefix-matching-the-published-image>"
+
+uv run hybridgym-funclocalize-infer .llm_config/config.json \
+    --workspace remote \
+    --num-workers 8 \
+    --n-limit 5
+```
+
+#### Building the image yourself
+
+If the image is not yet available in the default registry, you can build and push to your own:
+
+```bash
+docker login ghcr.io -u <GITHUB_USERNAME> --password-stdin <<< "<GITHUB_PAT>"
+
+export OPENHANDS_EVAL_AGENT_SERVER_IMAGE="ghcr.io/<GITHUB_USERNAME>/eval-agent-server"
+
+uv run python -c "
+from benchmarks.utils.build_utils import build_image
+result = build_image(
+    base_image='python:3.11-bookworm',
+    target_image='${OPENHANDS_EVAL_AGENT_SERVER_IMAGE}',
+    custom_tag='hybridgym-funclocalize',
+    target='binary',
+    push=True,
+)
+print('Tags:', result.tags)
+"
+```
+
+The PAT needs `write:packages` scope. Make the package public at `https://github.com/users/<GITHUB_USERNAME>/packages/container/package/eval-agent-server` (Package settings > Danger Zone > Public).
+
+Then run with:
+
+```bash
+export RUNTIME_API_KEY="<your-openhands-runtime-api-key>"
+export OPENHANDS_EVAL_AGENT_SERVER_IMAGE="ghcr.io/<GITHUB_USERNAME>/eval-agent-server"
+export IMAGE_TAG_PREFIX="$(uv run python -c "from benchmarks.utils.version import SDK_SHORT_SHA; print(SDK_SHORT_SHA)")"
+
+uv run hybridgym-funclocalize-infer .llm_config/config.json \
+    --workspace remote \
+    --num-workers 8 \
+    --n-limit 5
+```
+
+### Evaluating Results
+
+```bash
+uv run hybridgym-funclocalize-eval ./eval_outputs/.../output.jsonl --run-id my_run
+```
+
+This generates `output.report.json` with resolved/unresolved/error instance counts and success rates.
+
+## Evaluation Criteria
+
+An instance is marked **resolved** when both conditions are met:
+
+| Criterion | Description |
+|-----------|-------------|
+| `target_docstring_edited` | At least one line was added within the target function/class line range |
+| `comments_only` | All changes across all files are comments or docstrings (no code modifications, no removed lines) |
+
+## References
+
+- [Hybrid-Gym Paper](https://arxiv.org/abs/2602.16819v1) -- "Hybrid-Gym: Training Coding Agents to Generalize Across Tasks"
+- [Hybrid-Gym GitHub](https://github.com/Hybrid-Gym/Hybrid-Gym)

--- a/benchmarks/hybridgym_funclocalize/__init__.py
+++ b/benchmarks/hybridgym_funclocalize/__init__.py
@@ -1,0 +1,1 @@
+"""Hybrid-Gym func_localize benchmark evaluation."""

--- a/benchmarks/hybridgym_funclocalize/config.py
+++ b/benchmarks/hybridgym_funclocalize/config.py
@@ -1,0 +1,26 @@
+"""
+Hybrid-Gym func_localize benchmark configuration.
+
+Task: Agent must locate a function/class by its description (no file path given)
+and add a docstring to it.
+
+Dataset: hybrid-gym/hybrid_gym_func_localize on HuggingFace.
+"""
+
+# Condenser configuration
+CONDENSER_DEFAULTS = {
+    "enable_condenser": False,
+    "condenser_max_size": 240,
+    "condenser_keep_first": 2,
+}
+
+# Inference defaults (used by run_infer.py)
+INFER_DEFAULTS = {
+    "dataset": "hybrid-gym/hybrid_gym_func_localize",
+    "split": "train",
+    "max_iterations": 30,
+    "tool_preset": "default",
+    "num_workers": 16,
+    "n_critic_runs": 1,
+    **CONDENSER_DEFAULTS,
+}

--- a/benchmarks/hybridgym_funclocalize/eval_infer.py
+++ b/benchmarks/hybridgym_funclocalize/eval_infer.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+Hybrid-Gym func_localize evaluation script.
+
+Reads output.jsonl from run_infer.py, loads the ground truth dataset,
+and evaluates whether the agent:
+  1. Added a docstring within the target function/class line range
+  2. Made only comment/docstring changes (no code modifications)
+
+Usage:
+    uv run hybridgym-funclocalize-eval output.jsonl --run-id my_run
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from datasets import load_dataset
+
+from benchmarks.utils.laminar import LaminarService
+from benchmarks.utils.report_costs import generate_cost_report
+from openhands.sdk import get_logger
+
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Patch parsing utilities
+# ---------------------------------------------------------------------------
+
+
+def patch2file_paths(patch: str) -> set[str]:
+    """Extract all modified file paths from a git patch."""
+    file_paths: set[str] = set()
+    for line in patch.split("\n"):
+        if line.startswith("diff --git"):
+            parts = line.split()
+            if len(parts) >= 4:
+                file_paths.add(parts[2][2:])  # strip 'a/' prefix
+    return file_paths
+
+
+def parse_git_patch(patch_text: str) -> list[dict]:
+    """Parse a git patch into per-file added/removed lines."""
+    lines = patch_text.split("\n")
+    files: list[dict] = []
+    current_file = None
+    added_lines: list[str] = []
+    removed_lines: list[str] = []
+    file_pattern = re.compile(r"^diff --git a/(.+) b/(.+)$")
+
+    for line in lines:
+        if line.startswith("diff --git"):
+            if current_file is not None:
+                files.append(
+                    {
+                        "filename": current_file,
+                        "added_lines": added_lines,
+                        "removed_lines": removed_lines,
+                    }
+                )
+            current_file = None
+            added_lines = []
+            removed_lines = []
+            match = file_pattern.match(line)
+            if match:
+                current_file = match.group(2)
+        elif (
+            line.startswith("+")
+            and not line.startswith("+++")
+            and current_file is not None
+        ):
+            content = line[1:].strip()
+            if content:
+                added_lines.append(content)
+        elif (
+            line.startswith("-")
+            and not line.startswith("---")
+            and current_file is not None
+        ):
+            content = line[1:].strip()
+            if content:
+                removed_lines.append(content)
+
+    if current_file is not None:
+        files.append(
+            {
+                "filename": current_file,
+                "added_lines": added_lines,
+                "removed_lines": removed_lines,
+            }
+        )
+    return files
+
+
+def parse_hunk_line_numbers(patch_text: str) -> list[dict]:
+    """Parse a git patch and extract line numbers where content was added."""
+    lines = patch_text.split("\n")
+    files: list[dict] = []
+    current_file = None
+    added_line_numbers: list[int] = []
+    hunk_pattern = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+    file_pattern = re.compile(r"^diff --git a/(.+) b/(.+)$")
+    current_line = 0
+
+    for line in lines:
+        if line.startswith("diff --git"):
+            if current_file is not None:
+                files.append(
+                    {"filename": current_file, "added_line_numbers": added_line_numbers}
+                )
+            current_file = None
+            added_line_numbers = []
+            match = file_pattern.match(line)
+            if match:
+                current_file = match.group(2)
+        elif line.startswith("@@"):
+            match = hunk_pattern.match(line)
+            if match:
+                current_line = int(match.group(1))
+        elif line.startswith("+") and not line.startswith("+++"):
+            added_line_numbers.append(current_line)
+            current_line += 1
+        elif (
+            not line.startswith("-")
+            and not line.startswith("---")
+            and current_file is not None
+        ):
+            if line.startswith(" ") or (
+                line and not line.startswith(("diff", "@@", "index", "---", "+++"))
+            ):
+                current_line += 1
+
+    if current_file is not None:
+        files.append(
+            {"filename": current_file, "added_line_numbers": added_line_numbers}
+        )
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Comment / docstring detection
+# ---------------------------------------------------------------------------
+
+
+def is_lines_comment_only(lines: list[str]) -> bool:
+    """Return True if every line is a comment, docstring, or whitespace."""
+    if not lines:
+        return True
+    in_docstring = False
+    docstring_char = None
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if in_docstring:
+            if docstring_char and docstring_char in stripped:
+                if (
+                    stripped.endswith(docstring_char)
+                    or stripped.count(docstring_char) % 2 == 1
+                ):
+                    in_docstring = False
+                    docstring_char = None
+            continue
+        if stripped.startswith("#"):
+            continue
+        for quote in ['"""', "'''"]:
+            if stripped.startswith(quote):
+                if stripped.count(quote) >= 2:
+                    after_first = stripped[3:]
+                    if quote in after_first:
+                        break  # single-line docstring
+                    else:
+                        in_docstring = True
+                        docstring_char = quote
+                        break
+                else:
+                    in_docstring = True
+                    docstring_char = quote
+                    break
+        else:
+            if not in_docstring:
+                return False
+    return True
+
+
+def check_add_comments_only(patch_dict: dict) -> bool:
+    """True if the patch only adds comments/docstrings and removes nothing."""
+    if patch_dict["removed_lines"]:
+        return False
+    return is_lines_comment_only(patch_dict["added_lines"])
+
+
+# ---------------------------------------------------------------------------
+# Instance-level evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_instance(instance_data: dict, output_data: dict) -> dict:
+    """Evaluate a single instance.
+
+    Success = target_docstring_edited AND comments_only.
+    """
+    history = output_data.get("history") or []
+    result = {
+        "instance_id": output_data.get("instance_id"),
+        "num_steps": len(history),
+        "target_docstring_edited": False,
+        "comments_only": False,
+        "success": False,
+    }
+
+    git_patch = output_data.get("test_result", {}).get("git_patch", "")
+    if not git_patch:
+        return result
+
+    patch_dicts = parse_git_patch(git_patch)
+    line_info = parse_hunk_line_numbers(git_patch)
+
+    # Determine targets
+    if "functions" in instance_data and instance_data["functions"]:
+        targets = instance_data["functions"]
+    else:
+        targets = [
+            {
+                "file_path": instance_data.get("file_path"),
+                "module_line_start": instance_data.get("module_line_start"),
+                "module_line_end": instance_data.get("module_line_end"),
+            }
+        ]
+
+    # Check all changes are comments/docstrings only
+    all_comments = all(check_add_comments_only(pd) for pd in patch_dicts)
+    result["comments_only"] = all_comments
+
+    # Check target function had a docstring added within its line range
+    target_edited = False
+    for file_info in line_info:
+        for target in targets:
+            if target.get("file_path") == file_info["filename"]:
+                raw_start = target.get("module_line_start")
+                raw_end = target.get("module_line_end")
+                if raw_start is None or raw_end is None:
+                    continue
+                start = int(raw_start) + 1  # 0-indexed → 1-indexed
+                end = int(raw_end) + 1
+                if any(start <= ln <= end for ln in file_info["added_line_numbers"]):
+                    target_edited = True
+                    break
+        if target_edited:
+            break
+
+    result["target_docstring_edited"] = target_edited
+    result["success"] = target_edited and all_comments
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def generate_report(
+    input_file: str,
+    output_file: str,
+    dataset_name: str,
+    split: str,
+) -> None:
+    """Generate evaluation report from output.jsonl + ground truth."""
+    # Load ground truth
+    instance_id2data: dict[str, dict] = {}
+    if dataset_name.endswith((".jsonl", ".json")):
+        with open(dataset_name) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    data = json.loads(line)
+                    instance_id2data[data["instance_id"]] = data
+    else:
+        dataset = load_dataset(dataset_name, split=split)
+        for row in dataset:  # type: ignore[union-attr]
+            row_dict = dict(row)  # type: ignore[call-overload]
+            instance_id2data[row_dict["instance_id"]] = row_dict
+    logger.info("Loaded %d ground truth instances", len(instance_id2data))
+
+    # Evaluate
+    results: list[dict] = []
+    resolved_ids: list[str] = []
+    unresolved_ids: list[str] = []
+    error_ids: list[str] = []
+    empty_patch_ids: list[str] = []
+
+    with open(input_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            output_data = json.loads(line)
+            iid = output_data.get("instance_id", "")
+
+            if output_data.get("error"):
+                error_ids.append(iid)
+                continue
+
+            git_patch = output_data.get("test_result", {}).get("git_patch", "")
+            if not git_patch.strip():
+                empty_patch_ids.append(iid)
+                continue
+
+            if iid not in instance_id2data:
+                logger.warning("instance_id %s not found in ground truth", iid)
+                unresolved_ids.append(iid)
+                continue
+
+            eval_result = evaluate_instance(instance_id2data[iid], output_data)
+            results.append(eval_result)
+            if eval_result["success"]:
+                resolved_ids.append(iid)
+            else:
+                unresolved_ids.append(iid)
+
+    submitted_ids = resolved_ids + unresolved_ids + error_ids + empty_patch_ids
+    report = {
+        "schema_version": 2,
+        "total_instances": len(submitted_ids),
+        "submitted_instances": len(submitted_ids),
+        "submitted_ids": submitted_ids,
+        "completed_instances": len(resolved_ids) + len(unresolved_ids),
+        "completed_ids": resolved_ids + unresolved_ids,
+        "resolved_instances": len(resolved_ids),
+        "resolved_ids": resolved_ids,
+        "unresolved_instances": len(unresolved_ids),
+        "unresolved_ids": unresolved_ids,
+        "error_instances": len(error_ids),
+        "error_ids": error_ids,
+        "empty_patch_instances": len(empty_patch_ids),
+        "empty_patch_ids": empty_patch_ids,
+        "incomplete_ids": error_ids + empty_patch_ids,
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(report, f, indent=2)
+
+    # Print summary
+    total = len(resolved_ids) + len(unresolved_ids)
+    target_edited = sum(1 for r in results if r["target_docstring_edited"])
+    comments_only = sum(1 for r in results if r["comments_only"])
+    logger.info("=== Evaluation Results ===")
+    logger.info("Total evaluated: %d", total)
+    logger.info(
+        "Resolved (success): %d/%d (%.1f%%)",
+        len(resolved_ids),
+        total,
+        100 * len(resolved_ids) / max(total, 1),
+    )
+    logger.info("Target docstring edited: %d/%d", target_edited, total)
+    logger.info("Comments only: %d/%d", comments_only, total)
+    logger.info("Empty patches: %d", len(empty_patch_ids))
+    logger.info("Errors: %d", len(error_ids))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate Hybrid-Gym func_localize outputs and generate report",
+    )
+    parser.add_argument("input_file", help="Path to output.jsonl from inference")
+    parser.add_argument("--run-id", required=True, help="Unique run identifier")
+    parser.add_argument(
+        "--dataset",
+        default="hybrid-gym/hybrid_gym_func_localize",
+        help="HuggingFace dataset name or local JSONL path for ground truth",
+    )
+    parser.add_argument("--split", default="train", help="Dataset split")
+    args = parser.parse_args()
+
+    input_path = Path(args.input_file)
+    if not input_path.exists():
+        logger.error("Input file does not exist: %s", input_path)
+        sys.exit(1)
+
+    report_path = input_path.with_suffix(".report.json")
+
+    try:
+        generate_report(
+            str(input_path),
+            str(report_path),
+            args.dataset,
+            args.split,
+        )
+        LaminarService.get().update_evaluation_scores(str(input_path), str(report_path))
+        generate_cost_report(str(input_path))
+        logger.info("Report saved to: %s", report_path)
+        print(json.dumps({"report_json": str(report_path)}))
+    except Exception as e:
+        logger.error("Evaluation failed: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybridgym_funclocalize/prompts/default.j2
+++ b/benchmarks/hybridgym_funclocalize/prompts/default.j2
@@ -1,0 +1,32 @@
+{% if is_multi %}
+I've uploaded a python code repository in the directory {{ workspace_dir_name }}.
+Your goal is to locate the following {{ num_targets }} targets (docstrings removed) and write docstrings for each:
+
+{{ target_list }}
+
+Follow these steps:
+1. EXPLORATION: Search the codebase (file paths not provided) to find where each target is defined.
+2. UNDERSTANDING: Read implementations to fully understand arguments, return values, and side effects.
+3. RECHECK: Verify that the function/class you located actually matches the given description. Compare the implementation behavior with the description to ensure you found the correct target.
+4. GENERATION: Insert a clear, concise Python docstring inside each definition using triple quotes. Cover purpose, parameters, return value(s), and important behaviors or exceptions.
+5. REVIEW: Double-check formatting and accuracy; avoid changing code outside the docstrings unless strictly necessary.
+{% else %}
+I've uploaded a python code repository in the directory {{ workspace_dir_name }}.
+Your goal is to locate the {{ module_type }} described below and write its docstring.
+
+<{{ module_type }}_description>
+{{ description }}
+</{{ module_type }}_description>
+
+Known details:
+- Target name: {{ target_name }}
+- The original docstring was removed; please restore/author it.
+
+Follow these steps:
+1. EXPLORATION: Search the codebase (no file path provided) to find where this {{ module_type }} is defined.
+2. UNDERSTANDING: Read the implementation to fully understand its arguments, return values, and side effects.
+3. RECHECK: Verify that the {{ module_type }} you located actually matches the given description. Compare the implementation behavior with the description to ensure you found the correct target.
+4. GENERATION: Insert a clear, concise Python docstring inside the definition using triple quotes. Cover purpose, parameters, return value(s), and important behaviors or exceptions.
+5. REVIEW: Double-check formatting and accuracy; avoid changing code outside the docstring unless strictly necessary.
+{% endif %}
+Be thorough in your exploration and reasoning. It's fine if your thinking process is lengthy - quality and completeness are more important than brevity.

--- a/benchmarks/hybridgym_funclocalize/run_infer.py
+++ b/benchmarks/hybridgym_funclocalize/run_infer.py
@@ -1,0 +1,427 @@
+"""Run inference for the Hybrid-Gym func_localize benchmark.
+
+Task: Agent must locate a function/class by description (no file path given)
+and add a docstring to it. Uses a generic python:3.11-bookworm image,
+cloning the repository at runtime.
+
+Dataset: hybrid-gym/hybrid_gym_func_localize on HuggingFace.
+"""
+
+import json
+import os
+from typing import Any, List
+
+from jinja2 import Environment, FileSystemLoader
+
+from benchmarks.hybridgym_funclocalize.config import INFER_DEFAULTS
+from benchmarks.utils.args_parser import add_prompt_path_argument, get_parser
+from benchmarks.utils.console_logging import summarize_instance
+from benchmarks.utils.constants import EVAL_AGENT_SERVER_IMAGE
+from benchmarks.utils.conversation import build_event_persistence_callback
+from benchmarks.utils.critics import create_critic
+from benchmarks.utils.dataset import get_dataset
+from benchmarks.utils.evaluation import Evaluation
+from benchmarks.utils.evaluation_utils import (
+    construct_eval_output_dir,
+    get_default_on_result_writer,
+)
+from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
+from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
+from benchmarks.utils.litellm_proxy import build_eval_llm
+from benchmarks.utils.llm_config import load_llm_config
+from benchmarks.utils.models import (
+    EvalInstance,
+    EvalMetadata,
+    EvalOutput,
+    ToolPresetType,
+)
+from benchmarks.utils.version import IMAGE_TAG_PREFIX
+from openhands.sdk import Agent, Conversation, Tool, get_logger
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.workspace import RemoteWorkspace
+from openhands.tools.delegate import DelegateTool
+from openhands.tools.preset.default import get_default_tools
+from openhands.workspace import APIRemoteWorkspace
+
+
+logger = get_logger(__name__)
+
+# Docker image for the workspace — generic Python, no specialized environment needed.
+BASE_DOCKER_IMAGE = "python:3.11-bookworm"
+
+
+def _get_workspace_dir_name(instance: dict) -> str:
+    """Derive workspace directory name from repo and base_commit."""
+    repo = instance["repo"]
+    commit = instance.get("base_commit", "latest")[:8]
+    return f"{repo}__{commit}".replace("/", "__")
+
+
+def _get_docstring_remove_command(instance: dict) -> str:
+    """Generate sed command(s) to remove existing docstrings before the agent runs."""
+    if "functions" in instance and instance["functions"]:
+        commands = []
+        for func in instance["functions"]:
+            start = func["docstring_line_start"]
+            end = func["docstring_line_end"]
+            if start != -1:
+                commands.append(f"sed -i '{start + 1},{end + 1}d' {func['file_path']}")
+        return " && ".join(commands) if commands else ""
+
+    start = instance.get("docstring_line_start", -1)
+    end = instance.get("docstring_line_end", -1)
+    file_path = instance.get("file_path", "")
+    if start != -1 and file_path:
+        return f"sed -i '{start + 1},{end + 1}d' {file_path}"
+    return ""
+
+
+def _format_targets(functions: list[dict]) -> str:
+    """Format a list of target functions for a multi-function prompt."""
+    lines = []
+    for idx, func in enumerate(functions, start=1):
+        name = func.get("module_name", "<unknown>")
+        kind = func.get("module_type", "function")
+        entry = f"{idx}. {name} ({kind})"
+        desc = func.get("function_description")
+        if desc:
+            entry += f"\n   Description: {desc}"
+        lines.append(entry)
+    return "\n".join(lines)
+
+
+def get_instruction(instance: dict, metadata: EvalMetadata, workspace_path: str) -> str:
+    """Generate the task instruction for the agent."""
+    workspace_dir_name = instance.get(
+        "_workspace_dir_name", _get_workspace_dir_name(instance)
+    )
+
+    assert metadata.prompt_path is not None
+    prompts_dir = os.path.dirname(metadata.prompt_path)
+    template_name = os.path.basename(metadata.prompt_path)
+    env = Environment(loader=FileSystemLoader(prompts_dir))
+    template = env.get_template(template_name)
+
+    # Multi-function instances carry a 'functions' list; single-function
+    # instances describe one target via top-level fields.
+    functions = instance.get("functions")
+    is_multi = bool(functions)
+
+    description = (
+        instance.get("brief_description")
+        or instance.get("function_description")
+        or instance.get("description")
+        or "No description provided."
+    )
+
+    context = {
+        "instance": instance,
+        "workspace_dir_name": workspace_dir_name,
+        "actual_workspace_path": workspace_path,
+        "module_type": instance.get("module_type", "function"),
+        "description": description,
+        "target_name": instance.get("module_name", "<unknown>"),
+        "metadata": metadata,
+        # Multi-function fields
+        "is_multi": is_multi,
+        "num_targets": len(functions) if is_multi else 1,
+        "target_list": _format_targets(functions) if is_multi else "",
+    }
+
+    return template.render(context)
+
+
+class FuncLocalizeEvaluation(Evaluation):
+    """
+    Hybrid-Gym func_localize evaluation implemented as a child of the
+    abstract Evaluation orchestrator.
+
+    Implements:
+      - prepare_instances()
+      - prepare_workspace(instance)
+      - evaluate_instance(instance, workspace)
+    """
+
+    def prepare_instances(self) -> List[EvalInstance]:
+        logger.info("Setting up func_localize evaluation data")
+
+        df = get_dataset(
+            dataset_name=self.metadata.dataset,
+            split=self.metadata.dataset_split,
+            eval_limit=self.metadata.eval_limit,
+            selected_instances_file=self.metadata.selected_instances_file,
+        )
+
+        instances: List[EvalInstance] = []
+        for _, row in df.iterrows():
+            inst_id = str(row["instance_id"])
+            instances.append(EvalInstance(id=inst_id, data=row.to_dict()))
+
+        logger.info("Total instances to process: %d", len(instances))
+        return instances
+
+    def prepare_workspace(
+        self,
+        instance: EvalInstance,
+        resource_factor: int = 1,
+        forward_env: list[str] | None = None,
+    ) -> RemoteWorkspace:
+        """Create a generic Docker workspace; clone repo at runtime."""
+        agent_server_image = f"{EVAL_AGENT_SERVER_IMAGE}:{IMAGE_TAG_PREFIX}-hybridgym-funclocalize-binary"
+
+        if self.metadata.workspace_type == "docker":
+            workspace = create_docker_workspace(
+                agent_server_image=agent_server_image,
+                base_image=BASE_DOCKER_IMAGE,
+                build_target="binary",
+                forward_env=forward_env or [],
+            )
+        elif self.metadata.workspace_type == "remote":
+            runtime_api_key = os.getenv("RUNTIME_API_KEY")
+            if not runtime_api_key:
+                raise ValueError(
+                    "RUNTIME_API_KEY environment variable is not set for remote workspace"
+                )
+            if not remote_image_exists(agent_server_image):
+                raise RuntimeError(
+                    f"Agent server image {agent_server_image} does not exist in container registry."
+                )
+            startup_timeout = float(os.getenv("REMOTE_RUNTIME_STARTUP_TIMEOUT", "600"))
+            workspace = APIRemoteWorkspace(
+                runtime_api_url=os.getenv(
+                    "RUNTIME_API_URL", "https://runtime.eval.all-hands.dev"
+                ),
+                runtime_api_key=runtime_api_key,
+                server_image=agent_server_image,
+                target_type="binary",
+                resource_factor=resource_factor,
+                forward_env=forward_env or [],
+                init_timeout=startup_timeout,
+                startup_wait_timeout=startup_timeout,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported workspace_type: {self.metadata.workspace_type}"
+            )
+
+        return workspace
+
+    def evaluate_instance(
+        self, instance: EvalInstance, workspace: RemoteWorkspace
+    ) -> EvalOutput:
+        """Clone repo, remove docstrings, run agent, collect patch."""
+        agent_llm = build_eval_llm(self.metadata.llm)
+        tools = self._get_tools(preset=self.metadata.tool_preset)
+        if self.metadata.enable_delegation:
+            tools.append(Tool(name=DelegateTool.name))
+        condenser = None
+        if self.metadata.enable_condenser:
+            condenser = LLMSummarizingCondenser(
+                llm=build_eval_llm(self.metadata.llm, usage_id="condenser"),
+                max_size=self.metadata.condenser_max_size,
+                keep_first=self.metadata.condenser_keep_first,
+            )
+        agent = Agent(
+            llm=agent_llm,
+            tools=tools,
+            system_prompt_kwargs={"cli_mode": True},
+            condenser=condenser,
+        )
+
+        assert isinstance(workspace, RemoteWorkspace)
+
+        # --- Workspace initialization ---
+        workspace_dir_name = _get_workspace_dir_name(instance.data)
+        instance.data["_workspace_dir_name"] = workspace_dir_name
+        repo_path = f"/workspace/{workspace_dir_name}"
+
+        # Clone repository
+        res = workspace.execute_command(
+            f"git clone https://github.com/{instance.data['repo']}.git {repo_path}"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to clone repo: {res.stderr}")
+
+        # Checkout base commit
+        res = workspace.execute_command(
+            f"cd {repo_path} && git checkout {instance.data['base_commit']} && git reset --hard"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to checkout base commit: {res.stderr}")
+
+        # Remove git remotes
+        workspace.execute_command(
+            f"cd {repo_path} && for r in $(git remote); do git remote remove $r; done"
+        )
+
+        # Remove existing docstrings
+        remove_cmd = _get_docstring_remove_command(instance.data)
+        if remove_cmd:
+            res = workspace.execute_command(f"cd {repo_path} && {remove_cmd}")
+            if res.exit_code != 0:
+                raise RuntimeError(f"Failed to remove docstrings: {res.stderr}")
+
+        # Re-init git to track agent changes from a clean slate
+        workspace.execute_command(f"cd {repo_path} && rm -rf .git")
+        res = workspace.execute_command(
+            f"cd {repo_path} && git init . && git add -A && "
+            f"git config user.email 'eval@openhands.dev' && "
+            f"git config user.name 'OpenHands Eval' && "
+            f"git commit -m 'Initial commit'"
+        )
+        if res.exit_code != 0:
+            logger.warning("Git re-init failed: %s", res.stderr)
+
+        # Capture new HEAD as base_commit for later diff
+        head_res = workspace.execute_command(f"cd {repo_path} && git rev-parse HEAD")
+        if head_res.exit_code == 0:
+            instance.data["base_commit"] = head_res.stdout.strip()
+            logger.info("Captured base_commit: %s", instance.data["base_commit"])
+
+        # --- Run agent ---
+        persist_callback = build_event_persistence_callback(
+            run_id=self.metadata.eval_output_dir,
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+        )
+
+        conversation = Conversation(
+            agent=agent,
+            workspace=workspace,
+            callbacks=[persist_callback],
+            max_iteration_per_run=self.metadata.max_iterations,
+            delete_on_close=True,
+        )
+
+        instruction = get_instruction(
+            instance=instance.data,
+            metadata=self.metadata,
+            workspace_path=workspace.working_dir,
+        )
+        conversation.send_message(instruction)
+        run_conversation_with_fake_user_response(conversation)
+
+        # --- Extract git patch ---
+        workspace.execute_command(f"cd {repo_path} && git add -A")
+
+        # Commit agent changes (may fail if no changes, that's ok)
+        workspace.execute_command(
+            f"cd {repo_path} && git commit --no-verify -m 'Agent changes' || true"
+        )
+
+        base_commit = instance.data["base_commit"]
+        logger.info("Extracting git patch: base_commit=%s", base_commit)
+
+        git_patch_result = workspace.execute_command(
+            f"cd {repo_path} && git --no-pager diff --no-color {base_commit} HEAD"
+        )
+        if git_patch_result.exit_code != 0:
+            logger.warning(
+                "git diff failed (exit=%d): %s",
+                git_patch_result.exit_code,
+                git_patch_result.stderr,
+            )
+        git_patch = git_patch_result.stdout if git_patch_result.exit_code == 0 else ""
+        logger.info("Git patch length: %d chars", len(git_patch))
+
+        summarize_instance(
+            instance_id=instance.id,
+            conversation=conversation,
+            git_patch=git_patch,
+            logger=logger,
+        )
+
+        test_result: dict[str, Any] = {
+            "git_patch": git_patch,
+        }
+
+        return EvalOutput(
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+            test_result=test_result,
+            instruction=instruction,
+            error=None,
+            history=list(conversation.state.events),
+            metrics=conversation.conversation_stats.get_combined_metrics(),
+        )
+
+    def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
+        """Get tools for the given preset."""
+        if preset == "gemini":
+            from openhands.tools.preset.gemini import get_gemini_tools
+
+            return get_gemini_tools(enable_browser=False)
+        elif preset == "planning":
+            from openhands.tools.preset.planning import get_planning_tools
+
+            return get_planning_tools()
+        else:
+            return get_default_tools(enable_browser=False)
+
+
+def main() -> None:
+    parser = get_parser()
+    add_prompt_path_argument(parser, __file__)
+    parser.set_defaults(**INFER_DEFAULTS)
+    args = parser.parse_args()
+
+    if args.n_critic_runs < 1:
+        raise ValueError(f"n_critic_runs must be >= 1, got {args.n_critic_runs}")
+
+    llm = load_llm_config(args.llm_config_path)
+    logger.info("Using LLM config: %s", llm.model_dump_json(indent=2))
+
+    dataset_description = (
+        args.dataset.replace("/", "__") + "-" + args.split.replace("/", "__")
+    )
+
+    structured_output_dir = construct_eval_output_dir(
+        base_dir=args.output_dir,
+        dataset_name=dataset_description,
+        model_name=llm.model,
+        max_iterations=args.max_iterations,
+        eval_note=args.note,
+    )
+
+    critic = create_critic(args)
+
+    # --disable-condenser takes precedence over --enable-condenser and defaults
+    enable_condenser = args.enable_condenser
+    if args.disable_condenser:
+        enable_condenser = False
+
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset=args.dataset,
+        dataset_split=args.split,
+        max_iterations=args.max_iterations,
+        eval_output_dir=structured_output_dir,
+        details={},
+        prompt_path=args.prompt_path,
+        eval_limit=args.n_limit,
+        n_critic_runs=args.n_critic_runs,
+        critic=critic,
+        selected_instances_file=args.select,
+        max_retries=args.max_retries,
+        workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
+        enable_delegation=args.enable_delegation,
+        agent_type=args.agent_type,
+        enable_condenser=enable_condenser,
+        condenser_max_size=args.condenser_max_size,
+        condenser_keep_first=args.condenser_keep_first,
+    )
+
+    evaluator = FuncLocalizeEvaluation(
+        metadata=metadata,
+        num_workers=args.num_workers,
+    )
+
+    evaluator.run(on_result=get_default_on_result_writer(evaluator.output_path))
+
+    logger.info("Evaluation completed!")
+    print(json.dumps({"output_json": str(evaluator.output_path)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybridgym_issuelocalize/README.md
+++ b/benchmarks/hybridgym_issuelocalize/README.md
@@ -1,0 +1,47 @@
+# Hybrid-Gym issue_localize Evaluation
+
+This module integrates the **issue_localize** benchmark from [Hybrid-Gym](https://github.com/Hybrid-Gym/Hybrid-Gym). Given a GitHub issue description, the agent must locate relevant code in the repository and add comments explaining why each location is related to the issue.
+
+## Overview
+
+Each instance provides:
+- A Python repository (cloned at runtime from GitHub)
+- A GitHub issue description (problem statement)
+- A gold patch indicating which files need modification
+
+The agent must explore the codebase, identify files related to the issue, and add comments at relevant locations. Success requires touching at least one file from the gold patch while making only comment changes.
+
+## Usage
+
+### Running Inference
+
+```bash
+uv run hybridgym-issuelocalize-infer .llm_config/config.json
+uv run hybridgym-issuelocalize-infer .llm_config/config.json --n-limit 5
+uv run hybridgym-issuelocalize-infer .llm_config/config.json --workspace docker
+```
+
+### Evaluating Results
+
+```bash
+uv run hybridgym-issuelocalize-eval ./eval_outputs/.../output.jsonl --run-id my_run
+```
+
+## Dataset
+
+- **HuggingFace**: [`SWE-Gym/SWE-Gym-Raw`](https://huggingface.co/datasets/SWE-Gym/SWE-Gym-Raw)
+- **Default split**: `train`
+
+## Evaluation Criteria
+
+An instance is marked **resolved** when both conditions are met:
+
+| Criterion | Description |
+|-----------|-------------|
+| `localization` | At least one file from the gold patch was touched by the agent |
+| `comments_only` | All changes are comments only (no code modifications); inline comments appended to existing lines are allowed |
+
+## References
+
+- [Hybrid-Gym Paper](https://arxiv.org/abs/2602.16819v1) -- "Hybrid-Gym: Training Coding Agents to Generalize Across Tasks"
+- [Hybrid-Gym GitHub](https://github.com/Hybrid-Gym/Hybrid-Gym)

--- a/benchmarks/hybridgym_issuelocalize/__init__.py
+++ b/benchmarks/hybridgym_issuelocalize/__init__.py
@@ -1,0 +1,1 @@
+"""Hybrid-Gym issue_localize benchmark evaluation."""

--- a/benchmarks/hybridgym_issuelocalize/config.py
+++ b/benchmarks/hybridgym_issuelocalize/config.py
@@ -1,0 +1,24 @@
+"""
+Hybrid-Gym issue_localize benchmark configuration.
+
+Task: Agent must locate code related to a GitHub issue and add comments
+explaining why each location is relevant.
+
+Dataset: SWE-Gym/SWE-Gym-Raw on HuggingFace.
+"""
+
+CONDENSER_DEFAULTS = {
+    "enable_condenser": False,
+    "condenser_max_size": 240,
+    "condenser_keep_first": 2,
+}
+
+INFER_DEFAULTS = {
+    "dataset": "SWE-Gym/SWE-Gym-Raw",
+    "split": "train",
+    "max_iterations": 30,
+    "tool_preset": "default",
+    "num_workers": 16,
+    "n_critic_runs": 1,
+    **CONDENSER_DEFAULTS,
+}

--- a/benchmarks/hybridgym_issuelocalize/eval_infer.py
+++ b/benchmarks/hybridgym_issuelocalize/eval_infer.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Hybrid-Gym issue_localize evaluation script.
+
+Reads output.jsonl from run_infer.py and evaluates whether the agent
+correctly localized files related to the issue. Success requires:
+  1. At least one gold-patch file was touched by the agent's patch
+  2. All changes are comments only (no code modifications)
+
+Usage:
+    uv run hybridgym-issuelocalize-eval output.jsonl --run-id my_run
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from benchmarks.utils.laminar import LaminarService
+from benchmarks.utils.report_costs import generate_cost_report
+from openhands.sdk import get_logger
+
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Patch parsing
+# ---------------------------------------------------------------------------
+
+
+def patch2file_paths(patch: str) -> set[str]:
+    file_paths: set[str] = set()
+    for line in patch.split("\n"):
+        if line.startswith("diff --git"):
+            parts = line.split()
+            if len(parts) >= 4:
+                file_paths.add(parts[2][2:])
+    return file_paths
+
+
+def parse_git_patch(patch_text: str) -> list[dict]:
+    lines = patch_text.split("\n")
+    files: list[dict] = []
+    current_file = None
+    added_lines: list[str] = []
+    removed_lines: list[str] = []
+    is_new_file = False
+    file_pattern = re.compile(r"^diff --git a/(.+) b/(.+)$")
+
+    for line in lines:
+        if line.startswith("diff --git"):
+            if current_file is not None:
+                files.append(
+                    {
+                        "filename": current_file,
+                        "added_lines": added_lines,
+                        "removed_lines": removed_lines,
+                        "is_new_file": is_new_file,
+                    }
+                )
+            current_file = None
+            added_lines = []
+            removed_lines = []
+            is_new_file = False
+            match = file_pattern.match(line)
+            if match:
+                current_file = match.group(2)
+        elif current_file is not None and line.startswith("new file mode"):
+            is_new_file = True
+        elif current_file is not None:
+            if line.startswith("+") and not line.startswith("+++"):
+                content = line[1:].strip()
+                if content:
+                    added_lines.append(content)
+            elif line.startswith("-") and not line.startswith("---"):
+                content = line[1:].strip()
+                if content:
+                    removed_lines.append(content)
+
+    if current_file is not None:
+        files.append(
+            {
+                "filename": current_file,
+                "added_lines": added_lines,
+                "removed_lines": removed_lines,
+                "is_new_file": is_new_file,
+            }
+        )
+    return files
+
+
+def check_add_comments_only(patch_dict: dict) -> bool:
+    """True if the patch only adds comments and doesn't modify code.
+
+    For new files, always returns True.
+    For existing files, allows:
+    - Pure comment additions (lines starting with #)
+    - Lines that match a removed line with an inline comment appended
+    """
+    if patch_dict["is_new_file"]:
+        return True
+
+    removed_stripped = {line.strip() for line in patch_dict["removed_lines"]}
+    matched_removed = set()
+
+    for line in patch_dict["added_lines"]:
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        if "#" in stripped:
+            code_part = stripped.split("#", 1)[0].strip()
+            if code_part in removed_stripped:
+                matched_removed.add(code_part)
+                continue
+        if stripped in removed_stripped:
+            matched_removed.add(stripped)
+            continue
+        return False
+
+    for line in patch_dict["removed_lines"]:
+        s = line.strip()
+        if s.startswith("#") or not s:
+            continue
+        if s not in matched_removed:
+            return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Instance evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_instance(output_data: dict) -> dict:
+    instance_id = output_data.get("instance_id", "")
+    instance = output_data.get("instance", {})
+    gold_patch = instance.get("patch", "")
+    gen_patch = output_data.get("test_result", {}).get("git_patch", "")
+
+    result = {
+        "instance_id": instance_id,
+        "localization": False,
+        "comments_only": False,
+        "success": False,
+    }
+
+    if not gen_patch.strip():
+        return result
+
+    gt_files = patch2file_paths(gold_patch)
+    patch_dicts = parse_git_patch(gen_patch)
+    gen_files = {pd["filename"] for pd in patch_dicts}
+
+    localization = len(gt_files & gen_files) > 0
+    comments_only = all(check_add_comments_only(pd) for pd in patch_dicts)
+
+    result["localization"] = localization
+    result["comments_only"] = comments_only
+    result["success"] = localization and comments_only
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def generate_report(input_file: str, output_file: str) -> None:
+    resolved_ids: list[str] = []
+    unresolved_ids: list[str] = []
+    error_ids: list[str] = []
+    empty_patch_ids: list[str] = []
+
+    with open(input_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            iid = data.get("instance_id", "")
+
+            if data.get("error"):
+                error_ids.append(iid)
+                continue
+
+            gen_patch = data.get("test_result", {}).get("git_patch", "")
+            if not gen_patch.strip():
+                empty_patch_ids.append(iid)
+                continue
+
+            r = evaluate_instance(data)
+            if r["success"]:
+                resolved_ids.append(iid)
+            else:
+                unresolved_ids.append(iid)
+
+    submitted_ids = resolved_ids + unresolved_ids + error_ids + empty_patch_ids
+    report = {
+        "schema_version": 2,
+        "total_instances": len(submitted_ids),
+        "submitted_instances": len(submitted_ids),
+        "resolved_instances": len(resolved_ids),
+        "resolved_ids": resolved_ids,
+        "unresolved_instances": len(unresolved_ids),
+        "unresolved_ids": unresolved_ids,
+        "error_instances": len(error_ids),
+        "error_ids": error_ids,
+        "empty_patch_instances": len(empty_patch_ids),
+        "empty_patch_ids": empty_patch_ids,
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(report, f, indent=2)
+
+    total = len(resolved_ids) + len(unresolved_ids)
+    logger.info("=== Evaluation Results ===")
+    logger.info("Total evaluated: %d", total)
+    logger.info(
+        "Resolved: %d/%d (%.1f%%)",
+        len(resolved_ids),
+        total,
+        100 * len(resolved_ids) / max(total, 1),
+    )
+    logger.info("Empty patches: %d  Errors: %d", len(empty_patch_ids), len(error_ids))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate Hybrid-Gym issue_localize outputs and generate report",
+    )
+    parser.add_argument("input_file", help="Path to output.jsonl from inference")
+    parser.add_argument("--run-id", required=True, help="Unique run identifier")
+    args = parser.parse_args()
+
+    input_path = Path(args.input_file)
+    if not input_path.exists():
+        logger.error("Input file does not exist: %s", input_path)
+        sys.exit(1)
+
+    report_path = input_path.with_suffix(".report.json")
+
+    try:
+        generate_report(str(input_path), str(report_path))
+        LaminarService.get().update_evaluation_scores(str(input_path), str(report_path))
+        generate_cost_report(str(input_path))
+        logger.info("Report saved to: %s", report_path)
+        print(json.dumps({"report_json": str(report_path)}))
+    except Exception as e:
+        logger.error("Evaluation failed: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hybridgym_issuelocalize/prompts/default.j2
+++ b/benchmarks/hybridgym_issuelocalize/prompts/default.j2
@@ -1,0 +1,39 @@
+I've uploaded a python code repository in the directory {{ workspace_dir_name }}. Consider the following issue description:
+
+<issue_description>
+{{ problem_statement }}
+</issue_description>
+
+Can you help me localize the code that causes the issue described in the <issue_description>?
+I've already taken care of all changes to the test files (if any) described in the <issue_description>. This means you DON'T have to modify the testing logic or any of the tests in any way!
+Your task is to localize the specific non-test files, classes or functions, and lines of code that need modification or contain key information to resolve the issue.
+
+Follow these phases to leave a comment at each corresponding location about why the code needs modification or is related to the issue:
+
+Phase 1. READING: read the problem and reword it in clearer terms
+   1.1 If there are code or config snippets. Express in words any best practices or conventions in them.
+   1.2 Hightlight message errors, method names, variables, file names, stack traces, and technical details.
+   1.3 Explain the problem in clear terms.
+   1.4 Enumerate the steps to reproduce the problem.
+   1.5 Hightlight any code that is related to the issue.
+
+Phase 2. EXPLORATION: find the non-test files that are related to the problem and possible solutions
+   2.1 Use `grep` to search for relevant methods, classes, keywords and error messages.
+   2.2 Identify all non-test files related to the problem statement.
+   2.3 Propose the methods and files to fix the issue and explain why.
+   2.4 From the possible file locations, select the most likely location to fix the issue.
+
+Phase 3. FIX ANALYSIS: state clearly the problem
+   3.1 State clearly what the problem is.
+   3.2 State clearly where the problem is located.
+   3.3 State clearly where to fix the problem and why.
+
+Phase 4. COMMENT GENERATION: leave a comment at each relevant location to explain why they are related to the issue
+   4.1 In each location related to the issue, leave a comment about why the code needs modification or contain key information to resolve the issue.
+   4.2 Just leave a comment. DO NOT modify the actual code in the repository.
+
+5. Output Format for Final Results:
+   5.1 Ensure you've left a comment on every location about why the code is related to the issue.
+   5.2 Ensure you have NOT modified the actual code in the repository.
+
+Be thorough in your exploration and reasoning. It's fine if your thinking process is lengthy - quality and completeness are more important than brevity.

--- a/benchmarks/hybridgym_issuelocalize/run_infer.py
+++ b/benchmarks/hybridgym_issuelocalize/run_infer.py
@@ -1,0 +1,335 @@
+"""Run inference for the Hybrid-Gym issue_localize benchmark.
+
+Task: Given a GitHub issue description, the agent must locate relevant code
+and add comments explaining why each location is related to the issue.
+
+Dataset: SWE-Gym/SWE-Gym-Raw on HuggingFace.
+"""
+
+import json
+import os
+from typing import Any, List
+
+from jinja2 import Environment, FileSystemLoader
+
+from benchmarks.hybridgym_issuelocalize.config import INFER_DEFAULTS
+from benchmarks.utils.args_parser import add_prompt_path_argument, get_parser
+from benchmarks.utils.console_logging import summarize_instance
+from benchmarks.utils.constants import EVAL_AGENT_SERVER_IMAGE
+from benchmarks.utils.conversation import build_event_persistence_callback
+from benchmarks.utils.critics import create_critic
+from benchmarks.utils.dataset import get_dataset
+from benchmarks.utils.evaluation import Evaluation
+from benchmarks.utils.evaluation_utils import (
+    construct_eval_output_dir,
+    get_default_on_result_writer,
+)
+from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_response
+from benchmarks.utils.image_utils import create_docker_workspace, remote_image_exists
+from benchmarks.utils.litellm_proxy import build_eval_llm
+from benchmarks.utils.llm_config import load_llm_config
+from benchmarks.utils.models import (
+    EvalInstance,
+    EvalMetadata,
+    EvalOutput,
+    ToolPresetType,
+)
+from benchmarks.utils.version import IMAGE_TAG_PREFIX
+from openhands.sdk import Agent, Conversation, Tool, get_logger
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.workspace import RemoteWorkspace
+from openhands.tools.delegate import DelegateTool
+from openhands.tools.preset.default import get_default_tools
+from openhands.workspace import APIRemoteWorkspace
+
+
+logger = get_logger(__name__)
+
+BASE_DOCKER_IMAGE = "python:3.11-bookworm"
+
+
+def _get_workspace_dir_name(instance: dict) -> str:
+    version = instance.get("version") or instance.get("pull_number", "latest")
+    return f"{instance['repo']}__{version}".replace("/", "__")
+
+
+def get_instruction(instance: dict, metadata: EvalMetadata, workspace_path: str) -> str:
+    workspace_dir_name = instance.get(
+        "_workspace_dir_name", _get_workspace_dir_name(instance)
+    )
+
+    assert metadata.prompt_path is not None
+    prompts_dir = os.path.dirname(metadata.prompt_path)
+    template_name = os.path.basename(metadata.prompt_path)
+    env = Environment(loader=FileSystemLoader(prompts_dir))
+    template = env.get_template(template_name)
+
+    context = {
+        "instance": instance,
+        "workspace_dir_name": workspace_dir_name,
+        "actual_workspace_path": workspace_path,
+        "problem_statement": instance.get("problem_statement", ""),
+        "metadata": metadata,
+    }
+
+    return template.render(context)
+
+
+class IssueLocalizeEvaluation(Evaluation):
+    """Hybrid-Gym issue_localize evaluation."""
+
+    def prepare_instances(self) -> List[EvalInstance]:
+        logger.info("Setting up issue_localize evaluation data")
+
+        df = get_dataset(
+            dataset_name=self.metadata.dataset,
+            split=self.metadata.dataset_split,
+            eval_limit=self.metadata.eval_limit,
+            selected_instances_file=self.metadata.selected_instances_file,
+        )
+
+        instances: List[EvalInstance] = []
+        for _, row in df.iterrows():
+            inst_id = str(row["instance_id"])
+            instances.append(EvalInstance(id=inst_id, data=row.to_dict()))
+
+        logger.info("Total instances to process: %d", len(instances))
+        return instances
+
+    def prepare_workspace(
+        self,
+        instance: EvalInstance,
+        resource_factor: int = 1,
+        forward_env: list[str] | None = None,
+    ) -> RemoteWorkspace:
+        agent_server_image = f"{EVAL_AGENT_SERVER_IMAGE}:{IMAGE_TAG_PREFIX}-hybridgym-issuelocalize-binary"
+
+        if self.metadata.workspace_type == "docker":
+            workspace = create_docker_workspace(
+                agent_server_image=agent_server_image,
+                base_image=BASE_DOCKER_IMAGE,
+                build_target="binary",
+                forward_env=forward_env or [],
+            )
+        elif self.metadata.workspace_type == "remote":
+            runtime_api_key = os.getenv("RUNTIME_API_KEY")
+            if not runtime_api_key:
+                raise ValueError(
+                    "RUNTIME_API_KEY environment variable is not set for remote workspace"
+                )
+            if not remote_image_exists(agent_server_image):
+                raise RuntimeError(
+                    f"Agent server image {agent_server_image} does not exist in container registry."
+                )
+            startup_timeout = float(os.getenv("REMOTE_RUNTIME_STARTUP_TIMEOUT", "600"))
+            workspace = APIRemoteWorkspace(
+                runtime_api_url=os.getenv(
+                    "RUNTIME_API_URL", "https://runtime.eval.all-hands.dev"
+                ),
+                runtime_api_key=runtime_api_key,
+                server_image=agent_server_image,
+                target_type="binary",
+                resource_factor=resource_factor,
+                forward_env=forward_env or [],
+                init_timeout=startup_timeout,
+                startup_wait_timeout=startup_timeout,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported workspace_type: {self.metadata.workspace_type}"
+            )
+
+        return workspace
+
+    def evaluate_instance(
+        self, instance: EvalInstance, workspace: RemoteWorkspace
+    ) -> EvalOutput:
+        agent_llm = build_eval_llm(self.metadata.llm)
+        tools = self._get_tools(preset=self.metadata.tool_preset)
+        if self.metadata.enable_delegation:
+            tools.append(Tool(name=DelegateTool.name))
+        condenser = None
+        if self.metadata.enable_condenser:
+            condenser = LLMSummarizingCondenser(
+                llm=build_eval_llm(self.metadata.llm, usage_id="condenser"),
+                max_size=self.metadata.condenser_max_size,
+                keep_first=self.metadata.condenser_keep_first,
+            )
+        agent = Agent(
+            llm=agent_llm,
+            tools=tools,
+            system_prompt_kwargs={"cli_mode": True},
+            condenser=condenser,
+        )
+
+        assert isinstance(workspace, RemoteWorkspace)
+
+        workspace_dir_name = _get_workspace_dir_name(instance.data)
+        instance.data["_workspace_dir_name"] = workspace_dir_name
+        repo_path = f"/workspace/{workspace_dir_name}"
+
+        # Clone and checkout
+        res = workspace.execute_command(
+            f"git clone https://github.com/{instance.data['repo']}.git {repo_path}"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to clone repo: {res.stderr}")
+
+        res = workspace.execute_command(
+            f"cd {repo_path} && git checkout {instance.data['base_commit']} && git reset --hard"
+        )
+        if res.exit_code != 0:
+            raise RuntimeError(f"Failed to checkout base commit: {res.stderr}")
+
+        workspace.execute_command(
+            f"cd {repo_path} && for r in $(git remote); do git remote remove $r; done"
+        )
+
+        # Re-init git
+        workspace.execute_command(f"cd {repo_path} && rm -rf .git")
+        res = workspace.execute_command(
+            f"cd {repo_path} && git init . && git add -A && "
+            f"git config user.email 'eval@openhands.dev' && "
+            f"git config user.name 'OpenHands Eval' && "
+            f"git commit -m 'Initial commit'"
+        )
+        if res.exit_code != 0:
+            logger.warning("Git re-init failed: %s", res.stderr)
+
+        head_res = workspace.execute_command(f"cd {repo_path} && git rev-parse HEAD")
+        if head_res.exit_code == 0:
+            instance.data["base_commit"] = head_res.stdout.strip()
+
+        # Run agent
+        persist_callback = build_event_persistence_callback(
+            run_id=self.metadata.eval_output_dir,
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+        )
+
+        conversation = Conversation(
+            agent=agent,
+            workspace=workspace,
+            callbacks=[persist_callback],
+            max_iteration_per_run=self.metadata.max_iterations,
+            delete_on_close=True,
+        )
+
+        instruction = get_instruction(
+            instance=instance.data,
+            metadata=self.metadata,
+            workspace_path=workspace.working_dir,
+        )
+        conversation.send_message(instruction)
+        run_conversation_with_fake_user_response(conversation)
+
+        # Extract patch
+        workspace.execute_command(f"cd {repo_path} && git add -A")
+        workspace.execute_command(
+            f"cd {repo_path} && git commit --no-verify -m 'Agent changes' || true"
+        )
+
+        base_commit = instance.data["base_commit"]
+        git_patch_result = workspace.execute_command(
+            f"cd {repo_path} && git --no-pager diff --no-color {base_commit} HEAD"
+        )
+        git_patch = git_patch_result.stdout if git_patch_result.exit_code == 0 else ""
+
+        summarize_instance(
+            instance_id=instance.id,
+            conversation=conversation,
+            git_patch=git_patch,
+            logger=logger,
+        )
+
+        test_result: dict[str, Any] = {"git_patch": git_patch}
+
+        return EvalOutput(
+            instance_id=instance.id,
+            attempt=self.current_attempt,
+            test_result=test_result,
+            instruction=instruction,
+            error=None,
+            history=list(conversation.state.events),
+            metrics=conversation.conversation_stats.get_combined_metrics(),
+        )
+
+    def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
+        """Get tools for the given preset."""
+        if preset == "gemini":
+            from openhands.tools.preset.gemini import get_gemini_tools
+
+            return get_gemini_tools(enable_browser=False)
+        elif preset == "planning":
+            from openhands.tools.preset.planning import get_planning_tools
+
+            return get_planning_tools()
+        else:
+            return get_default_tools(enable_browser=False)
+
+
+def main() -> None:
+    parser = get_parser()
+    add_prompt_path_argument(parser, __file__)
+    parser.set_defaults(**INFER_DEFAULTS)
+    args = parser.parse_args()
+
+    if args.n_critic_runs < 1:
+        raise ValueError(f"n_critic_runs must be >= 1, got {args.n_critic_runs}")
+
+    llm = load_llm_config(args.llm_config_path)
+    logger.info("Using LLM config: %s", llm.model_dump_json(indent=2))
+
+    dataset_description = (
+        args.dataset.replace("/", "__") + "-" + args.split.replace("/", "__")
+    )
+
+    structured_output_dir = construct_eval_output_dir(
+        base_dir=args.output_dir,
+        dataset_name=dataset_description,
+        model_name=llm.model,
+        max_iterations=args.max_iterations,
+        eval_note=args.note,
+    )
+
+    critic = create_critic(args)
+
+    enable_condenser = args.enable_condenser
+    if args.disable_condenser:
+        enable_condenser = False
+
+    metadata = EvalMetadata(
+        llm=llm,
+        dataset=args.dataset,
+        dataset_split=args.split,
+        max_iterations=args.max_iterations,
+        eval_output_dir=structured_output_dir,
+        details={},
+        prompt_path=args.prompt_path,
+        eval_limit=args.n_limit,
+        n_critic_runs=args.n_critic_runs,
+        critic=critic,
+        selected_instances_file=args.select,
+        max_retries=args.max_retries,
+        workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
+        enable_delegation=args.enable_delegation,
+        agent_type=args.agent_type,
+        enable_condenser=enable_condenser,
+        condenser_max_size=args.condenser_max_size,
+        condenser_keep_first=args.condenser_keep_first,
+    )
+
+    evaluator = IssueLocalizeEvaluation(
+        metadata=metadata,
+        num_workers=args.num_workers,
+    )
+
+    evaluator.run(on_result=get_default_on_result_writer(evaluator.output_path))
+
+    logger.info("Evaluation completed!")
+    print(json.dumps({"output_json": str(evaluator.output_path)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,14 @@ swebenchmultilingual-eval = "benchmarks.swebenchmultilingual.eval_infer:main"
 swefficiency-infer = "benchmarks.swefficiency.run_infer:main"
 terminalbench-infer = "benchmarks.terminalbench.run_infer:main"
 terminalbench-eval = "benchmarks.terminalbench.eval_infer:main"
+hybridgym-funclocalize-infer = "benchmarks.hybridgym_funclocalize.run_infer:main"
+hybridgym-funclocalize-eval = "benchmarks.hybridgym_funclocalize.eval_infer:main"
+hybridgym-depsearch-infer = "benchmarks.hybridgym_depsearch.run_infer:main"
+hybridgym-depsearch-eval = "benchmarks.hybridgym_depsearch.eval_infer:main"
+hybridgym-funcgen-infer = "benchmarks.hybridgym_funcgen.run_infer:main"
+hybridgym-funcgen-eval = "benchmarks.hybridgym_funcgen.eval_infer:main"
+hybridgym-issuelocalize-infer = "benchmarks.hybridgym_issuelocalize.run_infer:main"
+hybridgym-issuelocalize-eval = "benchmarks.hybridgym_issuelocalize.eval_infer:main"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,6 +12,7 @@ import importlib
 import inspect
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -298,6 +299,31 @@ def _get_test_instance_for_benchmark(benchmark_name: str) -> EvalInstance:
                 "problem_statement": "Test problem for swefficiency",
             },
         )
+    elif benchmark_name.startswith("hybridgym_"):
+        data: dict[str, Any] = {
+            "instance_id": "test-instance-1",
+            "repo": "test/repo",
+            "base_commit": "abc123",
+            "module_name": "test_func",
+            "module_type": "function",
+            "function_description": "A test function",
+            "module_line_start": 10,
+            "module_line_end": 20,
+            "docstring_line_start": -1,
+            "docstring_line_end": -1,
+            # depsearch fields
+            "target_function_name": "test_func",
+            "target_function_file": "test.py",
+            "target_function_line_start": 10,
+            # funcgen fields
+            "file_path": "test.py",
+            "func_name": "test_func",
+            "func_docstring_raw": "A test function",
+            # issuelocalize fields
+            "problem_statement": "Test issue",
+            "version": "1.0",
+        }
+        return EvalInstance(id="test-instance-1", data=data)
     else:
         # Generic instance for unknown benchmarks
         return EvalInstance(
@@ -438,6 +464,23 @@ def _create_metadata_for_benchmark(benchmark_name: str, llm: LLM) -> EvalMetadat
             dataset="swefficiency/swefficiency",
             dataset_split="test",
             details={"test": True},
+            prompt_path=prompt_path,
+            critic=PassCritic(),
+        )
+    elif benchmark_name.startswith("hybridgym_"):
+        prompt_path = str(
+            Path(__file__).parent.parent
+            / "benchmarks"
+            / benchmark_name
+            / "prompts"
+            / "default.j2"
+        )
+        return EvalMetadata(
+            llm=llm,
+            max_iterations=5,
+            eval_output_dir="/tmp/eval_output",
+            dataset=f"hybrid-gym/{benchmark_name}",
+            dataset_split="train",
             prompt_path=prompt_path,
             critic=PassCritic(),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1293,7 +1292,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1304,7 +1302,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1517,6 +1514,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -2401,7 +2403,7 @@ wheels = [
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "vendor/software-agent-sdk/openhands-agent-server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2543,7 +2545,7 @@ dev = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "vendor/software-agent-sdk/openhands-sdk" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2551,7 +2553,7 @@ dependencies = [
     { name = "fakeredis", extra = ["lua"] },
     { name = "fastmcp" },
     { name = "filelock" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "litellm" },
     { name = "lmnr" },
     { name = "pydantic" },
@@ -2574,7 +2576,7 @@ requires-dist = [
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.32.1" },
     { name = "fastmcp", specifier = ">=3.0.0" },
     { name = "filelock", specifier = ">=3.20.1" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "litellm", specifier = "==1.80.10" },
     { name = "lmnr", specifier = ">=0.7.24" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -2587,7 +2589,7 @@ provides-extras = ["boto3"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "vendor/software-agent-sdk/openhands-tools" }
 dependencies = [
     { name = "bashlex" },
@@ -2616,7 +2618,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-workspace"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "vendor/software-agent-sdk/openhands-workspace" }
 dependencies = [
     { name = "openhands-agent-server" },
@@ -6704,6 +6706,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add four **Hybrid-Gym** benchmarks (`hybridgym_funclocalize`, `hybridgym_depsearch`, `hybridgym_funcgen`, `hybridgym_issuelocalize`) from [Hybrid-Gym](https://github.com/Hybrid-Gym/Hybrid-Gym) ("Training Coding Agents to Generalize Across Tasks").
- **func_localize**: Agent locates a function/class by natural-language description and writes its (missing) docstring.
- **dep_search**: Agent analyzes a target function, traces its dependencies, and annotates each with a comment.
- **func_gen**: Agent implements a function body from its signature and docstring (body replaced with TODO stub).
- **issue_localize**: Agent reads a GitHub issue and adds comments at relevant code locations.
- The benchmarks use `python:3.11-bookworm` as the base image and clone the target repo at runtime. For docker workspace the agent server image is built on-the-fly; for remote workspace a single static image must be pre-built per benchmark (see below).
- **func_gen** evaluation additionally requires the `yiqingxyq/repost:v0` Docker image for running RepoST test scripts.
- Datasets on HuggingFace: [`hybrid-gym/hybrid_gym_func_localize`](https://huggingface.co/datasets/hybrid-gym/hybrid_gym_func_localize), [`hybrid-gym/hybrid_gym_dep_search`](https://huggingface.co/datasets/hybrid-gym/hybrid_gym_dep_search), [`hybrid-gym/hybrid_gym_func_gen`](https://huggingface.co/datasets/hybrid-gym/hybrid_gym_func_gen), [`SWE-Gym/SWE-Gym-Raw`](https://huggingface.co/datasets/SWE-Gym/SWE-Gym-Raw).
- Follows repo conventions: tool preset support, delegation support, LaminarService integration, standard `Evaluation` subclass pattern, module-level `get_default_tools` import.

## Remote workspace image
Each benchmark needs a single static agent server image (unlike swebench which needs per-instance images). After merge, build and push once per benchmark:

```bash
for BENCH in hybridgym-funclocalize hybridgym-depsearch hybridgym-funcgen hybridgym-issuelocalize; do
  IMAGE_TAG_PREFIX=<prefix> uv run python -c "
from benchmarks.utils.build_utils import build_image
build_image(base_image='python:3.11-bookworm', target_image='ghcr.io/openhands/eval-agent-server',
custom_tag='${BENCH}', target='binary', push=True)
"
done
```

Until then, users can build to their own registry (see each benchmark's README).

## Test plan
- [x] All pre-commit checks pass (ruff format, ruff lint, pyright strict) -- 0 errors across all 4 benchmarks
- [x] Full test suite passes: 337/337 tests including new hybridgym parametrized metrics tests
- [x] Smoke test passed (docker workspace, 1 instance): func_localize resolved 1/1
- [x] Remote workspace smoke test: pipeline runs end-to-end (infer + eval)
- [x] Imports verified clean (`run_infer` and `eval_infer` for all 4 benchmarks)
- [x] Follows repo conventions: tool preset support, delegation support, LaminarService integration, standard Evaluation subclass pattern
- [x] `test_metrics.py` updated with hybridgym-specific test instances and metadata
