### PR TITLE
fix #675: Modify commit0 initial message to prevent cheating

### DIFF
--- a/benchmarks/commit0/prompts/default.j2
+++ b/benchmarks/commit0/prompts/default.j2
@@ -11,6 +11,10 @@ Here is your task:
   Do not change the names of existing functions or classes, as they may be referenced
   from other code like unit tests, etc.
 
+  Implement the solution from scratch. Do NOT use git clone, pip install, npm install, or
+  any other method to obtain the target package/library from external sources. The
+  code must be written entirely by you without copying or looking at similar code online.
+
   When you generate code, you must maintain the original formatting of the function
   stubs (such as whitespaces), otherwise we will not able to search/replace blocks
   for code modifications, and therefore you will receive a score of 0 for your generated

--- a/benchmarks/commit0/prompts/default.j2
+++ b/benchmarks/commit0/prompts/default.j2
@@ -15,6 +15,9 @@ Here is your task:
   any other method to obtain the target package/library from external sources. The
   code must be written entirely by you without copying or looking at similar code online.
 
+  Do NOT pip install the target package to obtain data files. All required data files 
+  are already available in /testbed/<package>/ directory.
+
   When you generate code, you must maintain the original formatting of the function
   stubs (such as whitespaces), otherwise we will not able to search/replace blocks
   for code modifications, and therefore you will receive a score of 0 for your generated


### PR DESCRIPTION
## Summary

Modify the commit0 initial prompt template (`benchmarks/commit0/prompts/default.j2`) to indicate that implementations should be created from scratch without copying or looking at similar code online.

### Change

Added an anti-cheating instruction to the default.j2 template:

```
Implement the solution from scratch. Do NOT use git clone, pip install, npm install, or
any other method to obtain the target package/library from external sources. The
code must be written entirely by you without copying or looking at similar code online.
```

This prevents agents from using git clone, pip install, npm install, or other methods to obtain the target package from external sources when tasked to implement something.

## Fixes

Fixes #675

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4997ab25-8360-4bc5-b10a-199391cdc896)