### PR TITLE
fix: drop Python-runtime COPY workaround, pin uv 0.11.6

### DIFF
--- a/benchmarks/utils/Dockerfile.agent-layer
+++ b/benchmarks/utils/Dockerfile.agent-layer
@@ -20,20 +20,9 @@ FROM ${BASE_IMAGE}
 ARG USERNAME=openhands
 ARG OPENHANDS_BUILD_GIT_SHA=unknown
 ENV OPENHANDS_BUILD_GIT_SHA=${OPENHANDS_BUILD_GIT_SHA}
-ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 
-# Copy the Python 3.13 runtime from the builder so the venv's symlinks resolve.
-# Since SDK v1.15.0 the builder venv uses --python-preference only-system,
-# meaning .venv/bin/python symlinks to /usr/local/bin/python3.13. The eval-base
-# image doesn't have Python 3.13, so we bring the interpreter and stdlib along.
-COPY --from=builder /usr/local/bin/python3.13 /usr/local/bin/python3.13
-COPY --from=builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
-COPY --from=builder /usr/local/lib/libpython3.13.so* /usr/local/lib/
-# The venv's python symlinks to /usr/local/bin/python3 (not python3.13),
-# so we need the python3 symlink to exist as well. Use COPY instead of
-# RUN ln because the base image may not be running as root.
-COPY --from=builder /usr/local/bin/python3 /usr/local/bin/python3
-ENV LD_LIBRARY_PATH=/usr/local/lib
-
+# /agent-server is self-contained: the SDK builder installs uv-managed Python
+# into /agent-server/uv-managed-python and the venv symlinks into it. No
+# downstream Python-runtime COPY is needed.
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server
 ENTRYPOINT ["/agent-server/.venv/bin/python", "-m", "openhands.agent_server"]

--- a/benchmarks/utils/Dockerfile.agent-layer-commit0
+++ b/benchmarks/utils/Dockerfile.agent-layer-commit0
@@ -1,7 +1,7 @@
 # Assembly Dockerfile for commit0 agent-server images.
 #
 # Commit0 base images are raw upstream benchmark images (e.g. Ubuntu 22.04)
-# that lack the runtime packages, user setup, and Python 3.13 that the SDK's
+# that lack the runtime packages and user setup that the SDK's
 # base-image-minimal target normally provides.  This Dockerfile layers those
 # onto the real upstream commit0 base before copying the agent-server payload.
 #
@@ -24,10 +24,9 @@ ARG UID=10001
 ARG GID=10001
 ARG OPENHANDS_BUILD_GIT_SHA=unknown
 ENV OPENHANDS_BUILD_GIT_SHA=${OPENHANDS_BUILD_GIT_SHA}
-ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 
 # Match the SDK minimal images by providing uv in the final container.
-COPY --from=ghcr.io/astral-sh/uv /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /bin/
 
 # Commit0 images are built from the raw upstream benchmark bases, so they are
 # missing the core runtime packages that the SDK's base-image-minimal target
@@ -87,19 +86,9 @@ ENV LANG=C.UTF-8
 ENV OH_ENABLE_VNC=false
 ENV LOG_JSON=true
 
-# Copy the Python 3.13 runtime from the builder so the venv's symlinks resolve.
-# Since SDK v1.15.0 the builder venv uses --python-preference only-system,
-# meaning .venv/bin/python symlinks to /usr/local/bin/python3.13. The eval-base
-# image doesn't have Python 3.13, so we bring the interpreter and stdlib along.
-COPY --from=builder /usr/local/bin/python3.13 /usr/local/bin/python3.13
-COPY --from=builder /usr/local/lib/python3.13 /usr/local/lib/python3.13
-COPY --from=builder /usr/local/lib/libpython3.13.so* /usr/local/lib/
-# The venv's python symlinks to /usr/local/bin/python3 (not python3.13),
-# so we need the python3 symlink to exist as well. Use COPY instead of
-# RUN ln because the base image may not be running as root.
-COPY --from=builder /usr/local/bin/python3 /usr/local/bin/python3
-ENV LD_LIBRARY_PATH=/usr/local/lib
-
+# /agent-server is self-contained: the SDK builder installs uv-managed Python
+# into /agent-server/uv-managed-python and the venv symlinks into it. No
+# downstream Python-runtime COPY is needed.
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server
 WORKDIR /
 USER ${USERNAME}

--- a/benchmarks/utils/Dockerfile.agent-layer-commit0
+++ b/benchmarks/utils/Dockerfile.agent-layer-commit0
@@ -25,8 +25,9 @@ ARG GID=10001
 ARG OPENHANDS_BUILD_GIT_SHA=unknown
 ENV OPENHANDS_BUILD_GIT_SHA=${OPENHANDS_BUILD_GIT_SHA}
 
-# Match the SDK minimal images by providing uv in the final container.
-COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /bin/
+# Reuse the same uv binary the SDK builder was built with, so the version
+# stays in sync automatically when the builder image is updated.
+COPY --from=builder /bin/uv /bin/uvx /bin/
 
 # Commit0 images are built from the raw upstream benchmark bases, so they are
 # missing the core runtime packages that the SDK's base-image-minimal target


### PR DESCRIPTION
## Summary

Remove the `COPY /usr/local/bin/python3.13` + `libpython3.13.so*` + stdlib workaround from `Dockerfile.agent-layer` and `Dockerfile.agent-layer-commit0`. The SDK builder now ships uv-managed python-build-standalone inside `/agent-server/uv-managed-python`, making `/agent-server` self-contained.

The commit0 Dockerfile now COPYs uv from the builder image instead of pinning a separate version, keeping them in sync automatically.

## Why

The workaround was introduced in #614 to paper over SDK v1.15.0's switch to `--python-preference only-system`. That made `.venv/bin/python` symlink to `/usr/local/bin/python3.13`, which doesn't exist on commit0's raw Ubuntu bases.

OpenHands/software-agent-sdk#2765 restores the self-contained `/agent-server` contract by switching back to uv-managed Python. The execstack issue that originally blocked this is fixed upstream in python-build-standalone 20260408 (pulled by uv >= 0.11.5).

## What changed

- `Dockerfile.agent-layer`: Remove 4 COPY lines + `LD_LIBRARY_PATH` + `UV_PYTHON_INSTALL_DIR` env (was 40 lines, now 29)
- `Dockerfile.agent-layer-commit0`: Same COPY removal + COPY uv from builder instead of hardcoding version (was 107 lines, now 96)
- `vendor/software-agent-sdk`: Bump to `fix/2761-uv-managed-python-simplified` HEAD

## :warning: This PR is blocked

**Do not merge** before OpenHands/software-agent-sdk#2765 merges and is released. If merged early, commit0 images will start with broken interpreter symlinks.

## Eval evidence

All runs used `sdk_ref=fix/2761-uv-managed-python-simplified` (SHA `f8481216`) + `benchmarks_branch=fix/2761-drop-workaround-simplified` (SHA `90677ab`), `eval_limit=5`, `claude-sonnet-4-5-20250929`.

| Benchmark | Agent | Eval Job | Status | Errors |
|-----------|-------|----------|--------|--------|
| **gaia** | default | [eval-24195874502](https://github.com/OpenHands/evaluation/actions/runs/24195874502) | ✅ Success | 0/5 |
| **gaia** | acp-claude | [eval-24195881440](https://github.com/OpenHands/evaluation/actions/runs/24195881440) | ✅ Success | 0/5 |
| **commit0** | default | [eval-24197261838](https://github.com/OpenHands/evaluation/actions/runs/24197261838) | ✅ Success | 0/5 |
| **commit0** | acp-claude | [eval-24195875909](https://github.com/OpenHands/evaluation/actions/runs/24195875909) | ✅ Success | 0/5 |
| **swebench** | default | [eval-24197261249](https://github.com/OpenHands/evaluation/actions/runs/24197261249) | ✅ Success | 0/5 |
| **swebench** | acp-claude | [eval-24197266112](https://github.com/OpenHands/evaluation/actions/runs/24197266112) | ✅ Success | 0/5 |

**6/6 runs, 30/30 conversations, 0 errors.** No execstack failures on either agent type.

## Test plan

- [x] Feature-branch eval at `eval_limit=5` on gaia, commit0, swebench — 0 errors (default agent)
- [x] Feature-branch eval at `eval_limit=5` on gaia, commit0, swebench — 0 errors (acp-claude agent)
- [x] `readlink -f /agent-server/.venv/bin/python` resolves into `/agent-server/uv-managed-python/` (verified via successful builds)

Refs OpenHands/software-agent-sdk#2761. Cleans up #614. Companion to OpenHands/software-agent-sdk#2765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)