### PR TITLE
fix(swebench): explicitly close conversation after evaluate_instance to prevent OOM

### DIFF
--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -330,74 +330,84 @@ class SWEBenchEvaluation(Evaluation):
             delete_on_close=True,
         )
 
-        logger.info("repo_path: %s", repo_path)
-        cp_testebed_repo = workspace.execute_command(
-            (f"mkdir -p {repo_path} ; cp -r /testbed/. {repo_path}")
-        )
-        assert cp_testebed_repo.exit_code == 0, (
-            f"cp_testebed_repo failed: {cp_testebed_repo.stderr}"
-        )
+        try:
+            logger.info("repo_path: %s", repo_path)
+            cp_testebed_repo = workspace.execute_command(
+                (f"mkdir -p {repo_path} ; cp -r /testbed/. {repo_path}")
+            )
+            assert cp_testebed_repo.exit_code == 0, (
+                f"cp_testebed_repo failed: {cp_testebed_repo.stderr}"
+            )
 
-        # git reset
-        git_reset = workspace.execute_command(f"cd {repo_path} ; git reset --hard")
-        assert git_reset.exit_code == 0, f"git reset failed: {git_reset.stderr}"
+            # git reset
+            git_reset = workspace.execute_command(f"cd {repo_path} ; git reset --hard")
+            assert git_reset.exit_code == 0, f"git reset failed: {git_reset.stderr}"
 
-        instruction = get_instruction(
-            instance=instance.data,
-            metadata=self.metadata,
-            workspace_path=workspace.working_dir,
-        )
-        with workspace_keepalive(self.metadata.agent_type, workspace):
-            conversation.send_message(instruction)
-            # Run conversation with fake user responses to handle agent messages
-            run_conversation_with_fake_user_response(conversation)
+            instruction = get_instruction(
+                instance=instance.data,
+                metadata=self.metadata,
+                workspace_path=workspace.working_dir,
+            )
+            with workspace_keepalive(self.metadata.agent_type, workspace):
+                conversation.send_message(instruction)
+                # Run conversation with fake user responses to handle agent messages
+                run_conversation_with_fake_user_response(conversation)
 
-        # git add
-        workspace.execute_command(f"cd {repo_path} ; git add -A")
+            # git add
+            workspace.execute_command(f"cd {repo_path} ; git add -A")
 
-        # git commit
-        # Use --no-verify to bypass pre-commit hooks (e.g., husky) that can fail
-        workspace.execute_command(
-            f"cd {repo_path} && "
-            f"git config --global user.email '{constants.GIT_USER_EMAIL}' && "
-            f"git config --global user.name '{constants.GIT_USER_NAME}' && "
-            f"git commit --no-verify -m '{constants.GIT_COMMIT_MESSAGE}'"
-        )
+            # git commit
+            # Use --no-verify to bypass pre-commit hooks (e.g., husky) that can fail
+            workspace.execute_command(
+                f"cd {repo_path} && "
+                f"git config --global user.email '{constants.GIT_USER_EMAIL}' && "
+                f"git config --global user.name '{constants.GIT_USER_NAME}' && "
+                f"git commit --no-verify -m '{constants.GIT_COMMIT_MESSAGE}'"
+            )
 
-        # Get git patch
-        base_commit = instance.data["base_commit"]
-        git_patch_result = workspace.execute_command(
-            (f"cd {repo_path} ; git --no-pager diff --no-color {base_commit} HEAD")
-        )
-        assert git_patch_result.exit_code == 0, (
-            f"git diff failed: {git_patch_result.stderr}"
-        )
-        git_patch = git_patch_result.stdout
+            # Get git patch
+            base_commit = instance.data["base_commit"]
+            git_patch_result = workspace.execute_command(
+                (f"cd {repo_path} ; git --no-pager diff --no-color {base_commit} HEAD")
+            )
+            assert git_patch_result.exit_code == 0, (
+                f"git diff failed: {git_patch_result.stderr}"
+            )
+            git_patch = git_patch_result.stdout
 
-        # Log instance summary
-        summarize_instance(
-            instance_id=instance.id,
-            conversation=conversation,
-            git_patch=git_patch,
-            logger=logger,
-        )
+            # Log instance summary
+            summarize_instance(
+                instance_id=instance.id,
+                conversation=conversation,
+                git_patch=git_patch,
+                logger=logger,
+            )
 
-        # Build test_result with git patch and optional ACP agent metadata
-        test_result: dict[str, Any] = {
-            "git_patch": git_patch,
-        }
-        if isinstance(agent, ACPAgent):
-            add_acp_agent_metadata(test_result, conversation)
+            # Build test_result with git patch and optional ACP agent metadata
+            test_result: dict[str, Any] = {
+                "git_patch": git_patch,
+            }
+            if isinstance(agent, ACPAgent):
+                add_acp_agent_metadata(test_result, conversation)
 
-        # EvalOutput is your model; keep fields consistent with prior JSONL
+            history = list(conversation.state.events)
+            metrics = conversation.conversation_stats.get_combined_metrics()
+        finally:
+            # Break the circular reference (RemoteConversation → WebSocket callback →
+            # run_complete_callback closure → self) so CPython's reference counter can
+            # reclaim the object immediately rather than waiting for the cyclic GC.
+            # Without this, ACP conversations with large event histories (no condenser,
+            # many tool calls) accumulate across instances and OOM the eval-container.
+            conversation.close()
+
         out = EvalOutput(
             instance_id=instance.id,
             attempt=self.current_attempt,
             test_result=test_result,
             instruction=instruction,
             error=None,
-            history=list(conversation.state.events),
-            metrics=conversation.conversation_stats.get_combined_metrics(),
+            history=history,
+            metrics=metrics,
         )
         return out
 

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -289,141 +289,151 @@ class SWEBenchEvaluation(Evaluation):
             delete_on_close=True,
         )
 
-        logger.info("repo_path: %s", repo_path)
-        # Copy testbed repo to workspace (same as regular swebench)
-        # The multimodal benchmark uses regular SWE-bench images which have /testbed
-        cp_testbed_repo = workspace.execute_command(
-            f"mkdir -p {repo_path} ; cp -r /testbed/. {repo_path}"
-        )
-        assert cp_testbed_repo.exit_code == 0, (
-            f"cp_testbed_repo failed: {cp_testbed_repo.stderr}"
-        )
+        try:
+            logger.info("repo_path: %s", repo_path)
+            # Copy testbed repo to workspace (same as regular swebench)
+            # The multimodal benchmark uses regular SWE-bench images which have /testbed
+            cp_testbed_repo = workspace.execute_command(
+                f"mkdir -p {repo_path} ; cp -r /testbed/. {repo_path}"
+            )
+            assert cp_testbed_repo.exit_code == 0, (
+                f"cp_testbed_repo failed: {cp_testbed_repo.stderr}"
+            )
 
-        # git reset to clean state
-        git_reset = workspace.execute_command(f"cd {repo_path} ; git reset --hard")
-        assert git_reset.exit_code == 0, f"git reset failed: {git_reset.stderr}"
+            # git reset to clean state
+            git_reset = workspace.execute_command(f"cd {repo_path} ; git reset --hard")
+            assert git_reset.exit_code == 0, f"git reset failed: {git_reset.stderr}"
 
-        instruction = get_instruction(
-            instance=instance.data,
-            metadata=self.metadata,
-            workspace_path=workspace.working_dir,
-        )
+            instruction = get_instruction(
+                instance=instance.data,
+                metadata=self.metadata,
+                workspace_path=workspace.working_dir,
+            )
 
-        # Handle image assets for multimodal instances
-        with workspace_keepalive(self.metadata.agent_type, workspace):
-            if "image_assets" in instance.data and instance.data["image_assets"]:
-                try:
-                    assets = json.loads(instance.data["image_assets"])
-                    if "problem_statement" in assets and assets["problem_statement"]:
-                        image_urls = assets["problem_statement"]
+            # Handle image assets for multimodal instances
+            with workspace_keepalive(self.metadata.agent_type, workspace):
+                if "image_assets" in instance.data and instance.data["image_assets"]:
+                    try:
+                        assets = json.loads(instance.data["image_assets"])
+                        if "problem_statement" in assets and assets["problem_statement"]:
+                            image_urls = assets["problem_statement"]
 
-                        # Filter and validate image URLs
-                        valid_urls = []
-                        index_dict = {}
-                        for url in image_urls:
-                            if is_valid_image_url(url):
-                                if url in instruction:
-                                    valid_urls.append(url)
-                                    idx = instruction.find(url)
-                                    index_dict[url] = idx
+                            # Filter and validate image URLs
+                            valid_urls = []
+                            index_dict = {}
+                            for url in image_urls:
+                                if is_valid_image_url(url):
+                                    if url in instruction:
+                                        valid_urls.append(url)
+                                        idx = instruction.find(url)
+                                        index_dict[url] = idx
+                                    else:
+                                        logger.warning(
+                                            f"Image URL {url} not found in instruction, skipping"
+                                        )
                                 else:
-                                    logger.warning(
-                                        f"Image URL {url} not found in instruction, skipping"
+                                    logger.info(
+                                        f"Image URL {url} is invalid or inaccessible, skipping"
                                     )
+
+                            if valid_urls:
+                                # Sort URLs by their position in the instruction
+                                sorted_urls = sorted(index_dict.items(), key=lambda x: x[1])
+                                sorted_urls = [item[0] for item in sorted_urls]
+
+                                # Add image numbering to instruction
+                                modified_instruction = instruction
+                                for idx, url in enumerate(sorted_urls):
+                                    modified_instruction = modified_instruction.replace(
+                                        url, f"{url} (Image: {idx + 1})"
+                                    )
+
+                                logger.info(
+                                    f"Sending instruction with {len(sorted_urls)} valid images"
+                                )
+
+                                # Create message with both text and images
+                                message = Message(
+                                    role="user",
+                                    content=[
+                                        TextContent(text=modified_instruction),
+                                        ImageContent(image_urls=sorted_urls),
+                                    ],
+                                )
+                                conversation.send_message(message)
                             else:
                                 logger.info(
-                                    f"Image URL {url} is invalid or inaccessible, skipping"
+                                    "No valid image URLs found, sending text-only instruction"
                                 )
-
-                        if valid_urls:
-                            # Sort URLs by their position in the instruction
-                            sorted_urls = sorted(index_dict.items(), key=lambda x: x[1])
-                            sorted_urls = [item[0] for item in sorted_urls]
-
-                            # Add image numbering to instruction
-                            modified_instruction = instruction
-                            for idx, url in enumerate(sorted_urls):
-                                modified_instruction = modified_instruction.replace(
-                                    url, f"{url} (Image: {idx + 1})"
-                                )
-
-                            logger.info(
-                                f"Sending instruction with {len(sorted_urls)} valid images"
-                            )
-
-                            # Create message with both text and images
-                            message = Message(
-                                role="user",
-                                content=[
-                                    TextContent(text=modified_instruction),
-                                    ImageContent(image_urls=sorted_urls),
-                                ],
-                            )
-                            conversation.send_message(message)
+                                conversation.send_message(instruction)
                         else:
-                            logger.info(
-                                "No valid image URLs found, sending text-only instruction"
-                            )
+                            logger.info("No problem_statement images found in image_assets")
                             conversation.send_message(instruction)
-                    else:
-                        logger.info("No problem_statement images found in image_assets")
+                    except (json.JSONDecodeError, KeyError) as e:
+                        logger.warning(f"Failed to parse image_assets: {e}")
                         conversation.send_message(instruction)
-                except (json.JSONDecodeError, KeyError) as e:
-                    logger.warning(f"Failed to parse image_assets: {e}")
+                else:
+                    logger.info("No image_assets found, sending text-only instruction")
                     conversation.send_message(instruction)
-            else:
-                logger.info("No image_assets found, sending text-only instruction")
-                conversation.send_message(instruction)
-            # Run conversation with fake user responses to handle agent messages
-            run_conversation_with_fake_user_response(conversation)
+                # Run conversation with fake user responses to handle agent messages
+                run_conversation_with_fake_user_response(conversation)
 
-        # git add
-        workspace.execute_command(f"cd {repo_path} ; git add -A")
+            # git add
+            workspace.execute_command(f"cd {repo_path} ; git add -A")
 
-        # git commit (same as regular swebench - includes git config)
-        # Use --no-verify to bypass pre-commit hooks (e.g., husky) that can fail
-        # and prevent the commit from being created
-        workspace.execute_command(
-            f"cd {repo_path} && "
-            "git config --global user.email 'evaluation@openhands.dev' && "
-            "git config --global user.name 'OpenHands Evaluation' && "
-            "git commit --no-verify -m 'patch'"
-        )
+            # git commit (same as regular swebench - includes git config)
+            # Use --no-verify to bypass pre-commit hooks (e.g., husky) that can fail
+            # and prevent the commit from being created
+            workspace.execute_command(
+                f"cd {repo_path} && "
+                "git config --global user.email 'evaluation@openhands.dev' && "
+                "git config --global user.name 'OpenHands Evaluation' && "
+                "git commit --no-verify -m 'patch'"
+            )
 
-        # Get git patch (same as regular swebench - use base_commit)
-        base_commit = instance.data["base_commit"]
-        git_patch_result = workspace.execute_command(
-            f"cd {repo_path} ; git --no-pager diff --no-color {base_commit} HEAD"
-        )
-        assert git_patch_result.exit_code == 0, (
-            f"git diff failed: {git_patch_result.stderr}"
-        )
-        git_patch = git_patch_result.stdout
+            # Get git patch (same as regular swebench - use base_commit)
+            base_commit = instance.data["base_commit"]
+            git_patch_result = workspace.execute_command(
+                f"cd {repo_path} ; git --no-pager diff --no-color {base_commit} HEAD"
+            )
+            assert git_patch_result.exit_code == 0, (
+                f"git diff failed: {git_patch_result.stderr}"
+            )
+            git_patch = git_patch_result.stdout
 
-        # Log instance summary
-        summarize_instance(
-            instance_id=instance.id,
-            conversation=conversation,
-            git_patch=git_patch or "",
-            logger=logger,
-        )
+            # Log instance summary
+            summarize_instance(
+                instance_id=instance.id,
+                conversation=conversation,
+                git_patch=git_patch or "",
+                logger=logger,
+            )
 
-        # Build test_result with optional ACP agent metadata
-        test_result: dict[str, Any] = {
-            "git_patch": git_patch,
-        }
-        if isinstance(agent, ACPAgent):
-            add_acp_agent_metadata(test_result, conversation)
+            # Build test_result with optional ACP agent metadata
+            test_result: dict[str, Any] = {
+                "git_patch": git_patch,
+            }
+            if isinstance(agent, ACPAgent):
+                add_acp_agent_metadata(test_result, conversation)
 
-        # EvalOutput is your model; keep fields consistent with prior JSONL
+            history = list(conversation.state.events)
+            metrics = conversation.conversation_stats.get_combined_metrics()
+        finally:
+            # Break the circular reference (RemoteConversation → WebSocket callback →
+            # run_complete_callback closure → self) so CPython's reference counter can
+            # reclaim the object immediately rather than waiting for the cyclic GC.
+            # Without this, ACP conversations with large event histories (no condenser,
+            # many tool calls) accumulate across instances and OOM the eval-container.
+            conversation.close()
+
         out = EvalOutput(
             instance_id=instance.id,
             attempt=self.current_attempt,
             test_result=test_result,
             instruction=instruction,
             error=None,
-            history=list(conversation.state.events),
-            metrics=conversation.conversation_stats.get_combined_metrics(),
+            history=history,
+            metrics=metrics,
         )
         return out
 

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -315,7 +315,10 @@ class SWEBenchEvaluation(Evaluation):
                 if "image_assets" in instance.data and instance.data["image_assets"]:
                     try:
                         assets = json.loads(instance.data["image_assets"])
-                        if "problem_statement" in assets and assets["problem_statement"]:
+                        if (
+                            "problem_statement" in assets
+                            and assets["problem_statement"]
+                        ):
                             image_urls = assets["problem_statement"]
 
                             # Filter and validate image URLs
@@ -338,7 +341,9 @@ class SWEBenchEvaluation(Evaluation):
 
                             if valid_urls:
                                 # Sort URLs by their position in the instruction
-                                sorted_urls = sorted(index_dict.items(), key=lambda x: x[1])
+                                sorted_urls = sorted(
+                                    index_dict.items(), key=lambda x: x[1]
+                                )
                                 sorted_urls = [item[0] for item in sorted_urls]
 
                                 # Add image numbering to instruction
@@ -367,7 +372,9 @@ class SWEBenchEvaluation(Evaluation):
                                 )
                                 conversation.send_message(instruction)
                         else:
-                            logger.info("No problem_statement images found in image_assets")
+                            logger.info(
+                                "No problem_statement images found in image_assets"
+                            )
                             conversation.send_message(instruction)
                     except (json.JSONDecodeError, KeyError) as e:
                         logger.warning(f"Failed to parse image_assets: {e}")


### PR DESCRIPTION
## Summary

- Wrap the conversation body in `try/finally` and call `conversation.close()` before returning from `evaluate_instance()` in both `swebench` and `swebenchmultimodal` `run_infer.py`
- `close()` sets `self._ws_client = None`, breaking the circular reference so CPython's reference counter can immediately reclaim `_cached_events`

## Root cause (OpenHands/evaluation#540)

`RemoteConversation` has a circular reference that prevents immediate GC:

```
conversation → _ws_client (WebSocketCallbackClient)
             → callback (composed_callback)
             → run_complete_callback closure (remote_conversation.py:813)
             → self._terminal_status_queue   ← captures self
```

Without an explicit `close()` call, CPython's cyclic GC must collect these objects, and it only runs on a threshold — not immediately. With 30 workers completing instances rapidly, many `RemoteConversation` objects pile up.

This is especially bad for ACP agents (`acp-codex`, `acp-claude`) because:
- `ACPAgent` raises `NotImplementedError` if a condenser is configured, so all events accumulate uncapped in `_cached_events`
- GPT-5.5 with `reasoning_effort=high` on large JS projects (wp-calypso in swebenchmultimodal) makes 100+ tool calls per instance; each `ACPToolCallEvent` stores `raw_input` + `raw_output` which can be MB-sized for file reads and test output

**Observed failure**: swebenchmultimodal with `acp-codex` OOMed the eval-container (12Gi limit) at ~40/68 instances across 5 consecutive runs. Both `num_workers=8` and `num_workers=30` hit the same fraction — confirming per-instance linear accumulation rather than concurrency pressure.

## Test plan

- [ ] Trigger a swebenchmultimodal eval with `acp-codex` agent type and verify it runs to completion without OOMKill
- [ ] Verify swebench eval still works normally (no regression)
- [ ] Confirm the fix applies to both files identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)