### PR TITLE
DO_NOT_MERGE_FOR_TESTING_ONLY - Simulate build images error

### DIFF
--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -194,6 +194,12 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # DO_NOT_MERGE_FOR_TESTING_ONLY - intentionally fail the build
+    # to simulate build errors for testing CI/CD error handling
+    import sys
+    print("DO_NOT_MERGE_FOR_TESTING_ONLY: Intentionally failing build_images.py", file=sys.stderr)
+    return 1
+
     from benchmarks.swebench.build_base_images import (
         assemble_all_agent_images,
         build_all_base_images,

--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -30,7 +30,9 @@ from openhands.sdk import get_logger
 
 
 logger = get_logger(__name__)
-WRAPPER_DOCKERFILE = Path(__file__).with_name("Dockerfile.swebench-deps")
+# DO_NOT_MERGE_FOR_TESTING_ONLY - simulating build image error
+# This branch intentionally fails to simulate build errors
+WRAPPER_DOCKERFILE = Path("nonexistent/Dockerfile.does-not-exist")
 
 
 def get_official_docker_image(


### PR DESCRIPTION
## Summary

This PR is for testing error handling in the SWE-bench image build workflow.

## Changes

- Modified `benchmarks/swebench/build_images.py` to use an invalid Dockerfile path to simulate build failures
- Marked with `DO_NOT_MERGE_FOR_TESTING_ONLY` prefix as requested

## Testing

This branch intentionally fails to test error handling in CI/CD pipelines.

Fixes #677

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b62c379d-02da-46b6-a192-a79bee1cb783)