### PR TITLE
ci: add free disk space step to prevent build failures

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -135,6 +135,19 @@ jobs:
           submodules: recursive
           token: ${{ secrets.PAT_TOKEN || github.token }}
 
+      # Free disk space to prevent "no space left on device" errors during
+      # large image builds. See OpenHands/evaluation#495 for context.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -78,6 +78,19 @@ jobs:
           submodules: recursive
           token: ${{ secrets.PAT_TOKEN || github.token }}
 
+      # Free disk space to prevent "no space left on device" errors during
+      # large image builds. See OpenHands/evaluation#495 for context.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}
         run: |

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -150,6 +150,19 @@ jobs:
           submodules: recursive
           token: ${{ secrets.PAT_TOKEN || github.token }}
 
+      # Free disk space to prevent "no space left on device" errors during
+      # large image builds. See OpenHands/evaluation#495 for context.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -140,6 +140,19 @@ jobs:
           submodules: recursive
           token: ${{ secrets.PAT_TOKEN || github.token }}
 
+      # Free disk space to prevent "no space left on device" errors during
+      # large image builds. See OpenHands/evaluation#495 for context.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -156,6 +156,19 @@ jobs:
           submodules: recursive
           token: ${{ secrets.PAT_TOKEN || github.token }}
 
+      # Free disk space to prevent "no space left on device" errors during
+      # large image builds. See OpenHands/evaluation#495 for context.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - uses: ./.github/actions/build-select-file
         with:
           instance-ids: ${{ env.INSTANCE_IDS }}


### PR DESCRIPTION
## Summary

Add `jlumbroso/free-disk-space` action to all 5 build workflows that are called from the evaluation repo (swebench, swtbench, gaia, commit0, swebenchmultimodal).

## Problem

After migrating from Blacksmith runners to `ubuntu-latest-8core` in PR #651, builds started failing with `no space left on device` errors during the Docker image assembly phase. This is because:

1. Standard GitHub-hosted runners have ~14GB of available disk space
2. Building hundreds of Docker images requires significantly more space
3. The Blacksmith runners previously provided more disk space

## Solution

The `free-disk-space` action removes unused software (Android SDK, .NET, Haskell tooling, etc.) and typically frees up 30-40GB of disk space. Docker images are preserved since we need them for the builds.

## Configuration

```yaml
- name: Free disk space
  uses: jlumbroso/free-disk-space@main
  with:
    tool-cache: false     # Keep for potential build tools
    android: true         # Remove Android SDK (~8GB)
    dotnet: true          # Remove .NET SDK (~2GB)
    haskell: true         # Remove Haskell tools (~5GB)
    large-packages: true  # Remove large packages (~3GB)
    docker-images: false  # Keep - we need them for builds!
    swap-storage: true    # Remove swap (~4GB)
```

## Testing

This can be tested by triggering a build workflow that previously failed with disk space errors.

## References

- Fixes OpenHands/evaluation#495
- Related to PR #651 (migration off Blacksmith runners)

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._