### PR TITLE
Add restriction against accessing installed package versions

### DIFF
--- a/benchmarks/commit0/prompts/default.j2
+++ b/benchmarks/commit0/prompts/default.j2
@@ -15,7 +15,12 @@ Here is your task:
   any other method to obtain the target package/library from external sources. The
   code must be written entirely by you without copying or looking at similar code online.
 
-  Do NOT pip install the target package to obtain data files. All required data files 
+  Do NOT access, copy, import from, or use the installed version of the target package
+  (e.g., in site-packages, .venv, dist-packages, pip cache, etc.). Only use the code
+  provided in the /testbed/ directory. The installed version may contain code that
+  you are supposed to implement yourself.
+
+  Do NOT pip install the target package to obtain data files. All required data files
   are already available in /testbed/<package>/ directory.
 
   When you generate code, you must maintain the original formatting of the function


### PR DESCRIPTION
## Summary

This PR adds a restriction to prevent agents from accessing the installed version of the target package, closing the cheating loophole discovered in the jinja benchmark run.

## Problem

In the jinja benchmark, the agent tried to copy the installed jinja2 from site-packages to study the reference implementation:
```
cp -r /agent-server/.venv/lib/python3.13/site-packages/jinja2 /tmp/jinja2_ref/
```

The current prompt only warned against pip installing, but did not prohibit accessing the already-installed version.

## Change

Added a new paragraph after the existing anti-cheating restrictions:

> Do NOT access, copy, import from, or use the installed version of the target package
> (e.g., in site-packages, .venv, dist-packages, pip cache, etc.). Only use the code
> provided in the /testbed/ directory. The installed version may contain code that
> you are supposed to implement yourself.

This is general enough to cover any Python package, not just jinja.

## Testing

The detect_cheating.py script in https://github.com/All-Hands-AI/research/pull/35 can be used to verify that future benchmark runs do not exhibit this pattern.