### PR TITLE
DO_NOT_MERGE_FOR_TESTING_ONLY - Simulate eval_infer error

### DIFF
--- a/benchmarks/swebench/eval_infer.py
+++ b/benchmarks/swebench/eval_infer.py
@@ -190,6 +190,9 @@ def run_swebench_evaluation(
 
 def main() -> None:
     """Main entry point for the script."""
+    # DO_NOT_MERGE_FOR_TESTING_ONLY - simulating eval_infer error
+    raise RuntimeError("DO_NOT_MERGE_FOR_TESTING_ONLY - simulated eval_infer error for testing")
+
     parser = argparse.ArgumentParser(
         description="Convert OpenHands output to SWE-Bench format and run evaluation",
         formatter_class=argparse.RawDescriptionHelpFormatter,


### PR DESCRIPTION
This PR is for testing error handling in the SWE-bench eval_infer workflow. It adds a RuntimeError at the start of the main function to simulate failures. Marked with DO_NOT_MERGE_FOR_TESTING_ONLY prefix as requested. Fixes #677