### PR TITLE
eval: honor GPT-5 prompt when available

### DIFF
--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -1,5 +1,6 @@
 import json
 import os
+from importlib import resources
 from typing import Any, List
 
 from jinja2 import Environment, FileSystemLoader
@@ -84,6 +85,21 @@ def get_tools_for_preset(
         from openhands.tools.preset.default import get_default_tools
 
         return get_default_tools(enable_browser=enable_browser)
+
+
+def get_system_prompt_filename_for_preset(preset: ToolPresetType) -> str | None:
+    """Return the optional agent system prompt filename for a tool preset."""
+    if preset != "gpt5":
+        return None
+
+    prompt_filename = "system_prompt_gpt_5_4.j2"
+    prompt_template = resources.files("openhands.sdk.agent.prompts").joinpath(
+        prompt_filename
+    )
+    if not prompt_template.is_file():
+        return None
+
+    return prompt_filename
 
 
 def get_instruction(
@@ -298,16 +314,23 @@ class SWEBenchEvaluation(Evaluation):
                 )
             # Load public skills (respects EXTENSIONS_REF env var)
             agent_context = create_agent_context()
-
-            agent = Agent(
-                llm=agent_llm,
-                tools=tools,
-                system_prompt_kwargs={"cli_mode": True},
-                condenser=condenser,
-                agent_context=agent_context,
-                # TODO: we can enable security analyzer later
-                # security_analyzer=LLMSecurityAnalyzer(),
+            system_prompt_filename = get_system_prompt_filename_for_preset(
+                self.metadata.tool_preset
             )
+
+            agent_kwargs = {
+                "llm": agent_llm,
+                "tools": tools,
+                "system_prompt_kwargs": {"cli_mode": True},
+                "condenser": condenser,
+                "agent_context": agent_context,
+                # TODO: we can enable security analyzer later
+                # "security_analyzer": LLMSecurityAnalyzer(),
+            }
+            if system_prompt_filename is not None:
+                agent_kwargs["system_prompt_filename"] = system_prompt_filename
+
+            agent = Agent(**agent_kwargs)
 
         assert isinstance(workspace, RemoteWorkspace)
 

--- a/tests/test_tool_presets.py
+++ b/tests/test_tool_presets.py
@@ -1,10 +1,14 @@
 import pytest
 
+import benchmarks.swebench.run_infer as swebench_run_infer
 from benchmarks.hybridgym_depsearch.run_infer import DepSearchEvaluation
 from benchmarks.hybridgym_funcgen.run_infer import FuncGenEvaluation
 from benchmarks.hybridgym_funclocalize.run_infer import FuncLocalizeEvaluation
 from benchmarks.hybridgym_issuelocalize.run_infer import IssueLocalizeEvaluation
-from benchmarks.swebench.run_infer import get_tools_for_preset as get_swebench_tools
+from benchmarks.swebench.run_infer import (
+    get_system_prompt_filename_for_preset as get_swebench_system_prompt,
+    get_tools_for_preset as get_swebench_tools,
+)
 from benchmarks.swebenchmultilingual.run_infer import (
     get_tools_for_preset as get_swebenchmultilingual_tools,
 )
@@ -48,3 +52,39 @@ def test_common_parser_accepts_gpt5_tool_preset():
     args = parser.parse_args(["--tool-preset", "gpt5"])
 
     assert args.tool_preset == "gpt5"
+
+
+class _FakePromptTemplate:
+    def __init__(self, exists: bool):
+        self._exists = exists
+
+    def joinpath(self, _filename: str):
+        return self
+
+    def is_file(self) -> bool:
+        return self._exists
+
+
+def test_swebench_uses_gpt5_system_prompt_when_available(monkeypatch):
+    monkeypatch.setattr(
+        swebench_run_infer.resources,
+        "files",
+        lambda _package: _FakePromptTemplate(True),
+    )
+
+    assert get_swebench_system_prompt("gpt5") == "system_prompt_gpt_5_4.j2"
+
+
+def test_swebench_falls_back_when_gpt5_system_prompt_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        swebench_run_infer.resources,
+        "files",
+        lambda _package: _FakePromptTemplate(False),
+    )
+
+    assert get_swebench_system_prompt("gpt5") is None
+
+
+@pytest.mark.parametrize("preset", ["default", "gemini", "planning"])
+def test_swebench_non_gpt5_presets_do_not_override_system_prompt(preset):
+    assert get_swebench_system_prompt(preset) is None


### PR DESCRIPTION
## Summary
- make `swebench` use `system_prompt_gpt_5_4.j2` when `tool_preset=gpt5` **and** the evaluated SDK actually ships that prompt template
- keep the current default-prompt behavior when the evaluated SDK does not include that template
- add focused tests for the prompt-selection helper

## Why
We want to run a branch-only eval experiment for `OpenHands/software-agent-sdk` PR #2712 without changing mainline benchmarks behavior.

The miss in the previous eval was that benchmarks selected the GPT-5 tool preset, but still constructed a plain `Agent(...)` with the default system prompt. This branch keeps the change narrow and safe for branch-based evals:
- newer SDK refs with `system_prompt_gpt_5_4.j2` get the GPT-5 prompt
- older SDK refs without that template still fall back to the default prompt

## Validation
- `uv run pytest tests/test_tool_presets.py`
- `uv run pre-commit run --files benchmarks/swebench/run_infer.py tests/test_tool_presets.py`

> This draft PR is intended for eval testing and is not meant to be merged as-is.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
