### PR TITLE
Remove binary diffs from agent patches in SWE-bench evaluation

### DIFF
--- a/benchmarks/swebench/eval_infer.py
+++ b/benchmarks/swebench/eval_infer.py
@@ -20,7 +20,7 @@ from benchmarks.swebench import constants
 from benchmarks.swebench.config import EVAL_DEFAULTS
 from benchmarks.utils.constants import MODEL_NAME_OR_PATH
 from benchmarks.utils.laminar import LaminarService
-from benchmarks.utils.patch_utils import remove_files_from_patch
+from benchmarks.utils.patch_utils import remove_binary_diffs, remove_files_from_patch
 from benchmarks.utils.report_costs import generate_cost_report
 from openhands.sdk import get_logger
 
@@ -83,6 +83,7 @@ def convert_to_swebench_format(input_file: str, output_file: str) -> None:
                     git_patch = ""
 
                 # postprocess git_patch
+                git_patch = remove_binary_diffs(git_patch)
                 git_patch = remove_files_from_patch(
                     git_patch, constants.SETUP_FILES_TO_REMOVE
                 )

--- a/benchmarks/swebenchmultilingual/eval_infer.py
+++ b/benchmarks/swebenchmultilingual/eval_infer.py
@@ -20,7 +20,7 @@ from benchmarks.swebenchmultilingual import constants
 from benchmarks.swebenchmultilingual.config import EVAL_DEFAULTS
 from benchmarks.utils.constants import MODEL_NAME_OR_PATH
 from benchmarks.utils.laminar import LaminarService
-from benchmarks.utils.patch_utils import remove_files_from_patch
+from benchmarks.utils.patch_utils import remove_binary_diffs, remove_files_from_patch
 from benchmarks.utils.report_costs import generate_cost_report
 from openhands.sdk import get_logger
 
@@ -83,6 +83,7 @@ def convert_to_swebench_format(input_file: str, output_file: str) -> None:
                     git_patch = ""
 
                 # postprocess git_patch
+                git_patch = remove_binary_diffs(git_patch)
                 git_patch = remove_files_from_patch(
                     git_patch, constants.SETUP_FILES_TO_REMOVE
                 )

--- a/benchmarks/swebenchmultimodal/eval_infer.py
+++ b/benchmarks/swebenchmultimodal/eval_infer.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from benchmarks.swebenchmultimodal.config import EVAL_DEFAULTS
 from benchmarks.utils.constants import MODEL_NAME_OR_PATH
-from benchmarks.utils.patch_utils import remove_files_from_patch
+from benchmarks.utils.patch_utils import remove_binary_diffs, remove_files_from_patch
 from benchmarks.utils.report_costs import generate_cost_report
 from openhands.sdk import get_logger
 
@@ -213,6 +213,7 @@ def convert_to_swebench_format(input_file: str, output_file: str) -> None:
                     git_patch = ""
 
                 # postprocess git_patch
+                git_patch = remove_binary_diffs(git_patch)
                 setup_files = ["pyproject.toml", "tox.ini", "setup.py"]
                 git_patch = remove_files_from_patch(git_patch, setup_files)
 

--- a/benchmarks/swtbench/eval_infer.py
+++ b/benchmarks/swtbench/eval_infer.py
@@ -25,7 +25,7 @@ from benchmarks.swtbench.image_utils import (
 )
 from benchmarks.utils.constants import MODEL_NAME_OR_PATH
 from benchmarks.utils.laminar import LaminarService
-from benchmarks.utils.patch_utils import remove_files_from_patch
+from benchmarks.utils.patch_utils import remove_binary_diffs, remove_files_from_patch
 from benchmarks.utils.report_costs import generate_cost_report
 from openhands.sdk import get_logger
 
@@ -203,6 +203,7 @@ def convert_to_swtbench_format(input_file: str, output_file: str) -> None:
                     git_patch = ""
 
                 # postprocess git_patch
+                git_patch = remove_binary_diffs(git_patch)
                 setup_files = ["pyproject.toml", "tox.ini", "setup.py"]
                 git_patch = remove_files_from_patch(git_patch, setup_files)
 

--- a/tests/test_swebench_eval_infer.py
+++ b/tests/test_swebench_eval_infer.py
@@ -60,3 +60,47 @@ class TestConvertToSwebenchFormat:
             result = json.loads(f.readline())
 
         assert result["model_name_or_path"] == MODEL_NAME_OR_PATH
+
+    def test_binary_diffs_are_removed(self):
+        """Test that binary diffs are removed from the patch."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as infile:
+            # Patch with a binary diff that should be removed
+            patch_with_binary = """diff --git a/test.py b/test.py
+--- a/test.py
++++ b/test.py
+@@ -1 +1 @@
+-old
++new
+diff --git a/binary.png b/binary.png
+Binary files differ
+diff --git a/another.py b/another.py
+--- a/another.py
++++ a/another.py
+@@ -1 +1 @@
+-foo
++bar"""
+            entry = {
+                "instance_id": "django__django-12345",
+                "test_result": {"git_patch": patch_with_binary},
+            }
+            infile.write(json.dumps(entry) + "\n")
+            input_path = infile.name
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".swebench.jsonl", delete=False
+        ) as outfile:
+            output_path = outfile.name
+
+        convert_to_swebench_format(input_path, output_path)
+
+        with open(output_path, "r") as f:
+            result = json.loads(f.readline())
+
+        # Verify binary diff was removed
+        assert "Binary files differ" not in result["model_patch"]
+        assert "diff --git a/binary.png" not in result["model_patch"]
+        # Verify regular diffs are preserved
+        assert "diff --git a/test.py" in result["model_patch"]
+        assert "diff --git a/another.py" in result["model_patch"]


### PR DESCRIPTION
## Summary

This fix addresses issue #654 by enabling the use of the existing `remove_binary_diffs` function in `patch_utils.py` during the SWE-bench evaluation conversion process.

The function was previously defined but never used by the eval code. This change applies `remove_binary_diffs()` to the `git_patch` before `remove_files_from_patch()` in all affected `eval_infer.py` files.

## Changes

- **benchmarks/swebench/eval_infer.py**: Import and apply `remove_binary_diffs()`
- **benchmarks/swtbench/eval_infer.py**: Import and apply `remove_binary_diffs()`
- **benchmarks/swebenchmultilingual/eval_infer.py**: Import and apply `remove_binary_diffs()`
- **benchmarks/swebenchmultimodal/eval_infer.py**: Import and apply `remove_binary_diffs()`
- **tests/test_swebench_eval_infer.py**: Add test to verify binary diffs are removed

## Testing

Added a test case `test_binary_diffs_are_removed` that verifies:
- Binary diffs (containing "Binary files differ") are removed from patches
- Regular diffs are preserved

All existing tests pass.

## Related Issue

Fixes #654