### PR TITLE
Remove unused SWE-Bench and SWT-Bench build agent-type flags

### DIFF
--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -22,11 +22,6 @@ on:
         required: false
         type: string
         default: ''
-      agent-type:
-        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
-        required: false
-        type: string
-        default: 'default'
       benchmarks-ref:
         description: 'Benchmarks repo ref to checkout (for cross-repo calls)'
         required: false
@@ -85,11 +80,6 @@ on:
         description: 'Rebuild images even if matching remote tags already exist'
         required: false
         default: 'false'
-        type: string
-      agent-type:
-        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
-        required: false
-        default: 'default'
         type: string
 
 # Defaults for automatic runs; keep INSTANCE_IDS/SELECT_FILE initialized so set -euo pipefail won't fail on unset vars.
@@ -267,14 +257,12 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
-          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
-          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
           EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
 
       - name: Archive build logs

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -22,11 +22,6 @@ on:
         required: false
         type: string
         default: ''
-      agent-type:
-        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
-        required: false
-        type: string
-        default: 'default'
       benchmarks-ref:
         description: 'Benchmarks repo ref to checkout (for cross-repo calls)'
         required: false
@@ -94,11 +89,6 @@ on:
         description: 'Rebuild images even if matching remote tags already exist'
         required: false
         default: 'false'
-        type: string
-      agent-type:
-        description: 'Agent type: default (skip ACP), acp-claude, acp-codex (keep ACP)'
-        required: false
-        default: 'default'
         type: string
 
 concurrency:
@@ -214,7 +204,6 @@ jobs:
           if [ "${FORCE_BUILD}" = "true" ]; then
             CMD="$CMD --force-build"
           fi
-          CMD="$CMD --agent-type ${AGENT_TYPE}"
 
           echo "Running: $CMD"
           eval "$CMD"
@@ -222,7 +211,6 @@ jobs:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
           EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-          AGENT_TYPE: ${{ inputs.agent-type || 'default' }}
 
       - name: Build prebaked eval env images
         if: ${{ inputs.build-eval-env == 'true' }}

--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -182,12 +182,6 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Rebuild final images even if matching remote tags already exist",
     )
-    parser.add_argument(
-        "--agent-type",
-        type=str,
-        default="default",
-        help="Agent type: default, acp-claude, acp-codex",
-    )
     return parser
 
 

--- a/tests/test_phased_build.py
+++ b/tests/test_phased_build.py
@@ -48,6 +48,67 @@ def _thread_pool(**kw):
     return ThreadPoolExecutor(**kw)
 
 
+class TestSWEBenchBuildImages:
+    def test_parser_does_not_accept_agent_type(self):
+        from benchmarks.swebench.build_images import get_parser
+
+        parser = get_parser()
+
+        with patch("argparse.ArgumentParser.exit", side_effect=SystemExit) as mock_exit:
+            try:
+                parser.parse_args(["--agent-type", "acp-claude"])
+            except SystemExit:
+                pass
+
+        mock_exit.assert_called_once()
+
+    @patch(
+        "benchmarks.swebench.build_base_images.assemble_all_agent_images",
+        return_value=0,
+    )
+    @patch(
+        "benchmarks.swebench.build_base_images.build_all_base_images", return_value=0
+    )
+    @patch(
+        "benchmarks.swebench.build_base_images.build_builder_image",
+        return_value=BuildOutput(
+            base_image="builder", tags=["builder:tag"], error=None
+        ),
+    )
+    @patch(
+        "benchmarks.swebench.build_images.collect_unique_base_images",
+        return_value=[
+            "docker.io/swebench/sweb.eval.x86_64.django_1776_django-12155:latest"
+        ],
+    )
+    @patch(
+        "benchmarks.swebench.build_images.default_build_output_dir",
+        return_value="build-dir",
+    )
+    def test_main_builds_without_agent_type(
+        self,
+        _build_dir,
+        collect_unique_base_images,
+        build_builder_image,
+        build_all_base_images,
+        assemble_all_agent_images,
+    ):
+        from benchmarks.swebench.build_images import main
+
+        rc = main(["--dataset", "dataset", "--split", "test"])
+
+        assert rc == 0
+        collect_unique_base_images.assert_called_once_with(
+            "dataset",
+            "test",
+            0,
+            None,
+        )
+        build_builder_image.assert_called_once_with(push=False, force_build=False)
+        build_all_base_images.assert_called_once()
+        assemble_all_agent_images.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # build_base_image: basic success / failure / skip
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the unused `--agent-type` argument from `benchmarks/swebench/build_images.py`
- stop forwarding `agent-type` into the SWE-Bench and SWT-Bench image build commands
- remove the now-unused `agent-type` workflow inputs from the SWE-Bench and SWT-Bench build workflows
- keep inference-side `agent_type` handling untouched where ACP behavior is still real
- add regression coverage for the SWE-Bench build CLI behavior

## Testing
- `python3` YAML parse of `.github/workflows/build-swebench-images.yml`
- `python3` YAML parse of `.github/workflows/build-swtbench-images.yml`
- `PYTHONPATH=/Users/simonrosenberg/worktrees/benchmarks-remove-unused-agent-type /Users/simonrosenberg/repositories/benchmarks/.venv/bin/pytest /Users/simonrosenberg/worktrees/benchmarks-remove-unused-agent-type/tests/test_phased_build.py`

Related to #695 and paired with OpenHands/evaluation#526.