### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_PUBLIC

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -46,5 +46,5 @@ jobs:
                   # Review style: roasted (other option: standard)
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary

Renames PAT secret references in workflow files to the scoped secret `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` as part of [OpenHands/evaluation#428](https://github.com/OpenHands/evaluation/issues/428) (PAT blast-radius reduction).

- Replaces `secrets.PAT_TOKEN` / `secrets.ALLHANDS_BOT_GITHUB_PAT` → `secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC`
- No logic changes

**Three scoped PAT identities:**
| Secret | Scope |
|---|---|
| `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` | Public repos |
| `OPENHANDS_BOT_GITHUB_PAT_PRIVATE` | Private repos |
| `OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH` | Cross-repo workflow dispatch |

The new token has been seeded as org token and is available. It was validated that it has the required permissions. 