### PR TITLE
Update max retries in all build images workflows to 5

### DIFF
--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -28,7 +28,7 @@ on:
       max-retries:
         description: 'Retries per image build'
         required: false
-        default: '2'
+        default: '5'
         type: string
       n-limit:
         description: 'Limit number of images to build (for testing). Leave blank for no limit.'

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -54,7 +54,7 @@ on:
       max-retries:
         description: 'Retries per image build'
         required: false
-        default: '2'
+        default: '5'
         type: string
       n-limit:
         description: 'Limit number of images to build (for testing). Leave blank for no limit.'

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -49,7 +49,7 @@ on:
       max-retries:
         description: 'Retries per image build'
         required: false
-        default: '2'
+        default: '5'
         type: string
       n-limit:
         description: 'Limit number of images to build (for testing). Leave blank for no limit.'

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -23,7 +23,7 @@ on:
       max-retries:
         description: 'Retries per image build'
         required: false
-        default: '2'
+        default: '5'
         type: string
       n-limit:
         description: 'Limit number of images to build (for testing). Leave blank for no limit.'

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -23,7 +23,7 @@ on:
       max-retries:
         description: 'Retries per image build'
         required: false
-        default: '2'
+        default: '5'
         type: string
       n-limit:
         description: 'Limit number of images to build (for testing). Leave blank for no limit.'

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -83,7 +83,7 @@ on:
       max-retries:
         description: 'Retries per batch for eval env builds'
         required: false
-        default: '2'
+        default: '5'
         type: string
       eval-env-build-batch-size:
         description: 'Env images per batch for eval env builds'


### PR DESCRIPTION
## Summary
Increases the default `max-retries` from 2 to 5 in all build image workflows to reduce unnecessary reruns (which often succeed on retry due to cache).

Affected workflows:
- `build-swebench-images.yml`
- `build-swebenchmultimodal-images.yml`
- `build-swtbench-images.yml`
- `build-swesmith-images.yml`
- `build-swegym-images.yml`
- `build-multiswebench-images.yml`

fixes #682

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/35f6ad5d-8f82-470b-92e9-547e475a9e2e)