### PR TITLE
Fix broken import path for load_public_skills

### DIFF
--- a/benchmarks/utils/agent_context.py
+++ b/benchmarks/utils/agent_context.py
@@ -1,7 +1,7 @@
 """Utilities for agent context and skills management."""
 
 from openhands.sdk.context import AgentContext
-from openhands.sdk.context.skills.skill import load_public_skills
+from openhands.sdk.skills.skill import load_public_skills
 
 
 def create_agent_context() -> AgentContext | None:


### PR DESCRIPTION
## Summary
- Fix import `from openhands.sdk.context.skills.skill` → `from openhands.sdk.skills.skill` in `benchmarks/utils/agent_context.py`
- `openhands.sdk.context.skills` is a deprecated shim that only has `__init__.py` (no `skill.py` submodule). The actual `load_public_skills` function lives at `openhands.sdk.skills.skill`.
- This was causing all swtbench and swebenchmultimodal eval jobs to crash immediately with `ModuleNotFoundError: No module named 'openhands.sdk.context.skills.skill'`

## Test plan
- [ ] Re-run swtbench and swebenchmultimodal evals with `benchmarks_branch=fix/agent-context-import-path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)