### PR TITLE
fix(image-build): release Docker disk during SWE/SWT assembly

### DIFF
--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -215,22 +215,35 @@ jobs:
         run: |
           make build
 
-      - name: "Preflight: verify runner disk"
+      - name: "Preflight: prune cache and verify BuildKit disk"
         run: |
           set -euo pipefail
-          df -h / || true
-          docker system df || true
-          # ubuntu-latest-8core has about 290 GiB total; after the free-disk
-          # step the SWT validation runs reported about 260 GiB free. Refuse
-          # to start a full cold build if the runner is far below that baseline.
-          MIN_GB=150
-          FREE_BYTES=$(df -B1 --output=avail / | tail -n1 | tr -d ' ')
-          MIN_BYTES=$((MIN_GB * 1024 * 1024 * 1024))
-          if [ "${FREE_BYTES:-0}" -lt "$MIN_BYTES" ]; then
-            echo "::error::Root filesystem has less than ${MIN_GB} GiB free (${FREE_BYTES} B). Refusing to start a full cold build."
-            exit 1
+          KEEP_GB=60
+          echo "Pruning BuildKit cache (target max-storage ${KEEP_GB} GiB, no filters)..."
+          # Prefer newer max-storage flag; fall back to keep-storage if not supported.
+          if ! docker buildx prune --all --force --max-storage ${KEEP_GB}g; then
+            docker buildx prune --all --force --keep-storage ${KEEP_GB}g || true
           fi
-          echo "Root filesystem free: ${FREE_BYTES} B (min ${MIN_BYTES} B) - ok"
+
+          if df -B1 /var/lib/buildkit > /tmp/buildkit_df 2>/dev/null; then
+            LINE=$(tail -n1 /tmp/buildkit_df)
+            TOTAL=$(echo "$LINE" | awk '{print $2}')
+            USED=$(echo "$LINE" | awk '{print $3}')
+            FREE=$(echo "$LINE" | awk '{print $4}')
+            if [ -n "$TOTAL" ] && [ -n "$FREE" ]; then
+              PCT=$(( 100 * USED / TOTAL ))
+              echo "BuildKit disk: used ${USED} / ${TOTAL} bytes (${PCT}%); free ${FREE} bytes"
+              MIN=$((75 * 1024 * 1024 * 1024))
+              if [ "$FREE" -lt "$MIN" ]; then
+                echo "::error::Not enough free space on /var/lib/buildkit (${FREE} bytes free, need >= ${MIN})"
+                exit 1
+              fi
+            else
+              echo "Warning: unable to parse df output for /var/lib/buildkit"
+            fi
+          else
+            echo "Warning: /var/lib/buildkit not found; skipping disk check"
+          fi
 
       - name: Build and push SWE-Bench images
         run: |

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -196,6 +196,20 @@ jobs:
           git add vendor/software-agent-sdk
           echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
 
+      # Reclaim runner disk by removing preinstalled toolchains we do not use.
+      # Full 500-image SWE-bench assembly has hit /var/lib/docker BuildKit
+      # ingest ENOSPC on ubuntu-latest-8core after the Blacksmith migration.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -215,35 +229,22 @@ jobs:
         run: |
           make build
 
-      - name: "Preflight: prune cache and verify BuildKit disk"
+      - name: "Preflight: verify runner disk"
         run: |
           set -euo pipefail
-          KEEP_GB=60
-          echo "Pruning BuildKit cache (target max-storage ${KEEP_GB} GiB, no filters)..."
-          # Prefer newer max-storage flag; fall back to keep-storage if not supported.
-          if ! docker buildx prune --all --force --max-storage ${KEEP_GB}g; then
-            docker buildx prune --all --force --keep-storage ${KEEP_GB}g || true
+          df -h / || true
+          docker system df || true
+          # ubuntu-latest-8core has about 290 GiB total; after the free-disk
+          # step the SWT validation runs reported about 260 GiB free. Refuse
+          # to start a full cold build if the runner is far below that baseline.
+          MIN_GB=150
+          FREE_BYTES=$(df -B1 --output=avail / | tail -n1 | tr -d ' ')
+          MIN_BYTES=$((MIN_GB * 1024 * 1024 * 1024))
+          if [ "${FREE_BYTES:-0}" -lt "$MIN_BYTES" ]; then
+            echo "::error::Root filesystem has less than ${MIN_GB} GiB free (${FREE_BYTES} B). Refusing to start a full cold build."
+            exit 1
           fi
-
-          if df -B1 /var/lib/buildkit > /tmp/buildkit_df 2>/dev/null; then
-            LINE=$(tail -n1 /tmp/buildkit_df)
-            TOTAL=$(echo "$LINE" | awk '{print $2}')
-            USED=$(echo "$LINE" | awk '{print $3}')
-            FREE=$(echo "$LINE" | awk '{print $4}')
-            if [ -n "$TOTAL" ] && [ -n "$FREE" ]; then
-              PCT=$(( 100 * USED / TOTAL ))
-              echo "BuildKit disk: used ${USED} / ${TOTAL} bytes (${PCT}%); free ${FREE} bytes"
-              MIN=$((75 * 1024 * 1024 * 1024))
-              if [ "$FREE" -lt "$MIN" ]; then
-                echo "::error::Not enough free space on /var/lib/buildkit (${FREE} bytes free, need >= ${MIN})"
-                exit 1
-              fi
-            else
-              echo "Warning: unable to parse df output for /var/lib/buildkit"
-            fi
-          else
-            echo "Warning: /var/lib/buildkit not found; skipping disk check"
-          fi
+          echo "Root filesystem free: ${FREE_BYTES} B (min ${MIN_BYTES} B) - ok"
 
       - name: Build and push SWE-Bench images
         run: |

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -196,20 +196,6 @@ jobs:
           git add vendor/software-agent-sdk
           echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
 
-      # Reclaim runner disk by removing preinstalled toolchains we do not use.
-      # Full 500-image SWE-bench assembly has hit /var/lib/docker BuildKit
-      # ingest ENOSPC on ubuntu-latest-8core after the Blacksmith migration.
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/benchmarks/swebench/build_base_images.py
+++ b/benchmarks/swebench/build_base_images.py
@@ -611,6 +611,57 @@ def assemble_agent_image(
         return BuildOutput(base_image=base_tag, tags=pushed_tags, error=error_summary)
 
     push_seconds = round(push_seconds, 3)
+
+    # Release disk after successful pushes. Full cold SWE/SWT-bench builds on
+    # ubuntu-latest-8core otherwise keep every final image and BuildKit ingest
+    # blob in the local daemon until the runner runs out of disk.
+    if push and pushed_tags:
+        rmi_targets = list(dict.fromkeys([*pushed_tags, base_tag]))
+        rmi_proc, rmi_timeout = _run_docker_command(
+            ["docker", "rmi", "-f", *rmi_targets]
+        )
+        if rmi_timeout:
+            logger.warning("[assembly] rmi timed out for %s", tag_label)
+        elif rmi_proc is not None and rmi_proc.returncode != 0:
+            logger.warning(
+                "[assembly] rmi failed for %s (rc=%d): %s",
+                tag_label,
+                rmi_proc.returncode,
+                (rmi_proc.stderr or rmi_proc.stdout or "").strip()[:200],
+            )
+
+        sys_prune_proc, sys_prune_timeout = _run_docker_command(
+            ["docker", "system", "prune", "-f"]
+        )
+        if sys_prune_timeout:
+            logger.warning("[assembly] system prune timed out for %s", tag_label)
+        elif sys_prune_proc is not None and sys_prune_proc.returncode != 0:
+            logger.warning(
+                "[assembly] system prune failed for %s (rc=%d)",
+                tag_label,
+                sys_prune_proc.returncode,
+            )
+
+        buildkit_cap_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "30"))
+        bp_proc, bp_timeout = _run_docker_command(
+            [
+                "docker",
+                "builder",
+                "prune",
+                "-af",
+                "--keep-storage",
+                f"{buildkit_cap_gb}g",
+            ]
+        )
+        if bp_timeout:
+            logger.warning("[assembly] buildkit prune timed out for %s", tag_label)
+        elif bp_proc is not None and bp_proc.returncode != 0:
+            logger.warning(
+                "[assembly] buildkit prune failed for %s (rc=%d)",
+                tag_label,
+                bp_proc.returncode,
+            )
+
     total_seconds = round(time.monotonic() - overall_started, 3)
 
     logger.info(
@@ -724,6 +775,17 @@ def assemble_all_agent_images(
     _, git_sha, _ = _get_sdk_submodule_info()
     sdk_short_sha = git_sha[:7] if git_sha != "unknown" else "unknown"
     content_hash = dockerfile_content_hash()
+
+    logger.info("Pre-assembly prune of buildx-container builder cache")
+    bx_proc, bx_timeout = _run_docker_command(["docker", "buildx", "prune", "-af"])
+    if bx_timeout:
+        logger.warning("Pre-assembly buildx prune timed out")
+    elif bx_proc is not None and bx_proc.returncode != 0:
+        logger.warning(
+            "Pre-assembly buildx prune failed (rc=%d): %s",
+            bx_proc.returncode,
+            (bx_proc.stderr or bx_proc.stdout or "").strip()[:200],
+        )
 
     build_log_dir = build_dir / "assembly-logs"
     manifest_file = build_dir / "manifest.jsonl"

--- a/tests/test_phased_build.py
+++ b/tests/test_phased_build.py
@@ -322,6 +322,26 @@ class TestAssembleAgentImage:
 
         assert result.error is None
         assert result.tags == ["tag-1", "tag-2"]
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert commands[-3:] == [
+            [
+                "docker",
+                "rmi",
+                "-f",
+                "tag-1",
+                "tag-2",
+                "ghcr.io/openhands/eval-base:abc",
+            ],
+            ["docker", "system", "prune", "-f"],
+            [
+                "docker",
+                "builder",
+                "prune",
+                "-af",
+                "--keep-storage",
+                "30g",
+            ],
+        ]
 
     def test_missing_dockerfile_returns_error(self, tmp_path):
         from benchmarks.swebench.build_base_images import assemble_agent_image
@@ -443,6 +463,10 @@ class TestBuildAllBaseImages:
 
 
 class TestAssembleAllAgentImages:
+    @patch(
+        "benchmarks.swebench.build_base_images._run_docker_command",
+        return_value=(_ok_proc(), None),
+    )
     @patch("benchmarks.swebench.build_base_images._assemble_with_logging")
     @patch(
         "benchmarks.swebench.build_base_images._get_sdk_submodule_info",
@@ -451,7 +475,9 @@ class TestAssembleAllAgentImages:
     @patch(
         "benchmarks.swebench.build_base_images.ProcessPoolExecutor", new=_thread_pool
     )
-    def test_manifest_written(self, mock_sdk, mock_assemble, tmp_path):
+    def test_manifest_written(
+        self, mock_sdk, mock_assemble, mock_docker_command, tmp_path
+    ):
         from benchmarks.swebench.build_base_images import assemble_all_agent_images
 
         ok = BuildOutput(base_image="img-a", tags=["final-tag"], error=None)
@@ -472,6 +498,9 @@ class TestAssembleAllAgentImages:
         ]
         assert len(records) == 1
         assert records[0]["tags"] == ["final-tag"]
+        mock_docker_command.assert_called_once_with(
+            ["docker", "buildx", "prune", "-af"]
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

SWE-bench and SWT-bench share the phased image assembly implementation in `benchmarks/swebench/build_base_images.py`. After the migration from Blacksmith to `ubuntu-latest-8core`, full cold image builds can exhaust Docker/BuildKit storage during assembly because pushed images and BuildKit ingest/cache data accumulate on the runner.

This PR keeps the fix in the shared assembly code only, so it applies to both SWE-bench and SWT-bench without workflow-specific preflight or generic runner disk cleanup changes.

## Evidence

SWE-bench showed the same failure mode as SWT-bench in workflow run 24433528621: a 500-image build on `ubuntu-latest-8core` only completed 113 assemblies and failed 387 with BuildKit errors such as:

- `ResourceExhausted: failed to copy: write /var/lib/docker/buildkit/content/ingest/.../data: no space left on device`
- `failed to open writer: mkdir /var/lib/docker/buildkit/content/ingest/...: no space left on device`

The symptom is Docker/BuildKit disk growth during local assembly, so the fix belongs in the shared assembly path rather than each workflow.

## Changes

- `assemble_agent_image`: after successful pushes, remove the pushed final tags and per-instance base tag, then run warning-only Docker cleanup:
  - `docker rmi -f ...`
  - `docker system prune -f`
  - `docker builder prune -af --keep-storage ${OPENHANDS_BUILDKIT_KEEP_STORAGE_GB:-30}g`
- `assemble_all_agent_images`: prune the selected buildx container cache before local daemon assembly starts.
- Tests cover the cleanup commands and pre-assembly prune.

## Intentionally unchanged

- No SWE-bench workflow preflight changes.
- No SWT-bench workflow preflight changes.
- No third-party `free-disk-space` action.

## Testing

- `uv run pytest tests/test_phased_build.py`
- `uv run ruff check benchmarks/swebench/build_base_images.py tests/test_phased_build.py`
- `git diff --check`

## Full validation

Both full image-building workflows succeeded from this PR head (`d3844b7354b6613af21c8d075cfe282304750ca6`):

- SWE-bench: https://github.com/OpenHands/benchmarks/actions/runs/24829894649
  - `princeton-nlp/SWE-bench_Verified`, `test`, `n-limit=500`, `force-build=true`
  - Base images: `Built=500 Failed=0`
  - Assembly: `Built=500 Skipped=0 Failed=0`
  - Duration: about 4h40m
- SWT-bench: https://github.com/OpenHands/benchmarks/actions/runs/24829894700
  - `eth-sri/SWT-bench_Verified_bm25_27k_zsp`, `test`, `n-limit=0`, `force-build=true`
  - Base images: `Built=433 Failed=0`
  - Assembly: `Built=433 Skipped=0 Failed=0`
  - Duration: about 5h48m

## AI disclosure

This PR was prepared by Codex on behalf of @simonrosenberg.
