### PR TITLE
[DO NOT MERGE] ci(swtbench): revert to Blacksmith runner (fallback for #495)

### DIFF
--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -116,7 +116,8 @@ jobs:
     # regress past 10h again, reopen that discussion rather than silently raising.
     timeout-minutes: 600
 
-    runs-on: ubuntu-latest-8core
+    runs-on:
+      labels: blacksmith-32vcpu-ubuntu-2204
 
     permissions:
       contents: read
@@ -171,8 +172,8 @@ jobs:
           git add vendor/software-agent-sdk
           echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Set up Docker Buildx with Blacksmith
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — fallback branch only

Parallel to #672 (the real fix). Keeps a known-good configuration on hand to dispatch against if the `docker rmi` + `free-disk-space` + preflight approach in #672 doesn't hold up under real load.

## What this does

Surgical revert of the swtbench portion of #651: puts `build-swtbench-images.yml` back on `blacksmith-32vcpu-ubuntu-2204` + `useblacksmith/setup-docker-builder@v1`. Everything added since — notably the `workflow_call` trigger + cross-repo checkout from #666 — is preserved.

## Why this "works"

Blacksmith runners have hundreds of GB of persistent disk, which masks the underlying bug in `assemble_agent_image` (local images retained after push). The bug is still there; the runner just has enough headroom that 433 images don't fill it.

So this is explicitly **not** the fix — it's the "revert the migration" escape hatch. The real fix is #672.

## Relationship to other work

- Fixes the symptom of OpenHands/evaluation#495 by going back to pre-#651 state.
- #672 fixes the root cause and should land instead. This PR stays open as a draft so we can pivot to it quickly if #672 regresses.

## AI disclosure

This PR was prepared by Claude (Claude Code) on behalf of @simonrosenberg.
