### PR TITLE
DO_NOT_MERGE_FOR_TESTING_ONLY - Simulate run_infer error

### DIFF
--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -399,6 +399,9 @@ class SWEBenchEvaluation(Evaluation):
 
 
 def main() -> None:
+    # DO_NOT_MERGE_FOR_TESTING_ONLY - simulating run_infer error
+    raise RuntimeError("DO_NOT_MERGE_FOR_TESTING_ONLY - simulated run_infer error for testing")
+
     parser = get_parser()
     add_prompt_path_argument(parser, __file__)
     parser.set_defaults(**INFER_DEFAULTS)


### PR DESCRIPTION
This PR is for testing error handling in the SWE-bench run_infer workflow. It adds a RuntimeError at the start of the main function to simulate failures. Marked with DO_NOT_MERGE_FOR_TESTING_ONLY prefix as requested. Fixes #677