### PR TITLE
fix(commit0): fix ACP packages and switch to ubuntu-latest-8core runner

### DIFF
--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -86,7 +86,7 @@ env:
   DATASET: wentingzhao/commit0_combined
   SPLIT: test
   REPO_SPLIT: lite
-  MAX_WORKERS: '4'
+  MAX_WORKERS: '8'
   N_LIMIT: ''
   INSTANCE_IDS: ''
   SELECT_FILE: ''

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -180,6 +180,15 @@ jobs:
         run: |
           make build
 
+      - name: Pre-flight disk and Docker status
+        run: |
+          echo "=== Disk usage ==="
+          df -h
+          echo "=== Memory ==="
+          free -h
+          echo "=== Docker system df ==="
+          docker system df || true
+
       - name: Build and push Commit0 images
         run: |
           set -euo pipefail

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -86,7 +86,7 @@ env:
   DATASET: wentingzhao/commit0_combined
   SPLIT: test
   REPO_SPLIT: lite
-  MAX_WORKERS: '8'
+  MAX_WORKERS: '4'
   N_LIMIT: ''
   INSTANCE_IDS: ''
   SELECT_FILE: ''

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -86,7 +86,7 @@ env:
   DATASET: wentingzhao/commit0_combined
   SPLIT: test
   REPO_SPLIT: lite
-  MAX_WORKERS: '4'
+  MAX_WORKERS: '1'
   N_LIMIT: ''
   INSTANCE_IDS: ''
   SELECT_FILE: ''

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -192,6 +192,7 @@ jobs:
           if ! docker buildx prune --all --force --max-storage ${KEEP_GB}g 2>/dev/null; then
             docker buildx prune --all --force --keep-storage ${KEEP_GB}g || true
           fi
+          docker builder prune -af --keep-storage ${KEEP_GB}g || true
           docker system prune -f || true
           echo "=== Post-prune disk ==="
           df -h

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -86,7 +86,7 @@ env:
   DATASET: wentingzhao/commit0_combined
   SPLIT: test
   REPO_SPLIT: lite
-  MAX_WORKERS: '1'
+  MAX_WORKERS: '4'
   N_LIMIT: ''
   INSTANCE_IDS: ''
   SELECT_FILE: ''
@@ -103,7 +103,7 @@ jobs:
 
     timeout-minutes: 600  # 10h — matches the old orchestrate_eval.py polling bound in the evaluation repo
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest-8core
 
     permissions:
       contents: read

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -180,13 +180,21 @@ jobs:
         run: |
           make build
 
-      - name: Pre-flight disk and Docker status
+      - name: "Preflight: prune cache and verify disk"
         run: |
-          echo "=== Disk usage ==="
+          set -euo pipefail
+          echo "=== Pre-prune disk ==="
           df -h
-          echo "=== Memory ==="
           free -h
-          echo "=== Docker system df ==="
+          docker system df || true
+          KEEP_GB=30
+          echo "Pruning BuildKit cache to ${KEEP_GB} GiB..."
+          if ! docker buildx prune --all --force --max-storage ${KEEP_GB}g 2>/dev/null; then
+            docker buildx prune --all --force --keep-storage ${KEEP_GB}g || true
+          fi
+          docker system prune -f || true
+          echo "=== Post-prune disk ==="
+          df -h
           docker system df || true
 
       - name: Build and push Commit0 images

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -199,19 +199,6 @@ def _assemble_commit0_image(
             error=f"docker buildx build exited {proc.returncode} for {base_image}",
         )
 
-    # Release disk after a successful push. ubuntu-24.04 runners have ~14 GiB
-    # free; building and exporting 16 large images without pruning fills the
-    # BuildKit content store and kills the runner mid-export.
-    if push:
-        keep_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "8"))
-        for prune_cmd in [
-            ["docker", "rmi", "-f", final_tag],
-            ["docker", "system", "prune", "-f"],
-            ["docker", "builder", "prune", "-af", "--keep-storage", f"{keep_gb}g"],
-        ]:
-            subprocess.run(prune_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        _log_disk(f"post-prune {base_image}")
-
     return BuildOutput(base_image=base_image, tags=[final_tag], error=None)
 
 
@@ -299,19 +286,19 @@ def assemble_commit0_agent_images(
     logger.info(
         "Starting commit0 assembly: %d images, max_workers=%d", len(base_images), max_workers
     )
-    # Prune BuildKit cache accumulated during the builder-image build phase
-    # before starting the per-image assembly loop.
-    subprocess.run(
-        ["docker", "buildx", "prune", "-af"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    _log_disk("post-pre-assembly-prune")
 
     built = 0
     skipped = 0
     failures = 0
     mu = Lock()
+
+    # Process in batches so we can prune BuildKit cache from the main process
+    # between batches without racing against active worker builds.
+    # ubuntu-24.04 runners have ~14 GiB free; without inter-batch pruning the
+    # BuildKit content store fills up and the runner is OOM/disk-killed.
+    batch_size = max_workers
+    batches = [base_images[i : i + batch_size] for i in range(0, len(base_images), batch_size)]
+    keep_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "8"))
 
     with (
         manifest_file.open("w") as writer,
@@ -321,63 +308,31 @@ def assemble_commit0_agent_images(
     ):
         _update_pbar(pbar, built, skipped, failures, 0, None, "Queueing")
 
-        with ProcessPoolExecutor(max_workers=max_workers) as ex:
-            futures = {}
-            in_progress: set[str] = set()
-            for base_image in base_images:
-                in_progress.add(base_image)
-                final_tag = get_agent_server_image_tag(base_image, target, target_image)
-                fut = ex.submit(
-                    _assemble_commit0_with_logging,
-                    log_dir=build_log_dir,
-                    base_image=base_image,
-                    builder_tag=builder_tag,
-                    final_tag=final_tag,
-                    git_sha=git_sha,
-                    push=push,
-                    max_retries=max_retries,
-                    force_build=force_build,
-                )
-                futures[fut] = base_image
-
-            _update_pbar(
-                pbar,
-                built,
-                skipped,
-                failures,
-                len(in_progress),
-                next(iter(in_progress), None),
-                "Assembling",
+        for batch_idx, batch in enumerate(batches, start=1):
+            logger.info(
+                "Batch %d/%d (%d images)", batch_idx, len(batches), len(batch)
             )
+            _log_disk(f"batch {batch_idx} start")
 
-            for fut in as_completed(futures):
-                base_image = futures[fut]
-                try:
-                    result: BuildOutput = fut.result()
-                except Exception as e:
-                    logger.error("Commit0 assembly failed for %s: %r", base_image, e)
-                    result = BuildOutput(base_image=base_image, tags=[], error=repr(e))
+            with ProcessPoolExecutor(max_workers=max_workers) as ex:
+                futures = {}
+                in_progress: set[str] = set()
+                for base_image in batch:
+                    in_progress.add(base_image)
+                    final_tag = get_agent_server_image_tag(base_image, target, target_image)
+                    fut = ex.submit(
+                        _assemble_commit0_with_logging,
+                        log_dir=build_log_dir,
+                        base_image=base_image,
+                        builder_tag=builder_tag,
+                        final_tag=final_tag,
+                        git_sha=git_sha,
+                        push=push,
+                        max_retries=max_retries,
+                        force_build=force_build,
+                    )
+                    futures[fut] = base_image
 
-                writer.write(result.model_dump_json() + "\n")
-                writer.flush()
-
-                with mu:
-                    if result.error or not result.tags:
-                        failures += 1
-                        status = "❌ Failed"
-                        logger.error(
-                            "Assembly FAILED for %s: %s", base_image, result.error
-                        )
-                    elif result.status == "skipped_remote_exists":
-                        skipped += 1
-                        status = "⏭ Skipped"
-                    else:
-                        built += 1
-                        status = "✅ Done"
-                    _log_disk(f"after {base_image} ({status})")
-
-                in_progress.discard(base_image)
-                pbar.update(1)
                 _update_pbar(
                     pbar,
                     built,
@@ -385,8 +340,59 @@ def assemble_commit0_agent_images(
                     failures,
                     len(in_progress),
                     next(iter(in_progress), None),
-                    status,
+                    f"Batch {batch_idx}/{len(batches)}",
                 )
+
+                for fut in as_completed(futures):
+                    base_image = futures[fut]
+                    try:
+                        result: BuildOutput = fut.result()
+                    except Exception as e:
+                        logger.error("Commit0 assembly failed for %s: %r", base_image, e)
+                        result = BuildOutput(base_image=base_image, tags=[], error=repr(e))
+
+                    writer.write(result.model_dump_json() + "\n")
+                    writer.flush()
+
+                    with mu:
+                        if result.error or not result.tags:
+                            failures += 1
+                            status = "❌ Failed"
+                            logger.error(
+                                "Assembly FAILED for %s: %s", base_image, result.error
+                            )
+                        elif result.status == "skipped_remote_exists":
+                            skipped += 1
+                            status = "⏭ Skipped"
+                        else:
+                            built += 1
+                            status = "✅ Done"
+
+                    in_progress.discard(base_image)
+                    pbar.update(1)
+                    _update_pbar(
+                        pbar,
+                        built,
+                        skipped,
+                        failures,
+                        len(in_progress),
+                        next(iter(in_progress), None),
+                        status,
+                    )
+
+            # All workers in this batch are done — safe to prune from main process.
+            _log_disk(f"batch {batch_idx} end (pre-prune)")
+            subprocess.run(
+                ["docker", "system", "prune", "-f"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            subprocess.run(
+                ["docker", "builder", "prune", "-af", "--keep-storage", f"{keep_gb}g"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            _log_disk(f"batch {batch_idx} end (post-prune)")
 
     logger.info(
         "Commit0 image assembly done. Built=%d Skipped=%d Failed=%d Manifest=%s",

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -198,6 +198,20 @@ def _assemble_commit0_image(
             tags=[],
             error=f"docker buildx build exited {proc.returncode} for {base_image}",
         )
+
+    # Release disk after a successful push. ubuntu-24.04 runners have ~14 GiB
+    # free; building and exporting 16 large images without pruning fills the
+    # BuildKit content store and kills the runner mid-export.
+    if push:
+        keep_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "8"))
+        for prune_cmd in [
+            ["docker", "rmi", "-f", final_tag],
+            ["docker", "system", "prune", "-f"],
+            ["docker", "builder", "prune", "-af", "--keep-storage", f"{keep_gb}g"],
+        ]:
+            subprocess.run(prune_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        _log_disk(f"post-prune {base_image}")
+
     return BuildOutput(base_image=base_image, tags=[final_tag], error=None)
 
 
@@ -285,6 +299,14 @@ def assemble_commit0_agent_images(
     logger.info(
         "Starting commit0 assembly: %d images, max_workers=%d", len(base_images), max_workers
     )
+    # Prune BuildKit cache accumulated during the builder-image build phase
+    # before starting the per-image assembly loop.
+    subprocess.run(
+        ["docker", "buildx", "prune", "-af"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    _log_disk("post-pre-assembly-prune")
 
     built = 0
     skipped = 0

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -10,7 +10,6 @@ Example:
 
 import hashlib
 import os
-import shutil
 import subprocess
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -134,19 +133,6 @@ def collect_base_images(
     return [get_base_docker_image(repo, docker_image_prefix) for repo in repos]
 
 
-def _log_disk(label: str) -> None:
-    """Log free disk space to stderr so it appears in the GH Actions log."""
-    try:
-        usage = shutil.disk_usage("/")
-        free_gib = usage.free / (1024**3)
-        total_gib = usage.total / (1024**3)
-        used_pct = (usage.used / usage.total) * 100
-        msg = f"[disk] {label}: {free_gib:.1f} GiB free / {total_gib:.1f} GiB total ({used_pct:.1f}% used)\n"
-        os.write(2, msg.encode())  # write to original fd 2 (bypasses capture_output redirect)
-    except Exception:
-        pass
-
-
 def _assemble_commit0_image(
     *,
     base_image: str,
@@ -155,49 +141,39 @@ def _assemble_commit0_image(
     git_sha: str,
     push: bool,
 ) -> BuildOutput:
-    cmd = [
-        "docker",
-        "buildx",
-        "build",
-        "--file",
-        str(COMMIT0_AGENT_LAYER_DOCKERFILE),
-        "--build-arg",
-        f"BASE_IMAGE={base_image}",
-        "--build-arg",
-        f"BUILDER_IMAGE={builder_tag}",
-        "--build-arg",
-        f"OPENHANDS_BUILD_GIT_SHA={git_sha}",
-        "--tag",
-        final_tag,
-        "--platform",
-        "linux/amd64",
+    # Build into the local Docker daemon (same pattern as swebench assemble_agent_image).
+    # This avoids BuildKit content-store accumulation that occurs with --push via buildx.
+    build_cmd = [
+        "docker", "build",
+        "--file", str(COMMIT0_AGENT_LAYER_DOCKERFILE),
+        "--build-arg", f"BASE_IMAGE={base_image}",
+        "--build-arg", f"BUILDER_IMAGE={builder_tag}",
+        "--build-arg", f"OPENHANDS_BUILD_GIT_SHA={git_sha}",
+        "--tag", final_tag,
+        str(COMMIT0_AGENT_LAYER_DOCKERFILE.parent),
     ]
-    if push:
-        cmd.append("--push")
-    else:
-        cmd.append("--load")
-    cmd.append(str(COMMIT0_AGENT_LAYER_DOCKERFILE.parent))
-
-    header = f"\n=== commit0 docker build: {base_image} → {final_tag} ===\n"
-    os.write(2, header.encode())
-    _log_disk(f"pre-build {base_image}")
-
-    # Run without capture_output so workers stream directly to the inherited OS
-    # file descriptors (fd 1/2 = GH Actions log). This makes output visible in
-    # the step log in real-time — critical for diagnosing mid-build failures
-    # where the runner is killed before any Python-level logging can flush.
-    proc = subprocess.run(cmd)
-
-    _log_disk(f"post-build {base_image}")
-    footer = f"=== done: {base_image} exit={proc.returncode} ===\n"
-    os.write(2, footer.encode())
-
+    proc = subprocess.run(build_cmd, capture_output=True, text=True)
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
     if proc.returncode != 0:
-        return BuildOutput(
-            base_image=base_image,
-            tags=[],
-            error=f"docker buildx build exited {proc.returncode} for {base_image}",
-        )
+        error = proc.stderr.strip() or proc.stdout.strip() or f"docker build failed (rc={proc.returncode})"
+        return BuildOutput(base_image=base_image, tags=[], error=error)
+
+    if push:
+        push_proc = subprocess.run(["docker", "push", final_tag], capture_output=True, text=True)
+        if push_proc.stdout:
+            print(push_proc.stdout, end="")
+        if push_proc.stderr:
+            print(push_proc.stderr, end="", file=sys.stderr)
+        if push_proc.returncode != 0:
+            error = push_proc.stderr.strip() or f"docker push failed (rc={push_proc.returncode})"
+            return BuildOutput(base_image=base_image, tags=[], error=error)
+
+        # Free local daemon storage after a successful push.
+        subprocess.run(["docker", "rmi", "-f", final_tag], capture_output=True)
+        subprocess.run(["docker", "system", "prune", "-f"], capture_output=True)
 
     return BuildOutput(base_image=base_image, tags=[final_tag], error=None)
 
@@ -282,23 +258,10 @@ def assemble_commit0_agent_images(
     manifest_file = build_dir / "manifest.jsonl"
     manifest_file.parent.mkdir(parents=True, exist_ok=True)
 
-    _log_disk("pre-assembly")
-    logger.info(
-        "Starting commit0 assembly: %d images, max_workers=%d", len(base_images), max_workers
-    )
-
     built = 0
     skipped = 0
     failures = 0
     mu = Lock()
-
-    # Process in batches so we can prune BuildKit cache from the main process
-    # between batches without racing against active worker builds.
-    # ubuntu-24.04 runners have ~14 GiB free; without inter-batch pruning the
-    # BuildKit content store fills up and the runner is OOM/disk-killed.
-    batch_size = max_workers
-    batches = [base_images[i : i + batch_size] for i in range(0, len(base_images), batch_size)]
-    keep_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "8"))
 
     with (
         manifest_file.open("w") as writer,
@@ -308,31 +271,59 @@ def assemble_commit0_agent_images(
     ):
         _update_pbar(pbar, built, skipped, failures, 0, None, "Queueing")
 
-        for batch_idx, batch in enumerate(batches, start=1):
-            logger.info(
-                "Batch %d/%d (%d images)", batch_idx, len(batches), len(batch)
+        with ProcessPoolExecutor(max_workers=max_workers) as ex:
+            futures = {}
+            in_progress: set[str] = set()
+            for base_image in base_images:
+                in_progress.add(base_image)
+                final_tag = get_agent_server_image_tag(base_image, target, target_image)
+                fut = ex.submit(
+                    _assemble_commit0_with_logging,
+                    log_dir=build_log_dir,
+                    base_image=base_image,
+                    builder_tag=builder_tag,
+                    final_tag=final_tag,
+                    git_sha=git_sha,
+                    push=push,
+                    max_retries=max_retries,
+                    force_build=force_build,
+                )
+                futures[fut] = base_image
+
+            _update_pbar(
+                pbar,
+                built,
+                skipped,
+                failures,
+                len(in_progress),
+                next(iter(in_progress), None),
+                "Assembling",
             )
-            _log_disk(f"batch {batch_idx} start")
 
-            with ProcessPoolExecutor(max_workers=max_workers) as ex:
-                futures = {}
-                in_progress: set[str] = set()
-                for base_image in batch:
-                    in_progress.add(base_image)
-                    final_tag = get_agent_server_image_tag(base_image, target, target_image)
-                    fut = ex.submit(
-                        _assemble_commit0_with_logging,
-                        log_dir=build_log_dir,
-                        base_image=base_image,
-                        builder_tag=builder_tag,
-                        final_tag=final_tag,
-                        git_sha=git_sha,
-                        push=push,
-                        max_retries=max_retries,
-                        force_build=force_build,
-                    )
-                    futures[fut] = base_image
+            for fut in as_completed(futures):
+                base_image = futures[fut]
+                try:
+                    result: BuildOutput = fut.result()
+                except Exception as e:
+                    logger.error("Commit0 assembly failed for %s: %r", base_image, e)
+                    result = BuildOutput(base_image=base_image, tags=[], error=repr(e))
 
+                writer.write(result.model_dump_json() + "\n")
+                writer.flush()
+
+                with mu:
+                    if result.error or not result.tags:
+                        failures += 1
+                        status = "❌ Failed"
+                    elif result.status == "skipped_remote_exists":
+                        skipped += 1
+                        status = "⏭ Skipped"
+                    else:
+                        built += 1
+                        status = "✅ Done"
+
+                in_progress.discard(base_image)
+                pbar.update(1)
                 _update_pbar(
                     pbar,
                     built,
@@ -340,59 +331,8 @@ def assemble_commit0_agent_images(
                     failures,
                     len(in_progress),
                     next(iter(in_progress), None),
-                    f"Batch {batch_idx}/{len(batches)}",
+                    status,
                 )
-
-                for fut in as_completed(futures):
-                    base_image = futures[fut]
-                    try:
-                        result: BuildOutput = fut.result()
-                    except Exception as e:
-                        logger.error("Commit0 assembly failed for %s: %r", base_image, e)
-                        result = BuildOutput(base_image=base_image, tags=[], error=repr(e))
-
-                    writer.write(result.model_dump_json() + "\n")
-                    writer.flush()
-
-                    with mu:
-                        if result.error or not result.tags:
-                            failures += 1
-                            status = "❌ Failed"
-                            logger.error(
-                                "Assembly FAILED for %s: %s", base_image, result.error
-                            )
-                        elif result.status == "skipped_remote_exists":
-                            skipped += 1
-                            status = "⏭ Skipped"
-                        else:
-                            built += 1
-                            status = "✅ Done"
-
-                    in_progress.discard(base_image)
-                    pbar.update(1)
-                    _update_pbar(
-                        pbar,
-                        built,
-                        skipped,
-                        failures,
-                        len(in_progress),
-                        next(iter(in_progress), None),
-                        status,
-                    )
-
-            # All workers in this batch are done — safe to prune from main process.
-            _log_disk(f"batch {batch_idx} end (pre-prune)")
-            subprocess.run(
-                ["docker", "system", "prune", "-f"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            subprocess.run(
-                ["docker", "builder", "prune", "-af", "--keep-storage", f"{keep_gb}g"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            _log_disk(f"batch {batch_idx} end (post-prune)")
 
     logger.info(
         "Commit0 image assembly done. Built=%d Skipped=%d Failed=%d Manifest=%s",

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -171,9 +171,15 @@ def _assemble_commit0_image(
             error = push_proc.stderr.strip() or f"docker push failed (rc={push_proc.returncode})"
             return BuildOutput(base_image=base_image, tags=[], error=error)
 
-        # Free local daemon storage after a successful push.
+        # Free local daemon storage and limit embedded BuildKit cache after each push,
+        # matching what swebench's assemble_agent_image does (PR #690).
+        keep_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "30"))
         subprocess.run(["docker", "rmi", "-f", final_tag], capture_output=True)
         subprocess.run(["docker", "system", "prune", "-f"], capture_output=True)
+        subprocess.run(
+            ["docker", "builder", "prune", "-af", "--keep-storage", f"{keep_gb}g"],
+            capture_output=True,
+        )
 
     return BuildOutput(base_image=base_image, tags=[final_tag], error=None)
 

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -10,6 +10,8 @@ Example:
 
 import hashlib
 import os
+import shutil
+import subprocess
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
@@ -32,7 +34,6 @@ from benchmarks.utils.build_utils import (
     capture_output,
     default_build_output_dir,
     get_build_parser,
-    run_docker_build_layer,
 )
 from benchmarks.utils.image_utils import remote_image_exists
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
@@ -133,6 +134,19 @@ def collect_base_images(
     return [get_base_docker_image(repo, docker_image_prefix) for repo in repos]
 
 
+def _log_disk(label: str) -> None:
+    """Log free disk space to stderr so it appears in the GH Actions log."""
+    try:
+        usage = shutil.disk_usage("/")
+        free_gib = usage.free / (1024**3)
+        total_gib = usage.total / (1024**3)
+        used_pct = (usage.used / usage.total) * 100
+        msg = f"[disk] {label}: {free_gib:.1f} GiB free / {total_gib:.1f} GiB total ({used_pct:.1f}% used)\n"
+        os.write(2, msg.encode())  # write to original fd 2 (bypasses capture_output redirect)
+    except Exception:
+        pass
+
+
 def _assemble_commit0_image(
     *,
     base_image: str,
@@ -141,21 +155,50 @@ def _assemble_commit0_image(
     git_sha: str,
     push: bool,
 ) -> BuildOutput:
-    result = run_docker_build_layer(
-        dockerfile=COMMIT0_AGENT_LAYER_DOCKERFILE,
-        context=COMMIT0_AGENT_LAYER_DOCKERFILE.parent,
-        tags=[final_tag],
-        build_args={
-            "BASE_IMAGE": base_image,
-            "BUILDER_IMAGE": builder_tag,
-            "OPENHANDS_BUILD_GIT_SHA": git_sha,
-        },
-        push=push,
-        platform="linux/amd64",
-        load=not push,
-    )
-    result.base_image = base_image
-    return result
+    cmd = [
+        "docker",
+        "buildx",
+        "build",
+        "--file",
+        str(COMMIT0_AGENT_LAYER_DOCKERFILE),
+        "--build-arg",
+        f"BASE_IMAGE={base_image}",
+        "--build-arg",
+        f"BUILDER_IMAGE={builder_tag}",
+        "--build-arg",
+        f"OPENHANDS_BUILD_GIT_SHA={git_sha}",
+        "--tag",
+        final_tag,
+        "--platform",
+        "linux/amd64",
+    ]
+    if push:
+        cmd.append("--push")
+    else:
+        cmd.append("--load")
+    cmd.append(str(COMMIT0_AGENT_LAYER_DOCKERFILE.parent))
+
+    header = f"\n=== commit0 docker build: {base_image} → {final_tag} ===\n"
+    os.write(2, header.encode())
+    _log_disk(f"pre-build {base_image}")
+
+    # Run without capture_output so workers stream directly to the inherited OS
+    # file descriptors (fd 1/2 = GH Actions log). This makes output visible in
+    # the step log in real-time — critical for diagnosing mid-build failures
+    # where the runner is killed before any Python-level logging can flush.
+    proc = subprocess.run(cmd)
+
+    _log_disk(f"post-build {base_image}")
+    footer = f"=== done: {base_image} exit={proc.returncode} ===\n"
+    os.write(2, footer.encode())
+
+    if proc.returncode != 0:
+        return BuildOutput(
+            base_image=base_image,
+            tags=[],
+            error=f"docker buildx build exited {proc.returncode} for {base_image}",
+        )
+    return BuildOutput(base_image=base_image, tags=[final_tag], error=None)
 
 
 def _assemble_commit0_with_logging(
@@ -238,6 +281,11 @@ def assemble_commit0_agent_images(
     manifest_file = build_dir / "manifest.jsonl"
     manifest_file.parent.mkdir(parents=True, exist_ok=True)
 
+    _log_disk("pre-assembly")
+    logger.info(
+        "Starting commit0 assembly: %d images, max_workers=%d", len(base_images), max_workers
+    )
+
     built = 0
     skipped = 0
     failures = 0
@@ -295,12 +343,16 @@ def assemble_commit0_agent_images(
                     if result.error or not result.tags:
                         failures += 1
                         status = "❌ Failed"
+                        logger.error(
+                            "Assembly FAILED for %s: %s", base_image, result.error
+                        )
                     elif result.status == "skipped_remote_exists":
                         skipped += 1
                         status = "⏭ Skipped"
                     else:
                         built += 1
                         status = "✅ Done"
+                    _log_disk(f"after {base_image} ({status})")
 
                 in_progress.discard(base_image)
                 pbar.update(1)

--- a/benchmarks/commit0/build_images.py
+++ b/benchmarks/commit0/build_images.py
@@ -10,7 +10,6 @@ Example:
 
 import hashlib
 import os
-import subprocess
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
@@ -33,6 +32,7 @@ from benchmarks.utils.build_utils import (
     capture_output,
     default_build_output_dir,
     get_build_parser,
+    run_docker_build_layer,
 )
 from benchmarks.utils.image_utils import remote_image_exists
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
@@ -141,47 +141,21 @@ def _assemble_commit0_image(
     git_sha: str,
     push: bool,
 ) -> BuildOutput:
-    # Build into the local Docker daemon (same pattern as swebench assemble_agent_image).
-    # This avoids BuildKit content-store accumulation that occurs with --push via buildx.
-    build_cmd = [
-        "docker", "build",
-        "--file", str(COMMIT0_AGENT_LAYER_DOCKERFILE),
-        "--build-arg", f"BASE_IMAGE={base_image}",
-        "--build-arg", f"BUILDER_IMAGE={builder_tag}",
-        "--build-arg", f"OPENHANDS_BUILD_GIT_SHA={git_sha}",
-        "--tag", final_tag,
-        str(COMMIT0_AGENT_LAYER_DOCKERFILE.parent),
-    ]
-    proc = subprocess.run(build_cmd, capture_output=True, text=True)
-    if proc.stdout:
-        print(proc.stdout, end="")
-    if proc.stderr:
-        print(proc.stderr, end="", file=sys.stderr)
-    if proc.returncode != 0:
-        error = proc.stderr.strip() or proc.stdout.strip() or f"docker build failed (rc={proc.returncode})"
-        return BuildOutput(base_image=base_image, tags=[], error=error)
-
-    if push:
-        push_proc = subprocess.run(["docker", "push", final_tag], capture_output=True, text=True)
-        if push_proc.stdout:
-            print(push_proc.stdout, end="")
-        if push_proc.stderr:
-            print(push_proc.stderr, end="", file=sys.stderr)
-        if push_proc.returncode != 0:
-            error = push_proc.stderr.strip() or f"docker push failed (rc={push_proc.returncode})"
-            return BuildOutput(base_image=base_image, tags=[], error=error)
-
-        # Free local daemon storage and limit embedded BuildKit cache after each push,
-        # matching what swebench's assemble_agent_image does (PR #690).
-        keep_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "30"))
-        subprocess.run(["docker", "rmi", "-f", final_tag], capture_output=True)
-        subprocess.run(["docker", "system", "prune", "-f"], capture_output=True)
-        subprocess.run(
-            ["docker", "builder", "prune", "-af", "--keep-storage", f"{keep_gb}g"],
-            capture_output=True,
-        )
-
-    return BuildOutput(base_image=base_image, tags=[final_tag], error=None)
+    result = run_docker_build_layer(
+        dockerfile=COMMIT0_AGENT_LAYER_DOCKERFILE,
+        context=COMMIT0_AGENT_LAYER_DOCKERFILE.parent,
+        tags=[final_tag],
+        build_args={
+            "BASE_IMAGE": base_image,
+            "BUILDER_IMAGE": builder_tag,
+            "OPENHANDS_BUILD_GIT_SHA": git_sha,
+        },
+        push=push,
+        platform="linux/amd64",
+        load=not push,
+    )
+    result.base_image = base_image
+    return result
 
 
 def _assemble_commit0_with_logging(

--- a/benchmarks/utils/Dockerfile.agent-layer-commit0
+++ b/benchmarks/utils/Dockerfile.agent-layer-commit0
@@ -65,9 +65,9 @@ RUN set -eux; \
     PATH="$ACP_NODE_DIR/bin:$PATH"; \
     node --version; \
     npm install -g \
-      @zed-industries/claude-agent-acp \
-      @zed-industries/codex-acp \
-      @google/gemini-cli; \
+      @zed-industries/claude-agent-acp@0.23.1 \
+      @zed-industries/codex-acp@0.11.1 \
+      @google/gemini-cli@0.38.0; \
     for bin in claude-agent-acp codex-acp gemini; do \
       if [ -e "$ACP_NODE_DIR/bin/$bin" ]; then \
         printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \

--- a/benchmarks/utils/Dockerfile.agent-layer-commit0
+++ b/benchmarks/utils/Dockerfile.agent-layer-commit0
@@ -65,7 +65,7 @@ RUN set -eux; \
     PATH="$ACP_NODE_DIR/bin:$PATH"; \
     node --version; \
     npm install -g \
-      @zed-industries/claude-agent-acp@0.23.1 \
+      @agentclientprotocol/claude-agent-acp@0.30.0 \
       @zed-industries/codex-acp@0.11.1 \
       @google/gemini-cli@0.38.0; \
     for bin in claude-agent-acp codex-acp gemini; do \


### PR DESCRIPTION
## Root causes

Two separate issues caused commit0 image builds to fail consistently from 2026-04-23.

### 1. Wrong / deprecated claude-agent-acp package

The commit0 Dockerfile was installing `@zed-industries/claude-agent-acp` while the SDK Dockerfile uses `@agentclientprotocol/claude-agent-acp` — the canonical package that `@zed-industries/claude-agent-acp` was renamed to. This was confirmed by the deprecation warning seen in build logs:

```
npm warn deprecated @zed-industries/claude-agent-acp@0.23.1: This package has been renamed to @agentclientprotocol/claude-agent-acp. Please migrate to continue receiving updates.
```

Using the deprecated package meant commit0 ACP images were 7 minor versions behind the SDK (0.23.1 vs 0.30.0) and would never receive future updates, risking protocol incompatibility with the SDK.

### 2. Unpinned `@google/gemini-cli` picked up breaking 0.39.0

`@google/gemini-cli` 0.39.0 was published on 2026-04-23 (same day as the failures). It introduced bundled ripgrep binaries via Node.js SEA, making the package 89 MB unpacked. With no version pin, every cold build silently picked up the new version.

### 3. Runner too small for cold builds

The `ubuntu-24.04` runner (2-core, ~14 GiB free disk) was too constrained for building commit0 images when no cached images existed in the registry. The `ubuntu-latest-8core` runner (8-core, 31 GiB RAM, 237 GiB free disk) used by swtbench handles this without issue.

## Fix

**`Dockerfile.agent-layer-commit0`**:
- Switch `@zed-industries/claude-agent-acp` → `@agentclientprotocol/claude-agent-acp@0.30.0` (matches SDK)
- Pin `@zed-industries/codex-acp@0.11.1` (unchanged package, pinned for stability)
- Pin `@google/gemini-cli@0.38.0` (last known-good version before 0.39.0)

**`build-commit0-images.yml`**:
- Switch runner from `ubuntu-24.04` to `ubuntu-latest-8core`
- Add preflight `docker buildx prune` + `docker builder prune` + `docker system prune` to clear accumulated cache from previous runs on the sticky runner
- Keep `MAX_WORKERS: '4'` (original value, works correctly on the larger runner)

## Validation

Build run [24861799673](https://github.com/OpenHands/benchmarks/actions/runs/24861799673) completed successfully in ~10 minutes with all 16 lite-split images built and pushed.

## AI disclosure

This PR was prepared by Claude Sonnet 4.6 on behalf of @simonrosenberg.