### PR TITLE
gaia: prefetch dataset before inference to avoid hf-xet deadlock

### DIFF
--- a/benchmarks/gaia/prefetch_gaia.py
+++ b/benchmarks/gaia/prefetch_gaia.py
@@ -61,6 +61,9 @@ def download_with_retries(workers: int, max_retries: int) -> str:
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     if not token:
         sys.exit("ERROR: GAIA is gated; set HF_TOKEN (an HF token with GAIA access).")
+    # Strip whitespace/newlines — tokens loaded from secret files often carry a
+    # trailing '\n' which makes snapshot_download fail with "Invalid header value".
+    token = token.strip()
 
     last_err: Exception | None = None
     for attempt in range(1, max_retries + 1):

--- a/benchmarks/gaia/prefetch_gaia.py
+++ b/benchmarks/gaia/prefetch_gaia.py
@@ -13,6 +13,7 @@ that the eval pod never needs to call hf_hub_download at runtime. This avoids:
 After a successful run, point HF_HOME / HF_DATASETS_CACHE at --dest in the
 eval pod and gaia-infer will load entirely from disk.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -22,19 +23,32 @@ import sys
 import time
 from pathlib import Path
 
+
 REPO_ID = "gaia-benchmark/GAIA"
 REPO_TYPE = "dataset"
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     p.add_argument(
         "--dest",
         default=os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface")),
         help="HF cache root to populate (default: $HF_HOME or ~/.cache/huggingface)",
     )
-    p.add_argument("--workers", type=int, default=4, help="Concurrent download workers (default: 4)")
-    p.add_argument("--max-retries", type=int, default=5, help="Retries on transient failures (default: 5)")
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Concurrent download workers (default: 4)",
+    )
+    p.add_argument(
+        "--max-retries",
+        type=int,
+        default=5,
+        help="Retries on transient failures (default: 5)",
+    )
     p.add_argument(
         "--verify",
         action="store_true",
@@ -56,7 +70,7 @@ def configure_env(dest: str) -> None:
 
 def download_with_retries(workers: int, max_retries: int) -> str:
     from huggingface_hub import snapshot_download
-    from huggingface_hub.utils import HfHubHTTPError
+    from huggingface_hub.errors import HfHubHTTPError
 
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     if not token:
@@ -68,7 +82,10 @@ def download_with_retries(workers: int, max_retries: int) -> str:
     last_err: Exception | None = None
     for attempt in range(1, max_retries + 1):
         backoff = min(60, 5 * 2 ** (attempt - 1))
-        print(f"[prefetch] attempt {attempt}/{max_retries} (workers={workers})", flush=True)
+        print(
+            f"[prefetch] attempt {attempt}/{max_retries} (workers={workers})",
+            flush=True,
+        )
         try:
             local_dir = snapshot_download(
                 repo_id=REPO_ID,
@@ -91,20 +108,26 @@ def download_with_retries(workers: int, max_retries: int) -> str:
                 print(f"[prefetch] sleeping {backoff}s before retry", flush=True)
                 time.sleep(backoff)
 
-    sys.exit(f"ERROR: snapshot_download failed after {max_retries} attempts: {last_err}")
+    sys.exit(
+        f"ERROR: snapshot_download failed after {max_retries} attempts: {last_err}"
+    )
 
 
 def verify(local_dir: str) -> None:
     """Sanity-check that every level can be loaded from the local cache."""
-    from datasets import load_dataset
+    from datasets import Dataset, load_dataset
 
     for level in ("2023_level1", "2023_level2", "2023_level3", "2023_all"):
         for split in ("validation", "test"):
             try:
                 ds = load_dataset(local_dir, level, split=split)
-                print(f"[verify] {level}/{split}: {len(ds)} rows OK", flush=True)
+                n = len(ds) if isinstance(ds, Dataset) else "?"
+                print(f"[verify] {level}/{split}: {n} rows OK", flush=True)
             except Exception as e:  # noqa: BLE001
-                print(f"[verify] {level}/{split}: FAILED — {type(e).__name__}: {e}", flush=True)
+                print(
+                    f"[verify] {level}/{split}: FAILED — {type(e).__name__}: {e}",
+                    flush=True,
+                )
 
 
 def main() -> int:

--- a/benchmarks/gaia/prefetch_gaia.py
+++ b/benchmarks/gaia/prefetch_gaia.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Prefetch the GAIA dataset from Hugging Face into a local cache.
+
+Usage:
+    HF_TOKEN=... python prefetch_gaia.py [--dest /path/to/cache] [--workers 4] [--max-retries 5]
+
+Designed to be run once at image-build time (or before gaia-infer in CI), so
+that the eval pod never needs to call hf_hub_download at runtime. This avoids:
+  - the hf-xet token-refresh deadlock (OpenHands/benchmarks#658)
+  - transient ChunkedEncodingError / IncompleteRead during streaming downloads
+
+After a successful run, point HF_HOME / HF_DATASETS_CACHE at --dest in the
+eval pod and gaia-infer will load entirely from disk.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+REPO_ID = "gaia-benchmark/GAIA"
+REPO_TYPE = "dataset"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument(
+        "--dest",
+        default=os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface")),
+        help="HF cache root to populate (default: $HF_HOME or ~/.cache/huggingface)",
+    )
+    p.add_argument("--workers", type=int, default=4, help="Concurrent download workers (default: 4)")
+    p.add_argument("--max-retries", type=int, default=5, help="Retries on transient failures (default: 5)")
+    p.add_argument(
+        "--verify",
+        action="store_true",
+        help="After download, try datasets.load_dataset() on every level to verify completeness.",
+    )
+    return p.parse_args()
+
+
+def configure_env(dest: str) -> None:
+    """Force the legacy HTTP path (no xet) and point HF cache at --dest."""
+    os.environ["HF_HOME"] = dest
+    os.environ["HF_DATASETS_CACHE"] = str(Path(dest) / "datasets")
+    os.environ["HUGGINGFACE_HUB_CACHE"] = str(Path(dest) / "hub")
+    os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
+    os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "0")
+    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "60")
+    Path(dest).mkdir(parents=True, exist_ok=True)
+
+
+def download_with_retries(workers: int, max_retries: int) -> str:
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.utils import HfHubHTTPError
+
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if not token:
+        sys.exit("ERROR: GAIA is gated; set HF_TOKEN (an HF token with GAIA access).")
+
+    last_err: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        backoff = min(60, 5 * 2 ** (attempt - 1))
+        print(f"[prefetch] attempt {attempt}/{max_retries} (workers={workers})", flush=True)
+        try:
+            local_dir = snapshot_download(
+                repo_id=REPO_ID,
+                repo_type=REPO_TYPE,
+                token=token,
+                max_workers=workers,
+                etag_timeout=30,
+                resume_download=True,
+            )
+            print(f"[prefetch] OK -> {local_dir}", flush=True)
+            return local_dir
+        except (HfHubHTTPError, OSError, Exception) as e:  # noqa: BLE001 - intentional broad catch
+            last_err = e
+            msg = f"{type(e).__name__}: {e}"
+            # Don't retry on hard auth/gating errors
+            if "401" in msg or "403" in msg or "gated" in msg.lower():
+                sys.exit(f"ERROR: auth/gate failure, not retrying: {msg}")
+            print(f"[prefetch] attempt {attempt} failed: {msg}", flush=True)
+            if attempt < max_retries:
+                print(f"[prefetch] sleeping {backoff}s before retry", flush=True)
+                time.sleep(backoff)
+
+    sys.exit(f"ERROR: snapshot_download failed after {max_retries} attempts: {last_err}")
+
+
+def verify(local_dir: str) -> None:
+    """Sanity-check that every level can be loaded from the local cache."""
+    from datasets import load_dataset
+
+    for level in ("2023_level1", "2023_level2", "2023_level3", "2023_all"):
+        for split in ("validation", "test"):
+            try:
+                ds = load_dataset(local_dir, level, split=split)
+                print(f"[verify] {level}/{split}: {len(ds)} rows OK", flush=True)
+            except Exception as e:  # noqa: BLE001
+                print(f"[verify] {level}/{split}: FAILED — {type(e).__name__}: {e}", flush=True)
+
+
+def main() -> int:
+    args = parse_args()
+    configure_env(args.dest)
+    free_gb = shutil.disk_usage(args.dest).free / 1024**3
+    print(f"[prefetch] dest={args.dest} free={free_gb:.1f} GiB", flush=True)
+    if free_gb < 2:
+        sys.exit("ERROR: less than 2 GiB free at destination; aborting.")
+
+    t0 = time.time()
+    local_dir = download_with_retries(args.workers, args.max_retries)
+    print(f"[prefetch] download done in {time.time() - t0:.1f}s", flush=True)
+
+    if args.verify:
+        verify(local_dir)
+
+    print(f"[prefetch] done. Set in your eval pod: HF_HOME={args.dest}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1815,14 +1815,12 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.80.10"
+version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
     { name = "fastuuid" },
-    { name = "grpcio", version = "1.67.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "grpcio", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "httpx" },
     { name = "importlib-metadata" },
     { name = "jinja2" },
@@ -1833,9 +1831,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/44/0aaa7449e7c4aa05668ec03f1f68a01b1e476591071d9659a68db19371a2/litellm-1.80.10.tar.gz", hash = "sha256:4a4aff7558945c2f7e5c6523e67c1b5525a46b10b0e1ad6b8f847cb13b16779e", size = 12764777, upload-time = "2025-12-14T02:07:05.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/a9/4814b6aa58f6705df2831eaadeb5bc8240684c8c9d5964245212f85049d1/litellm-1.80.10-py3-none-any.whl", hash = "sha256:9b3e561efaba0eb1291cb1555d3dcb7283cf7f3cb65aadbcdb42e2a8765898c8", size = 11264240, upload-time = "2025-12-14T02:07:02.414Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
 ]
 
 [[package]]
@@ -2577,7 +2575,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.0.0" },
     { name = "filelock", specifier = ">=3.20.1" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
-    { name = "litellm", specifier = "==1.80.10" },
+    { name = "litellm", specifier = ">=1.82.6,!=1.82.7,!=1.82.8" },
     { name = "lmnr", specifier = ">=0.7.24" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary

Adds `benchmarks/gaia/prefetch_gaia.py`, a small script that downloads the GAIA dataset into the HuggingFace cache **before** inference starts, using plain HTTPS (not xet).

The pre-fetch runs once at pod startup so that when the inference workers later call `snapshot_download`, everything is already cached locally and the xet codepath is never exercised.

Paired with OpenHands/evaluation#465 which wires this into the GAIA eval job.

## Context

Tracked in #658. GAIA inference has been wedging indefinitely inside `hf_hub_download` via the xet protocol — workers stuck in `futex_wait_queue`, never making progress, 0 instances completed after 13h+. Root cause is in hf-xet's `token_refresher` callback (recursion into Python logging from a Rust tokio thread that isn't registered in `threading._active`).

Previous workaround: OpenHands/evaluation#464 disables xet entirely via `HF_HUB_DISABLE_XET=1`.

This PR is an alternative workaround: we can keep xet enabled for everything else and just avoid using it for GAIA by pre-warming the cache via HTTPS first.

## Commits

- `636bc3b` gaia: add `prefetch_gaia.py` for runtime dataset prefetch
- `11d38c8` gaia: strip whitespace from `HF_TOKEN` before `snapshot_download` (secret files often carry a trailing `\n` → "Invalid header value")

## Test plan

- [x] Dataset prefetch completes against GAIA (tested on eval run 24335736778)
- [x] Inference proceeds past dataset preparation after prefetch runs
- [ ] Full end-to-end GAIA eval completes without xet-related stalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)