### PR TITLE
chore(ci): rename secrets.PAT_TOKEN to secrets.ALLHANDS_BOT_GITHUB_PAT

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -133,7 +133,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
 
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -76,7 +76,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
 
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -148,7 +148,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
 
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -138,7 +138,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
 
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -154,7 +154,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || github.token }}
 
       - uses: ./.github/actions/build-select-file
         with:

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -46,5 +46,5 @@ jobs:
                   # Review style: roasted (other option: standard)
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary
- Rename `secrets.PAT_TOKEN` → `secrets.ALLHANDS_BOT_GITHUB_PAT` across 6 workflow files (6 references)
- Standardizes on `ALLHANDS_BOT_GITHUB_PAT` as the org-wide secret name for the bot's GitHub PAT
- Part of OpenHands/evaluation#428

## Affected workflows
`build-gaia-images.yml`, `build-swebench-images.yml`, `build-swebenchmultimodal-images.yml`, `build-swtbench-images.yml`, `build-commit0-images.yml`, `pr-review-by-openhands.yml`

## Prerequisite
`ALLHANDS_BOT_GITHUB_PAT` must be configured as an org/repo secret visible to this repo before merging.

## Test plan
- [ ] Verify `ALLHANDS_BOT_GITHUB_PAT` secret is available to this repo
- [ ] After merge, trigger one build workflow and verify it succeeds (falls back to `github.token` if secret unavailable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)