### PR TITLE
fix(evaluation): gc.collect() after each instance to reclaim cyclic RemoteConversation objects

### DIFF
--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -650,13 +650,9 @@ class Evaluation(ABC, BaseModel):
                 # from the attempt files, not from this in-memory list.
                 out.history = []
 
-                # Force the cyclic GC to run now. RemoteConversation objects
-                # have a circular reference (conversation → WebSocket callback
-                # → run_complete_callback closure → conversation) that prevents
-                # CPython's reference counter from freeing them immediately.
-                # Without this, ACP conversations (which have no condenser and
-                # accumulate large event histories) pile up across instances and
-                # can OOM the eval-container before the GC threshold fires.
+                # Flush cyclic-GC objects. RemoteConversation holds a circular
+                # reference via its WebSocket callback closure, so CPython's
+                # reference counter can't free it immediately on scope exit.
                 gc.collect()
 
                 attempt_outputs.append(out)

--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -10,6 +10,7 @@ concurrency for I/O-bound workloads (HTTP calls to LLM proxy + runtime API).
 
 import asyncio
 import base64
+import gc
 import json
 import os
 import tarfile
@@ -648,6 +649,15 @@ class Evaluation(ABC, BaseModel):
                 # persisted to disk. The critic and aggregator read history
                 # from the attempt files, not from this in-memory list.
                 out.history = []
+
+                # Force the cyclic GC to run now. RemoteConversation objects
+                # have a circular reference (conversation → WebSocket callback
+                # → run_complete_callback closure → conversation) that prevents
+                # CPython's reference counter from freeing them immediately.
+                # Without this, ACP conversations (which have no condenser and
+                # accumulate large event histories) pile up across instances and
+                # can OOM the eval-container before the GC threshold fires.
+                gc.collect()
 
                 attempt_outputs.append(out)
 


### PR DESCRIPTION
## Summary

Add `gc.collect()` after each instance result is persisted, so the cyclic GC runs once per instance rather than on an unpredictable threshold.

## Why

`RemoteConversation` has a circular reference via its WebSocket callback closure that prevents CPython's reference counter from freeing it immediately. Objects with large `_cached_events` lists accumulate across instances and can OOM the eval-container. Fixes OpenHands/evaluation#540.

## Companion PR

OpenHands/software-agent-sdk#3031 eliminates the cycle at the source with a `weakref`. This `gc.collect()` is a belt-and-suspenders safety net.