### PR TITLE
Disable buildx provenance attestations on image pushes

### DIFF
--- a/benchmarks/swebench/build_base_images.py
+++ b/benchmarks/swebench/build_base_images.py
@@ -234,6 +234,8 @@ def build_base_image(
 
     if push:
         cmd.append("--push")
+        # Skip provenance attestation; see issue #684.
+        cmd.append("--provenance=false")
     else:
         cmd.append("--load")
 
@@ -465,6 +467,8 @@ def build_builder_image(
         ]
         if push:
             cmd.append("--push")
+            # Skip provenance attestation; see issue #684.
+            cmd.append("--provenance=false")
         else:
             cmd.append("--load")
         cmd.append(str(ctx))

--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -129,6 +129,9 @@ def run_docker_build_layer(
     # Push or load
     if push:
         cmd.append("--push")
+        # Skip the provenance attestation manifest — each attestation registers
+        # as an extra untagged package version on GHCR; see issue #684.
+        cmd.append("--provenance=false")
     elif load:
         cmd.append("--load")
 


### PR DESCRIPTION
## Summary

Adds `--provenance=false` to every `docker buildx build --push` invocation, disabling the default provenance attestation manifest that buildx ≥ v0.10 attaches to each pushed image.

## Why

`ghcr.io/openhands/eval-agent-server` has ~412,000 package versions today: 135k tagged + ~276k untagged. Probing a sample image shows the untagged count is almost entirely attestation-manifest sub-manifests — `"platform": "unknown/unknown"` with `vnd.docker.reference.type=attestation-manifest`, the [documented shape](https://docs.docker.com/build/metadata/attestations/attestation-storage/) of a buildx provenance attestation. Each push adds 1 tagged version (the OCI index) plus 2 untagged sub-manifests (the linux/amd64 manifest + the attestation). 135,642 × 2 ≈ 271k — matches observed within ~2%.

We don't consume the attestations anywhere (no `cosign verify-attestation`, no verification steps in eval code, images are not redistributed outside OpenHands), so disabling the default halves the rate at which untagged versions accumulate on GHCR going forward. Ref #684.

## What changes

Three one-line additions — one in `benchmarks/utils/build_utils.py` and two in `benchmarks/swebench/build_base_images.py`, all guarded by `if push:` since attestations are only produced on `--push`.

## What does NOT change

- Image contents, layers, digests — identical.
- Runtime behavior — `docker pull` + `docker run` are unaffected.
- Tagging scheme, CI triggers, retention policy — all untouched.
- The plain `docker push` legacy path in `build_base_images.py:~526-571` — doesn't use buildx, doesn't produce attestations, nothing to change.