### PR TITLE
feat: pass Laminar API key via parameter instead of environment variables

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -248,6 +248,7 @@ class Commit0Evaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """
         Create workspace and set up the commit0 repository.
@@ -311,6 +312,7 @@ class Commit0Evaluation(Evaluation):
                 server_image=agent_server_image,
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
                 resource_factor=resource_factor,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,

--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -249,6 +249,7 @@ class Commit0Evaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """
         Create workspace and set up the commit0 repository.
@@ -313,6 +314,7 @@ class Commit0Evaluation(Evaluation):
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -158,6 +158,7 @@ class GAIAEvaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """Create workspace and copy necessary files.
 
@@ -218,6 +219,7 @@ class GAIAEvaluation(Evaluation):
                 target_type="binary",  # GAIA images use binary target
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
             )
         else:

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -157,6 +157,7 @@ class GAIAEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """Create workspace and copy necessary files.
 
@@ -216,6 +217,7 @@ class GAIAEvaluation(Evaluation):
                 startup_wait_timeout=startup_timeout,
                 target_type="binary",  # GAIA images use binary target
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
                 resource_factor=resource_factor,
             )
         else:

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -186,6 +186,7 @@ class MultiSWEBenchEvaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
@@ -226,6 +227,7 @@ class MultiSWEBenchEvaluation(Evaluation):
                 working_dir="/workspace",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
             )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")
@@ -258,6 +260,7 @@ class MultiSWEBenchEvaluation(Evaluation):
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
             )
         else:

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -185,6 +185,7 @@ class MultiSWEBenchEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
@@ -224,6 +225,7 @@ class MultiSWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 working_dir="/workspace",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
             )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")
@@ -255,6 +257,7 @@ class MultiSWEBenchEvaluation(Evaluation):
                 startup_wait_timeout=startup_timeout,
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
                 resource_factor=resource_factor,
             )
         else:

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -390,6 +390,7 @@ class OpenAgentSafetyEvaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """Create a fresh Docker workspace for this instance.
 
@@ -417,6 +418,7 @@ class OpenAgentSafetyEvaluation(Evaluation):
             extra_ports=True,
             forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
         )
 
         # Setup host mapping for The Agent Company services

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -389,6 +389,7 @@ class OpenAgentSafetyEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """Create a fresh Docker workspace for this instance.
 
@@ -415,6 +416,7 @@ class OpenAgentSafetyEvaluation(Evaluation):
             platform="linux/amd64",
             extra_ports=True,
             forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
         )
 
         # Setup host mapping for The Agent Company services

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -147,6 +147,8 @@ class SWEBenchEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
@@ -156,6 +158,8 @@ class SWEBenchEvaluation(Evaluation):
             resource_factor: Resource factor for runtime allocation (default: 1).
                            Higher values allocate more CPU/memory resources.
                            Used by APIRemoteWorkspace for remote runtime allocation.
+            laminar_api_key: Laminar API key for observability tracing.
+            laminar_span_context: Laminar span context for trace continuity.
         """
         forward_env = get_acp_forward_env(self.metadata.agent_type, forward_env)
 
@@ -194,6 +198,8 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 working_dir="/workspace",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
             )
         elif self.metadata.workspace_type == "apptainer":
             if not remote_image_exists(agent_server_image):
@@ -215,6 +221,8 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 working_dir="/workspace",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
             )
         elif self.metadata.workspace_type == "remote":
@@ -248,6 +256,8 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,

--- a/benchmarks/swebenchmultilingual/run_infer.py
+++ b/benchmarks/swebenchmultilingual/run_infer.py
@@ -138,6 +138,7 @@ class SWEBenchEvaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
@@ -186,6 +187,7 @@ class SWEBenchEvaluation(Evaluation):
                 working_dir="/workspace",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
             )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")
@@ -221,6 +223,7 @@ class SWEBenchEvaluation(Evaluation):
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,

--- a/benchmarks/swebenchmultilingual/run_infer.py
+++ b/benchmarks/swebenchmultilingual/run_infer.py
@@ -137,6 +137,7 @@ class SWEBenchEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
@@ -184,6 +185,7 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 working_dir="/workspace",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
             )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")
@@ -218,6 +220,7 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
                 resource_factor=resource_factor,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -154,6 +154,7 @@ class SWEBenchEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
@@ -186,6 +187,7 @@ class SWEBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 working_dir="/workspace",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
             )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")
@@ -215,6 +217,7 @@ class SWEBenchEvaluation(Evaluation):
                 startup_wait_timeout=startup_timeout,
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
                 resource_factor=resource_factor,
             )
         else:

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -155,6 +155,7 @@ class SWEBenchEvaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """
         Use DockerWorkspace by default.
@@ -188,6 +189,7 @@ class SWEBenchEvaluation(Evaluation):
                 working_dir="/workspace",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
             )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")
@@ -218,6 +220,7 @@ class SWEBenchEvaluation(Evaluation):
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
             )
         else:

--- a/benchmarks/swefficiency/run_infer.py
+++ b/benchmarks/swefficiency/run_infer.py
@@ -201,6 +201,7 @@ class SWEfficiencyEvaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """
         Create workspace for the instance.
@@ -284,6 +285,7 @@ class SWEfficiencyEvaluation(Evaluation):
                 target_type="source",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
                 init_timeout=600.0,
                 startup_wait_timeout=600.0,

--- a/benchmarks/swefficiency/run_infer.py
+++ b/benchmarks/swefficiency/run_infer.py
@@ -200,6 +200,7 @@ class SWEfficiencyEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """
         Create workspace for the instance.
@@ -282,6 +283,7 @@ class SWEfficiencyEvaluation(Evaluation):
                 server_image=agent_server_image,
                 target_type="source",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
                 resource_factor=resource_factor,
                 init_timeout=600.0,
                 startup_wait_timeout=600.0,

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -165,6 +165,7 @@ class SWTBenchEvaluation(Evaluation):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """
         Create workspace based on workspace_type (docker or remote).
@@ -222,6 +223,7 @@ class SWTBenchEvaluation(Evaluation):
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
                 resource_factor=resource_factor,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -164,6 +164,7 @@ class SWTBenchEvaluation(Evaluation):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """
         Create workspace based on workspace_type (docker or remote).
@@ -220,6 +221,7 @@ class SWTBenchEvaluation(Evaluation):
                 server_image=agent_server_image,
                 target_type="source" if "source" in build_target else "binary",
                 forward_env=forward_env or [],
+                laminar_api_key=laminar_api_key,
                 resource_factor=resource_factor,
                 init_timeout=startup_timeout,
                 startup_wait_timeout=startup_timeout,

--- a/benchmarks/utils/acp.py
+++ b/benchmarks/utils/acp.py
@@ -7,7 +7,6 @@ import threading
 from contextlib import contextmanager
 from typing import Any, cast
 
-from benchmarks.utils.laminar import LMNR_ENV_VARS
 from openhands.sdk import get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.workspace import RemoteWorkspace
@@ -73,22 +72,18 @@ def get_acp_forward_env(
     For non-ACP agent types (e.g. ``"default"``), *forward_env* is returned
     unchanged.
 
-    For ACP agent types, LMNR_ENV_VARS are included in forward_env to enable
-    Laminar tracing within the workspace.  Provider credentials (API keys,
-    base URLs) are **not** forwarded here — they are passed via
-    ``ACPAgent.acp_env`` in :func:`build_acp_agent` to avoid leaking them
-    into logged workspace payloads.
+    For ACP agent types, *forward_env* is returned as-is. Laminar credentials
+    (API key and span context) are passed via workspace parameters instead of
+    environment variables to prevent them from leaking into logged payloads.
+    Provider credentials (API keys, base URLs) are **not** forwarded here —
+    they are passed via ``ACPAgent.acp_env`` in :func:`build_acp_agent` to
+    avoid leaking them into logged workspace payloads.
     """
     if agent_type not in _ACP_ENV_VARS:
         return forward_env
 
-    forward_env = list(forward_env or [])
-
-    # Include Laminar env vars for tracing in ACP agents
-    for lmnr_var in LMNR_ENV_VARS:
-        if lmnr_var not in forward_env:
-            forward_env.append(lmnr_var)
-
+    # Return forward_env as-is for ACP agents; Laminar variables are now
+    # passed via workspace parameters instead of environment forwarding
     return forward_env
 
 

--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -31,7 +31,7 @@ from benchmarks.utils.constants import OUTPUT_FILENAME
 from benchmarks.utils.critics import get_completed_instances
 from benchmarks.utils.failure_classifier import FailureCategory, classify_failure
 from benchmarks.utils.iterative import aggregate_results, get_failed_instances
-from benchmarks.utils.laminar import LMNR_ENV_VARS, LaminarEvalMetadata, LaminarService
+from benchmarks.utils.laminar import LaminarEvalMetadata, LaminarService
 from benchmarks.utils.litellm_proxy import (
     create_virtual_key,
     delete_key,
@@ -213,6 +213,7 @@ class Evaluation(ABC, BaseModel):
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
         laminar_api_key: str | None = None,
+        laminar_span_context: str | None = None,
     ) -> RemoteWorkspace:
         """Create and return a context-managed Workspace for the given instance.
 
@@ -222,6 +223,9 @@ class Evaluation(ABC, BaseModel):
             forward_env: Environment variables to forward into the workspace.
             laminar_api_key: Laminar API key for observability tracing.
                 When provided, injected as LMNR_PROJECT_API_KEY in the workspace.
+                Should NOT be included in forward_env to avoid logging leaks.
+            laminar_span_context: Laminar span context for trace continuity.
+                When provided, injected as LMNR_SPAN_CONTEXT in the workspace.
                 Should NOT be included in forward_env to avoid logging leaks.
         """
         raise NotImplementedError
@@ -947,15 +951,17 @@ class Evaluation(ABC, BaseModel):
             virtual_key = create_virtual_key(instance.id, run_id=run_id)
             set_current_virtual_key(virtual_key)
 
-            # Extract Laminar API key from environment and pass separately to avoid
-            # exposing it in environment dicts or logged payloads
+            # Extract Laminar credentials from environment and pass separately to avoid
+            # exposing them in environment dicts or logged payloads
             laminar_api_key = os.getenv("LMNR_PROJECT_API_KEY")
+            laminar_span_context = os.getenv("LMNR_SPAN_CONTEXT")
 
             workspace = self.prepare_workspace(
                 instance,
                 resource_factor=resource_factor,
-                forward_env=LMNR_ENV_VARS,
+                forward_env=[],
                 laminar_api_key=laminar_api_key,
+                laminar_span_context=laminar_span_context,
             )
 
             # Record runtime/pod mapping only for remote runtimes

--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -212,6 +212,7 @@ class Evaluation(ABC, BaseModel):
         instance: EvalInstance,
         resource_factor: int = 1,
         forward_env: list[str] | None = None,
+        laminar_api_key: str | None = None,
     ) -> RemoteWorkspace:
         """Create and return a context-managed Workspace for the given instance.
 
@@ -219,6 +220,9 @@ class Evaluation(ABC, BaseModel):
             instance: The evaluation instance to prepare workspace for.
             resource_factor: Resource factor for runtime allocation (default: 1).
             forward_env: Environment variables to forward into the workspace.
+            laminar_api_key: Laminar API key for observability tracing.
+                When provided, injected as LMNR_PROJECT_API_KEY in the workspace.
+                Should NOT be included in forward_env to avoid logging leaks.
         """
         raise NotImplementedError
 
@@ -943,10 +947,15 @@ class Evaluation(ABC, BaseModel):
             virtual_key = create_virtual_key(instance.id, run_id=run_id)
             set_current_virtual_key(virtual_key)
 
+            # Extract Laminar API key from environment and pass separately to avoid
+            # exposing it in environment dicts or logged payloads
+            laminar_api_key = os.getenv("LMNR_PROJECT_API_KEY")
+
             workspace = self.prepare_workspace(
                 instance,
                 resource_factor=resource_factor,
                 forward_env=LMNR_ENV_VARS,
+                laminar_api_key=laminar_api_key,
             )
 
             # Record runtime/pod mapping only for remote runtimes

--- a/benchmarks/utils/laminar.py
+++ b/benchmarks/utils/laminar.py
@@ -13,8 +13,10 @@ from openhands.sdk import get_logger
 
 
 # Environment variables to forward to the workspace
+# Note: LMNR_PROJECT_API_KEY is no longer forwarded here.
+# Instead, it's passed as the `laminar_api_key` parameter to workspace instances.
+# This prevents the credential from appearing in environment dicts or logged payloads.
 LMNR_ENV_VARS = [
-    "LMNR_PROJECT_API_KEY",
     "LMNR_SPAN_CONTEXT",
 ]
 

--- a/benchmarks/utils/laminar.py
+++ b/benchmarks/utils/laminar.py
@@ -12,14 +12,6 @@ from pydantic import BaseModel
 from openhands.sdk import get_logger
 
 
-# Environment variables to forward to the workspace
-# Note: LMNR_PROJECT_API_KEY is no longer forwarded here.
-# Instead, it's passed as the `laminar_api_key` parameter to workspace instances.
-# This prevents the credential from appearing in environment dicts or logged payloads.
-LMNR_ENV_VARS = [
-    "LMNR_SPAN_CONTEXT",
-]
-
 logger = get_logger(__name__)
 
 


### PR DESCRIPTION
## Summary

Update benchmarks to use the new `laminar_api_key` parameter introduced in the SDK workspace classes. This prevents the LMNR_PROJECT_API_KEY credential from appearing in environment dicts or logged payloads.

## Changes

- Remove `LMNR_PROJECT_API_KEY` from `LMNR_ENV_VARS` in `benchmarks/utils/laminar.py`
- Keep `LMNR_SPAN_CONTEXT` for tracing continuity
- Extract `LMNR_PROJECT_API_KEY` from environment in `evaluate_instance()`
- Pass `laminar_api_key` parameter to `prepare_workspace()` method
- Update abstract method signature to include `laminar_api_key` parameter
- Update all 8 benchmark implementations to:
  - Accept `laminar_api_key` parameter in `prepare_workspace()`
  - Pass it to workspace instantiation (`DockerWorkspace`, `APIRemoteWorkspace`)

## Security Impact

Credentials are now injected at the container level rather than in Python environment dicts, preventing them from appearing in:
- Logged payloads
- Datadog metrics/logs
- Debug output

This complements the SDK changes where workspace classes have `laminar_api_key` parameter support.

## Test Plan

- [ ] Verify benchmarks run with Laminar tracing enabled
- [ ] Confirm credentials don't appear in logs/metrics
- [ ] Check that existing evaluations still create traces correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)