### PR TITLE
fix: disable xet protocol to prevent huggingface_hub deadlock on Python 3.12

### DIFF
--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -94,9 +94,13 @@ class GAIAEvaluation(Evaluation):
         logger.info(
             f"Loading GAIA dataset: {level}, split: {self.metadata.dataset_split}"
         )
+        # Disable xet protocol to avoid deadlock from token_refresher RecursionError
+        # on Python 3.12 (huggingface_hub xet + unregistered Rust threads + logging recursion).
+        os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
         dataset = cast(DatasetDict, load_dataset("gaia-benchmark/GAIA", level))
 
         # Download dataset files
+        # HF_HUB_DISABLE_XET=1 was set above to avoid xet deadlock on Python 3.12.
         logger.info(f"Downloading GAIA dataset files to {DATASET_CACHE_DIR}")
         DATASET_CACHE_DIR.mkdir(parents=True, exist_ok=True)
         huggingface_hub.snapshot_download(

--- a/benchmarks/utils/dataset.py
+++ b/benchmarks/utils/dataset.py
@@ -77,6 +77,9 @@ def _load_hf_dataset_with_retry(dataset_name: str, split: str) -> Dataset:
     # Default HF timeout is ~10s; bump it to reduce transient ReadTimeouts.
     os.environ.setdefault("HF_HUB_HTTP_TIMEOUT", "60")
     os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", os.environ["HF_HUB_HTTP_TIMEOUT"])
+    # Disable xet protocol to avoid deadlock from token_refresher RecursionError
+    # on Python 3.12 (huggingface_hub xet + unregistered Rust threads + logging recursion).
+    os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 
     attempts = 5
     backoff = 5.0


### PR DESCRIPTION
## Summary

Fix deadlock when `huggingface_hub` uses the xet protocol with Python 3.12.

## Problem

When downloading from HuggingFace, `huggingface_hub` defaults to the xet protocol. On Python 3.12, the `token_refresher` callback runs on an unregistered Rust tokio worker thread. Calling `logging.debug()` on that thread reaches `threading.current_thread()`, which synthesizes a `_DummyThread`. In Python 3.12 this codepath re-enters logging and recurses until hitting the recursion limit → `TokenRefreshFailure` → deadlock.

Affected runs have been stuck for 13+ hours with `0/N` instances completed, stuck in `hf_hub_download` via xet.

See OpenHands/benchmarks#658.

## Fix

Set `HF_HUB_DISABLE_XET=1` to force the legacy HTTP/LFS path before any HuggingFace dataset downloads.

Changes in two places:
1. **`benchmarks/utils/dataset.py`** - fixes all benchmarks using `get_dataset()` (SWE-bench, SWE-bench multimodal, etc.)
2. **`benchmarks/gaia/run_infer.py`** - fixes GAIA's direct `load_dataset()` and `snapshot_download()` calls

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4d45978c-b79c-458b-98b3-40166270a873)