### PR TITLE
fix(commit0): increase conversation and instance timeouts to 4h

### DIFF
--- a/benchmarks/commit0/config.py
+++ b/benchmarks/commit0/config.py
@@ -15,11 +15,10 @@ CONDENSER_DEFAULTS = {
 
 # Timeout for each conversation run in seconds.
 # marshmallow: ~98 min, chardet: ~60 min, babel: >3h (exhausted 3h limit without committing)
-# Using 6h (21600s) for babel which needs extended exploration of a large codebase.
-CONVERSATION_TIMEOUT = 21600
+CONVERSATION_TIMEOUT = 4 * 60 * 60
 
 # Per-instance hard kill timeout in seconds (passed to Evaluation base class).
-# Set to 4h to match CONVERSATION_TIMEOUT headroom; babel needs >3h of active work.
+# Matches CONVERSATION_TIMEOUT so the conversation timeout fires before the hard kill.
 INSTANCE_TIMEOUT = 4 * 60 * 60
 
 # Inference defaults (used by run_infer.py)

--- a/benchmarks/commit0/config.py
+++ b/benchmarks/commit0/config.py
@@ -18,6 +18,10 @@ CONDENSER_DEFAULTS = {
 # Using 6h (21600s) for babel which needs extended exploration of a large codebase.
 CONVERSATION_TIMEOUT = 21600
 
+# Per-instance hard kill timeout in seconds (passed to Evaluation base class).
+# Set to 4h to match CONVERSATION_TIMEOUT headroom; babel needs >3h of active work.
+INSTANCE_TIMEOUT = 4 * 60 * 60
+
 # Inference defaults (used by run_infer.py)
 # Note: commit0 uses n_critic_runs=1 and max_retries=1 (different from default of 3)
 INFER_DEFAULTS = {

--- a/benchmarks/commit0/config.py
+++ b/benchmarks/commit0/config.py
@@ -13,6 +13,11 @@ CONDENSER_DEFAULTS = {
     "condenser_keep_first": 2,  # Number of initial events to always keep
 }
 
+# Timeout for each conversation run in seconds.
+# commit0 instances (especially babel/chardet/marshmallow) are large repos that
+# routinely need >60 min — 7200s (2h) avoids spurious timeouts on retries.
+CONVERSATION_TIMEOUT = 7200
+
 # Inference defaults (used by run_infer.py)
 # Note: commit0 uses n_critic_runs=1 and max_retries=1 (different from default of 3)
 INFER_DEFAULTS = {

--- a/benchmarks/commit0/config.py
+++ b/benchmarks/commit0/config.py
@@ -14,9 +14,9 @@ CONDENSER_DEFAULTS = {
 }
 
 # Timeout for each conversation run in seconds.
-# commit0 instances are large repos that need extended time:
-# marshmallow finished in ~98 min; babel/chardet need >120 min — 10800s (3h).
-CONVERSATION_TIMEOUT = 10800
+# marshmallow: ~98 min, chardet: ~60 min, babel: >3h (exhausted 3h limit without committing)
+# Using 6h (21600s) for babel which needs extended exploration of a large codebase.
+CONVERSATION_TIMEOUT = 21600
 
 # Inference defaults (used by run_infer.py)
 # Note: commit0 uses n_critic_runs=1 and max_retries=1 (different from default of 3)

--- a/benchmarks/commit0/config.py
+++ b/benchmarks/commit0/config.py
@@ -14,9 +14,9 @@ CONDENSER_DEFAULTS = {
 }
 
 # Timeout for each conversation run in seconds.
-# commit0 instances (especially babel/chardet/marshmallow) are large repos that
-# routinely need >60 min — 7200s (2h) avoids spurious timeouts on retries.
-CONVERSATION_TIMEOUT = 7200
+# commit0 instances are large repos that need extended time:
+# marshmallow finished in ~98 min; babel/chardet need >120 min — 10800s (3h).
+CONVERSATION_TIMEOUT = 10800
 
 # Inference defaults (used by run_infer.py)
 # Note: commit0 uses n_critic_runs=1 and max_retries=1 (different from default of 3)

--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -13,7 +13,7 @@ from benchmarks.commit0.build_images import (
     get_agent_server_image_tag_prefix,
     get_base_docker_image,
 )
-from benchmarks.commit0.config import BUILD_TARGET, INFER_DEFAULTS
+from benchmarks.commit0.config import BUILD_TARGET, CONVERSATION_TIMEOUT, INFER_DEFAULTS
 from benchmarks.utils.acp import (
     add_acp_agent_metadata,
     build_acp_agent,
@@ -383,7 +383,8 @@ class Commit0Evaluation(Evaluation):
         repo_path = f"/workspace/{workspace_dir_name}"
 
         if is_acp_agent(self.metadata.agent_type):
-            agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model)
+            acp_timeout = int(os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT)))
+            agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model, prompt_timeout=float(acp_timeout))
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
             tools = get_default_tools(enable_browser=False)
@@ -431,7 +432,7 @@ class Commit0Evaluation(Evaluation):
         )
         with workspace_keepalive(self.metadata.agent_type, workspace):
             conversation.send_message(instruction)
-            run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", "3600"))
+            run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT)))
             conversation.run(timeout=run_timeout)
 
         history = list(conversation.state.events)

--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -390,15 +390,13 @@ class Commit0Evaluation(Evaluation):
         """
         workspace_dir_name = instance.data["repo"].split("/")[1]
         repo_path = f"/workspace/{workspace_dir_name}"
+        run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT)))
 
         if is_acp_agent(self.metadata.agent_type):
-            acp_timeout = int(
-                os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT))
-            )
             agent = build_acp_agent(
                 self.metadata.agent_type,
                 self.metadata.llm.model,
-                prompt_timeout=float(acp_timeout),
+                prompt_timeout=float(run_timeout),
             )
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
@@ -447,9 +445,6 @@ class Commit0Evaluation(Evaluation):
         )
         with workspace_keepalive(self.metadata.agent_type, workspace):
             conversation.send_message(instruction)
-            run_timeout = int(
-                os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT))
-            )
             conversation.run(timeout=run_timeout)
 
         history = list(conversation.state.events)

--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -13,7 +13,12 @@ from benchmarks.commit0.build_images import (
     get_agent_server_image_tag_prefix,
     get_base_docker_image,
 )
-from benchmarks.commit0.config import BUILD_TARGET, CONVERSATION_TIMEOUT, INFER_DEFAULTS
+from benchmarks.commit0.config import (
+    BUILD_TARGET,
+    CONVERSATION_TIMEOUT,
+    INFER_DEFAULTS,
+    INSTANCE_TIMEOUT,
+)
 from benchmarks.utils.acp import (
     add_acp_agent_metadata,
     build_acp_agent,
@@ -195,7 +200,11 @@ class Commit0Evaluation(Evaluation):
         dataset_name: str | None = None,
         dataset_split: str | None = None,
     ):
-        super().__init__(metadata=metadata, num_workers=num_workers)
+        super().__init__(
+            metadata=metadata,
+            num_workers=num_workers,
+            instance_timeout=INSTANCE_TIMEOUT,
+        )
         # Store additional parameters in metadata.details for access in methods
         if not hasattr(metadata, "details") or metadata.details is None:
             metadata.details = {}
@@ -383,8 +392,14 @@ class Commit0Evaluation(Evaluation):
         repo_path = f"/workspace/{workspace_dir_name}"
 
         if is_acp_agent(self.metadata.agent_type):
-            acp_timeout = int(os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT)))
-            agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model, prompt_timeout=float(acp_timeout))
+            acp_timeout = int(
+                os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT))
+            )
+            agent = build_acp_agent(
+                self.metadata.agent_type,
+                self.metadata.llm.model,
+                prompt_timeout=float(acp_timeout),
+            )
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
             tools = get_default_tools(enable_browser=False)
@@ -432,7 +447,9 @@ class Commit0Evaluation(Evaluation):
         )
         with workspace_keepalive(self.metadata.agent_type, workspace):
             conversation.send_message(instruction)
-            run_timeout = int(os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT)))
+            run_timeout = int(
+                os.getenv("CONVERSATION_TIMEOUT", str(CONVERSATION_TIMEOUT))
+            )
             conversation.run(timeout=run_timeout)
 
         history = list(conversation.state.events)

--- a/benchmarks/utils/acp.py
+++ b/benchmarks/utils/acp.py
@@ -166,7 +166,9 @@ def build_acp_agent(
                 acp_env[var] = virtual_key
 
     if prompt_timeout is None:
-        prompt_timeout = _ACP_PROMPT_TIMEOUT_OVERRIDES.get(agent_type, ACP_PROMPT_TIMEOUT)
+        prompt_timeout = _ACP_PROMPT_TIMEOUT_OVERRIDES.get(
+            agent_type, ACP_PROMPT_TIMEOUT
+        )
 
     return cast(Any, ACPAgent)(
         acp_command=get_acp_command(agent_type),

--- a/benchmarks/utils/acp.py
+++ b/benchmarks/utils/acp.py
@@ -136,7 +136,11 @@ def _get_acp_env(agent_type: str) -> dict[str, str]:
     return acp_env
 
 
-def build_acp_agent(agent_type: str, llm_model: str) -> ACPAgent:
+def build_acp_agent(
+    agent_type: str,
+    llm_model: str,
+    prompt_timeout: float | None = None,
+) -> ACPAgent:
     """Create an ACPAgent while remaining compatible with older type stubs.
 
     Provider credentials are passed via ``acp_env`` so they reach the ACP
@@ -146,6 +150,8 @@ def build_acp_agent(agent_type: str, llm_model: str) -> ACPAgent:
     ``litellm_proxy.set_current_virtual_key``), it overrides the API key
     so the proxy can track spend for this instance.  Thread-safe via
     ``threading.local``.
+
+    ``prompt_timeout`` overrides the per-agent-type default when provided.
     """
     from benchmarks.utils.litellm_proxy import get_current_virtual_key
 
@@ -159,7 +165,8 @@ def build_acp_agent(agent_type: str, llm_model: str) -> ACPAgent:
             if var.endswith("API_KEY"):
                 acp_env[var] = virtual_key
 
-    prompt_timeout = _ACP_PROMPT_TIMEOUT_OVERRIDES.get(agent_type, ACP_PROMPT_TIMEOUT)
+    if prompt_timeout is None:
+        prompt_timeout = _ACP_PROMPT_TIMEOUT_OVERRIDES.get(agent_type, ACP_PROMPT_TIMEOUT)
 
     return cast(Any, ACPAgent)(
         acp_command=get_acp_command(agent_type),


### PR DESCRIPTION
## Summary

- Adds `CONVERSATION_TIMEOUT = 4 * 60 * 60` (4h) to `commit0/config.py`, replacing the implicit 3600s default
- Adds `INSTANCE_TIMEOUT = 4 * 60 * 60` (4h) and passes it to `Evaluation.__init__()` so the per-instance hard kill matches the conversation budget
- Wires `CONVERSATION_TIMEOUT` through to both `acp_prompt_timeout` in `build_acp_agent` and `conversation.run(timeout=...)` — both previously hard-coded to 3600s
- Adds an optional `prompt_timeout` param to `build_acp_agent` so benchmarks can override the global ACP default without touching `acp.py` constants

## Motivation

Observed during Opus 4.7 commit0 run: babel, chardet, and marshmallow all failed with `Remote conversation ended with error` after exactly 3600s on every retry. Root cause: `CONVERSATION_TIMEOUT` and `acp_prompt_timeout` both defaulted to 3600s, and these large repos need more time.

Data from live runs:
- marshmallow: ~98 min
- chardet: ~60 min
- babel: >3h

Both `CONVERSATION_TIMEOUT` and `INSTANCE_TIMEOUT` are set to 4h so they are aligned — the conversation timeout fires cleanly before the hard kill.