### PR TITLE
chore: use github.token for submodule checkout instead of PAT_TOKEN

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -133,7 +133,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -76,7 +76,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -148,7 +148,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -138,7 +138,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -154,7 +154,7 @@ jobs:
           repository: OpenHands/benchmarks
           ref: ${{ steps.checkout-ref.outputs.ref }}
           submodules: recursive
-          token: ${{ secrets.PAT_TOKEN || github.token }}
+          token: ${{ github.token }}
 
       - uses: ./.github/actions/build-select-file
         with:


### PR DESCRIPTION
## Summary

- Replaces `${{ secrets.PAT_TOKEN || github.token }}` with `${{ github.token }}` in 5 build-image workflows
- All submodules are in public repos — `github.token` has sufficient read access; the PAT adds nothing here
- Removes an unnecessary PAT dependency, reducing blast radius if the shared token is ever rotated or compromised

## Workflows changed

- `build-commit0-images.yml`
- `build-gaia-images.yml`
- `build-swebench-images.yml`
- `build-swebenchmultimodal-images.yml`
- `build-swtbench-images.yml`

## Test plan

- [x] Trigger one of the build workflows manually and confirm submodule checkout succeeds with `github.token`

**Validation completed (2026-04-20):**
- ✅ **swebench** evaluation: Run [24677938467](https://github.com/OpenHands/evaluation/actions/runs/24677938467) — **PASSED** (2 instances)
- ✅ **gaia** evaluation: Run [24677947183](https://github.com/OpenHands/evaluation/actions/runs/24677947183) — **PASSED** (2 instances)

Both benchmarks successfully completed with `github.token` using this branch. No regressions detected.

Part of OpenHands/evaluation#428 (PAT_TOKEN blast radius reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)