### PR TITLE
ci: run commit0 image build on github runner

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -27,7 +27,7 @@ on:
       max-workers:
         description: 'Number of concurrent build workers'
         required: false
-        default: '16'
+        default: '4'
         type: string
       n-limit:
         description: 'Limit number of repos to build (for testing). Leave blank for no limit.'
@@ -59,7 +59,7 @@ env:
   DATASET: wentingzhao/commit0_combined
   SPLIT: test
   REPO_SPLIT: lite
-  MAX_WORKERS: '16'
+  MAX_WORKERS: '4'
   N_LIMIT: ''
   INSTANCE_IDS: ''
   SELECT_FILE: ''
@@ -76,8 +76,7 @@ jobs:
 
     timeout-minutes: 1440
 
-    runs-on:
-      labels: blacksmith-32vcpu-ubuntu-2204
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -130,8 +129,8 @@ jobs:
           git add vendor/software-agent-sdk
           echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
 
-      - name: Set up Docker Buildx with Blacksmith
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -343,7 +343,11 @@ def build_commit0_images(
             return 0
 
         logger.info("Using phased source-image assembly for commit0 target %s", target)
-        builder_result = build_builder_image(push=push, platform="linux/amd64")
+        builder_result = build_builder_image(
+            push=push,
+            platform="linux/amd64",
+            force_build=force_build,
+        )
         if builder_result.error or not builder_result.tags:
             logger.error("Failed to build shared SDK builder image: %s", builder_result)
             return 1

--- a/benchmarks/swebench/build_base_images.py
+++ b/benchmarks/swebench/build_base_images.py
@@ -418,6 +418,7 @@ def build_builder_image(
     builder_image: str = EVAL_BUILDER_IMAGE,
     push: bool = False,
     platform: str = "linux/amd64",
+    force_build: bool = False,
 ) -> BuildOutput:
     """Build and push the SDK builder image (Phase 0).
 
@@ -430,7 +431,7 @@ def build_builder_image(
     # For the builder, we use the builder_image repo name (not a Docker base image).
     build_id = builder_image
 
-    if remote_image_exists(tag):
+    if not force_build and remote_image_exists(tag):
         logger.info("Builder image %s already exists. Skipping.", tag)
         return BuildOutput(base_image=build_id, tags=[tag], error=None)
 

--- a/tests/test_commit0_run_infer.py
+++ b/tests/test_commit0_run_infer.py
@@ -37,8 +37,8 @@ def test_source_targets_use_phased_assembly(monkeypatch):
     builder_calls = []
     assemble_calls = []
 
-    def fake_builder_image(*, push, platform):
-        builder_calls.append((push, platform))
+    def fake_builder_image(*, push, platform, force_build):
+        builder_calls.append((push, platform, force_build))
         return SimpleNamespace(error=None, tags=["ghcr.io/example/builder:test"])
 
     def fake_assemble(**kwargs):
@@ -64,7 +64,7 @@ def test_source_targets_use_phased_assembly(monkeypatch):
     )
 
     assert exit_code == 0
-    assert builder_calls == [(True, "linux/amd64")]
+    assert builder_calls == [(True, "linux/amd64", True)]
     assert assemble_calls == [
         {
             "base_images": ["docker.io/example/base:v0"],

--- a/tests/test_phased_build.py
+++ b/tests/test_phased_build.py
@@ -476,6 +476,35 @@ class TestBuildBuilderImage:
         assert len(result.tags) == 1
 
     @patch(
+        "benchmarks.swebench.build_base_images.remote_image_exists", return_value=True
+    )
+    @patch(
+        "benchmarks.swebench.build_base_images._get_sdk_submodule_info",
+        return_value=("sdk", "abc1234567", "v1"),
+    )
+    @patch("benchmarks.swebench.build_base_images._get_repo_root")
+    @patch("openhands.agent_server.docker.build._make_build_context")
+    @patch(
+        "benchmarks.swebench.build_base_images.subprocess.run", return_value=_ok_proc()
+    )
+    def test_force_build_bypasses_remote_exists(
+        self, mock_run, mock_make_context, mock_repo_root, _sdk, _exists, tmp_path
+    ):
+        from benchmarks.swebench.build_base_images import build_builder_image
+
+        ctx = tmp_path / "ctx"
+        ctx.mkdir()
+        (ctx / "Dockerfile").write_text("FROM scratch\n")
+        mock_make_context.return_value = ctx
+        mock_repo_root.return_value = tmp_path
+
+        result = build_builder_image(force_build=True)
+
+        assert result.error is None
+        assert len(result.tags) == 1
+        mock_run.assert_called_once()
+
+    @patch(
         "benchmarks.swebench.build_base_images.remote_image_exists", return_value=False
     )
     @patch(


### PR DESCRIPTION
## Summary
- move the Commit0 image build workflow off Blacksmith onto standard `ubuntu-24.04`
- reduce default Commit0 build parallelism from 16 workers to 4 workers for the standard runner
- make Commit0 `--force-build` rebuild the shared phased builder image instead of skipping it when the tag already exists

## Validation
- `uv run pytest tests/test_commit0_run_infer.py tests/test_phased_build.py`
- `uv run ruff check benchmarks/commit0/build_images.py benchmarks/swebench/build_base_images.py tests/test_commit0_run_infer.py tests/test_phased_build.py`
- workflow validation succeeded on this branch: https://github.com/OpenHands/benchmarks/actions/runs/24206915693
- that run completed successfully on standard `ubuntu-24.04` with `n-limit=4` and `force-build=true`
