### PR TITLE
Fix GAIA build target docs: binary-minimal -> binary

### DIFF
--- a/benchmarks/gaia/Dockerfile.gaia
+++ b/benchmarks/gaia/Dockerfile.gaia
@@ -1,7 +1,7 @@
 # Dockerfile for GAIA evaluation with MCP server pre-installed
 # Extends the base SDK image to pre-cache mcp-server-fetch and eliminate startup delays
 
-ARG SDK_IMAGE=ghcr.io/openhands/eval-agent-server:f715937-gaia-binary-minimal
+ARG SDK_IMAGE=ghcr.io/openhands/eval-agent-server:f715937-gaia-binary
 FROM ${SDK_IMAGE}
 
 # Switch to root to install packages

--- a/benchmarks/gaia/build_images.py
+++ b/benchmarks/gaia/build_images.py
@@ -7,7 +7,7 @@ GAIA uses a single universal image for all instances since they share the same P
 
 Example:
   uv run benchmarks/gaia/build_images.py \
-    --image ghcr.io/openhands/eval-agent-server --target binary-minimal --push
+    --image ghcr.io/openhands/eval-agent-server --target binary --push
 """
 
 import sys


### PR DESCRIPTION
## Summary

Fixes the documentation in GAIA benchmark files to use the correct build target `binary` instead of `binary-minimal`.

## Details

The GAIA benchmark requires Chromium for browser operations, which is only available in the `binary` target (not `binary-minimal`). The documentation example in `build_images.py` and the default ARG in `Dockerfile.gaia` were incorrectly showing `binary-minimal`.

This change aligns the documentation with the actual runtime configuration in `run_infer.py`, which explicitly uses `binary` target (see lines 179, 186, 195, 217).

### Changes

- **`benchmarks/gaia/build_images.py`**: Updated the example command from `--target binary-minimal` to `--target binary`
- **`benchmarks/gaia/Dockerfile.gaia`**: Updated the default ARG SDK_IMAGE from `gaia-binary-minimal` to `gaia-binary`

Closes #39

---

_This PR was created by an AI assistant (OpenHands) to address issue #39._

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4b177e45-d891-4683-b6ff-8319639ce1ac)