### PR TITLE
fix(litellm-proxy): set 6h TTL on virtual keys to prevent indefinite leak

### DIFF
--- a/benchmarks/utils/litellm_proxy.py
+++ b/benchmarks/utils/litellm_proxy.py
@@ -75,7 +75,7 @@ def create_virtual_key(
         resp = httpx.post(
             f"{base_url}/key/generate",
             headers={"Authorization": f"Bearer {api_key}"},
-            json={"metadata": metadata, "max_budget": max_budget},
+            json={"metadata": metadata, "max_budget": max_budget, "duration": "6h"},
             timeout=_TIMEOUT,
         )
         resp.raise_for_status()

--- a/tests/test_litellm_proxy.py
+++ b/tests/test_litellm_proxy.py
@@ -87,6 +87,7 @@ class TestCreateVirtualKey:
             "run_id": "run-42",
         }
         assert kwargs["json"]["max_budget"] == 10.0
+        assert kwargs["json"]["duration"] == "6h"
         assert kwargs["headers"]["Authorization"] == "Bearer sk-admin"
 
     def test_raises_on_http_error(self, monkeypatch):


### PR DESCRIPTION
## Summary

- Virtual keys were created via `/key/generate` with no `duration` field, making them **permanent** until explicitly deleted
- The `finally`-block deletion can be skipped if the process is killed (SIGKILL from K8s timeout) or the `delete_key` HTTP call fails silently (exception is caught and only logged at WARNING)
- Without a TTL, any key that escapes cleanup lives forever on the proxy — this is the root cause of virtual keys leaking in GCS artifacts remaining active

The fix adds `"duration": "6h"` to the key generation request. 6h was chosen based on the actual deployment config (`evaluation/eval-job/values.yaml`):

| Benchmark | CONVERSATION_TIMEOUT |
|-----------|---------------------|
| commit0 | 14400s (4h) — longest |
| swebench, swtbench, gaia, swebenchmultimodal, terminalbench | 7200s (2h) |

A single attempt's maximum lifetime is ~4h 10min (commit0 conversation + workspace startup). 6h covers this with ~1h 50min buffer while ensuring any leaked key auto-expires rather than living indefinitely.

## Test plan

- [x] Existing `tests/test_litellm_proxy.py` updated to assert `duration == "6h"` in the key generation payload — all 27 tests pass
- [ ] Verify on next eval run that the proxy shows keys with an expiry timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)