### PR TITLE
add apptainer eval support for swe bench

### DIFF
--- a/benchmarks/swebench/README.md
+++ b/benchmarks/swebench/README.md
@@ -184,6 +184,39 @@ uv run swebench-infer .llm_config/sonnet-4-5.json \
 | **Cost** | Local compute only | API usage costs |
 | **Use Case** | Development, testing | Production benchmarks, research |
 
+### Apptainer Workspace for HPC Clusters
+
+#### Step 1: Build and push images using a separate machine with Docker support
+
+```bash
+uv run python -m benchmarks.swebench.build_images \
+  --dataset princeton-nlp/SWE-bench_Verified \
+  --split test \
+  --image ghcr.io/openhands/eval-agent-server \
+  --target source-minimal \
+  --push
+```
+
+The wrapper layer (`docutils<0.21`, `roman`) is applied in-place for allowlisted repos during this build pipeline (currently `sphinx-doc`).
+
+#### Step 2: Run on HPC with Apptainer
+
+**Optionally**, you can override the default location where Apptainer cache is saved using the below environment variables:
+
+```bash
+export APPTAINER_CACHEDIR=<desired path to directory> # ensure that this directory exists
+export APPTAINER_TMPDIR=<desired path to directory> # ensure that this directory exists
+```
+
+```bash
+uv run swebench-infer path/to/llm_config.json \
+    --dataset princeton-nlp/SWE-bench_Verified \
+    --split test \
+    --workspace apptainer
+```
+
+In `apptainer` mode, SWE-Bench uses pre-built registry images as-is and does not run local Docker builds.
+
 ## Evaluation
 
 After running inference (with either workspace type), evaluate the generated patches using the official SWE-Bench evaluation:

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -48,7 +48,7 @@ from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.delegate import DelegateTool
-from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
+from openhands.workspace import APIRemoteWorkspace, ApptainerWorkspace, DockerWorkspace
 
 
 logger = get_logger(__name__)
@@ -193,6 +193,28 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 working_dir="/workspace",
                 forward_env=forward_env or [],
+            )
+        elif self.metadata.workspace_type == "apptainer":
+            if not remote_image_exists(agent_server_image):
+                raise RuntimeError(
+                    f"Agent server image {agent_server_image} does not exist in container registry, "
+                    "make sure to build, push it, and make it public accessible before using apptainer workspace."
+                )
+
+            logger.info(
+                f"Using apptainer workspace with pre-built image {agent_server_image} "
+                f"(tag prefix: {get_phased_image_tag_prefix()})"
+            )
+            if wrap_needed:
+                logger.info(
+                    "Skipping local wrap for apptainer workspace; expecting image to be pre-wrapped in registry"
+                )
+
+            workspace = ApptainerWorkspace(
+                server_image=agent_server_image,
+                working_dir="/workspace",
+                forward_env=forward_env or [],
+                cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
             )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")

--- a/benchmarks/utils/args_parser.py
+++ b/benchmarks/utils/args_parser.py
@@ -41,7 +41,7 @@ def get_parser(add_llm_config: bool = True) -> argparse.ArgumentParser:
         "--workspace",
         type=str,
         default="remote",
-        choices=["docker", "remote"],
+        choices=["docker", "remote", "apptainer"],
         help="Type of workspace to use (default: remote)",
     )
     parser.add_argument(

--- a/benchmarks/utils/models.py
+++ b/benchmarks/utils/models.py
@@ -54,9 +54,9 @@ class EvalMetadata(BaseModel):
         ge=0,
         description="Maximum number of retries for instances that throw exceptions",
     )
-    workspace_type: Literal["docker", "remote"] = Field(
+    workspace_type: Literal["docker", "remote", "apptainer"] = Field(
         default="docker",
-        description="Type of workspace to use, e.g., 'docker' or 'remote'",
+        description="Type of workspace to use, e.g., 'docker', 'remote', or 'apptainer'",
     )
     base_resource_factor: int = Field(
         default=1,


### PR DESCRIPTION
This PR adds support to evaluate OpenHands on SWE-Bench with Apptainer runtimes - most HPCs don't support using docker but support apptainer and this PR allows running evals in such HPC clusters easily.