### PR TITLE
Strengthen restriction against accessing installed package versions

### DIFF
--- a/benchmarks/commit0/prompts/default.j2
+++ b/benchmarks/commit0/prompts/default.j2
@@ -15,10 +15,12 @@ Here is your task:
   any other method to obtain the target package/library from external sources. The
   code must be written entirely by you without copying or looking at similar code online.
 
-  Do NOT access, copy, import from, or use the installed version of the target package
-  (e.g., in site-packages, .venv, dist-packages, pip cache, etc.). Only use the code
-  provided in the /testbed/ directory. The installed version may contain code that
-  you are supposed to implement yourself.
+  Do NOT access, copy, import from, or use any installed version of the target package.
+  This includes ANY site-packages, .venv, venv, dist-packages, pip cache, or editable
+  install locations - whether in /home, /usr, /agent-server, /testbed, or anywhere else
+  on the system. Only use the code provided in the /testbed/<package>/ directory.
+  The installed version contains code that you are supposed to implement yourself.
+  Do NOT read files, list directories, or import from any installed package location.
 
   Do NOT pip install the target package to obtain data files. All required data files
   are already available in /testbed/<package>/ directory.


### PR DESCRIPTION
## Summary

This PR strengthens the anti-cheating restriction in the commit0 prompt to prevent agents from accessing ANY installed version of the target package.

## Problem

The previous fix (PR #687) prohibited accessing site-packages and .venv, but agents found loopholes:

1. **simpy case**: Agent accessed  to read metadata
2. **jinja case**: Agent accessed 

## Fix

The new text explicitly prohibits:
- ANY site-packages, .venv, venv, dist-packages locations
- Locations in /home, /usr, /agent-server, /testbed, or anywhere else on the system
- Reading files, listing directories, or importing from any installed package location

> Do NOT access, copy, import from, or use any installed version of the target package.
> This includes ANY site-packages, .venv, venv, dist-packages, pip cache, or editable
> install locations - whether in /home, /usr, /agent-server, /testbed, or anywhere else
> on the system. Only use the code provided in the /testbed/<package>/ directory.
> The installed version contains code that you are supposed to implement yourself.
> Do NOT read files, list directories, or import from any installed package location.

## Testing

This fix should prevent the cheating patterns observed in:
- Run 24745405298: jinja accessing /agent-server/.venv
- Run 24787421361: simpy accessing /testbed/.venv