### PR TITLE
ci: run GAIA image build on github runner

### DIFF
--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -32,8 +32,7 @@ jobs:
 
     timeout-minutes: 1440
 
-    runs-on:
-      labels: blacksmith-32vcpu-ubuntu-2204
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -69,7 +68,7 @@ jobs:
           echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
 
       - name: Set up Docker Buildx
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- move the GAIA image build workflow off Blacksmith onto standard `ubuntu-24.04`
- replace the Blacksmith Docker builder setup with `docker/setup-buildx-action@v4`

## Validation
- the same GAIA workflow change was already validated successfully in https://github.com/OpenHands/benchmarks/actions/runs/24205611222
- PR #652 is just that GAIA-specific subset extracted from the broader migration branch, so the validated GAIA diff is identical here
