### PR TITLE
Add nightly GHCR retention workflow for eval-agent-server

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -36,11 +36,9 @@ jobs:
   clean:
     runs-on: ubuntu-latest
     timeout-minutes: 720  # 12h — first real run may delete tens of thousands of versions
-    permissions:
-      packages: write
     steps:
       - name: Delete old eval-agent-server versions
-        uses: snok/container-retention-policy@v3.0.0
+        uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03  # v3.0.0
         with:
           account: OpenHands
           token: ${{ secrets.GHCR_CLEANUP_PAT }}

--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -1,0 +1,52 @@
+name: GHCR retention - eval-agent-server
+
+# Nightly garbage collection of ghcr.io/openhands/eval-agent-server.
+# Context: see issue #684 — the package had 133k+ tags with no retention,
+# fanning out per SDK sha (97.9% of tags). This job deletes versions older
+# than the cut-off, keeping a safety buffer of the most recent versions.
+#
+# The workflow runs against the public package but still requires a PAT
+# with `delete:packages` + `read:packages` because the default GITHUB_TOKEN
+# cannot delete org-level package versions.
+
+on:
+  schedule:
+    # Daily at 03:17 UTC. Odd minute to avoid the top-of-hour stampede on GH-hosted runners.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run only (list deletions without performing them)"
+        type: boolean
+        default: true
+      cut-off:
+        description: "Age threshold (e.g. 2mo, 30d, 2w)"
+        type: string
+        default: "2mo"
+      keep-n-most-recent:
+        description: "Always keep this many most-recent versions regardless of cut-off"
+        type: string
+        default: "100"
+
+concurrency:
+  group: ghcr-retention-eval-agent-server
+  cancel-in-progress: false
+
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    timeout-minutes: 720  # 12h — first real run may delete tens of thousands of versions
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old eval-agent-server versions
+        uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: OpenHands
+          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+          image-names: eval-agent-server
+          image-tags: "!v1.0.0*"  # preserve legacy v1.0.0* tags — audit before removing this guard
+          cut-off: ${{ inputs.cut-off || '2mo' }}
+          keep-n-most-recent: ${{ inputs.keep-n-most-recent || '100' }}
+          tag-selection: both  # delete both tagged and untagged versions
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ghcr-retention.yml` — a nightly GC job that deletes old versions of `ghcr.io/openhands/eval-agent-server`. Refs #684.

## What it does

- Nightly at 03:17 UTC, plus `workflow_dispatch` with `dry-run` (default `true`), `cut-off` (default `2mo`), and `keep-n-most-recent` (default `100`) inputs. Scheduled runs perform real deletions; manual runs dry-run by default.
- Deletes versions older than `cut-off` **except** the 100 most-recently-created and any tag matching `v1.0.0*`.
- Uses [`snok/container-retention-policy@v3.0.0`](https://github.com/snok/container-retention-policy) — handles multi-arch manifest lists so deleting a parent index doesn't leave dangling children.
- Scoped to `eval-agent-server` only.

## Prerequisites

1. Add secret `GHCR_CLEANUP_PAT` — classic PAT with `delete:packages` + `read:packages` (or fine-grained with `Packages: read & write` on the org). `GITHUB_TOKEN` cannot delete org package versions.
2. Confirm `benchmarks` has `Write` role at https://github.com/orgs/OpenHands/packages/container/eval-agent-server/settings (the existing 8 build workflows already push successfully, so this is likely already set).

## Rollout

1. Merge.
2. Trigger manually with `dry-run: true` → read the log, sanity-check the delete count (expect tens of thousands).
3. Trigger manually with `dry-run: false` for the first real purge, or wait for the next nightly. First run may take hours due to GHCR secondary rate limits (`timeout-minutes: 720`).

## Known gap

Retention does not cross-reference eval metadata on GCS (`gs://openhands-evaluation-results/metadata/*.jsonl`), so an in-flight eval against a >2mo SDK sha could lose its image mid-run. Low probability given the 100-version buffer; proper fix (pre-delete jsonl filter) is a follow-up PR. cc @juanmichelini @simonrosenberg.

## Test plan

- [ ] Add `GHCR_CLEANUP_PAT` secret
- [ ] Confirm package-repo link has `Write` role
- [ ] Manual dispatch with `dry-run: true` — inspect the deletion list
- [ ] Manual dispatch with `dry-run: false` for the first real purge
- [ ] Verify post-run tag count via `ghcr.io/v2/openhands/eval-agent-server/tags/list` (expect ~130k → a few thousand)
- [ ] Confirm a subsequent `build-swebench-images.yml` run still succeeds