### PR TITLE
DRAFT: swtbench: tighten default prompt to discourage non-test edits (option 1 of #708)

### DIFF
--- a/benchmarks/swtbench/prompts/default.j2
+++ b/benchmarks/swtbench/prompts/default.j2
@@ -10,10 +10,19 @@ I've uploaded a python code repository in the directory {{ workspace_dir_name }}
 
 Can you help me implement the necessary changes to the repository to test whether the issue in <issue_description> was resolved?
 I will take care of all changes to any of the non-test files. This means you DON'T have to modify the actual logic and ONLY have to update test logic and tests!
-Your task is to make the minimal changes to tests files in the /workspace directory to reproduce the issue in the <issue_description>, i.e., such that the generated tests fail in the current state (where the issue is unresolved) and pass when the issue will be resolved.
+Your task is to make the minimal changes to existing test files in the /workspace directory to reproduce the issue in the <issue_description>, i.e., such that the generated tests fail in the current state (where the issue is unresolved) and pass when the issue will be resolved.
+
+IMPORTANT — only the diff against existing test files inside the repository's test directory (e.g. `tests/`, `test/`, `testing/`) will be scored:
+* DO NOT modify any source file (e.g. files under `sympy/`, `django/`, `sphinx/`, `requests/`, …). Doing so makes your test pass against your own "fix" instead of failing on the buggy code, which silences the bug-reveal signal and earns zero credit.
+* DO NOT commit scratch files at the repository root (e.g. `reproduction.py`, `test_repro.py`, `FIX_SUMMARY.md`). Use the BashTool to run throwaway Python instead of saving a file.
+* DO NOT touch `build/`, `docs/`, `pyproject.toml`, `tox.ini`, `setup.py`, etc.
+* The harness applies the real maintainer fix on top of your patch when scoring, so the bug does NOT need to be fixed for your test to pass on the post-fix state — only write the test.
+
 Follow these steps to reproduce the issue:
 1. As a first step, it might be a good idea to explore the repo to familiarize yourself with its structure.
-2. Create a script `reproduction.py` to reproduce the error and execute it with `python reproduction.py` using the BashTool, to confirm the error
-3. Edit the sourcecode of the repo to integrate your reproduction script into the test framework
-4. Run the test framework and make sure your tests fail! Only submit FAILING tests! Never submit passing tests.
+2. Use the BashTool (e.g. `python -c '...'`) to confirm the buggy behavior. Do not commit a `reproduction.py` to the repo.
+3. Edit only existing test files inside the repository's test directory to add a test that exercises the bug.
+4. Run the test framework and make sure your new test fails! Only submit FAILING tests! Never submit passing tests.
+5. Before finishing, run `git diff --name-only` and confirm every changed path is a test file inside the project's test directory. Revert anything else.
+
 Your thinking should be thorough and so it's fine if it's very long.


### PR DESCRIPTION
Addresses option 1 from #708.

## What

Tightens the existing SWT-bench prompt at `benchmarks/swtbench/prompts/default.j2` so the agent stops modifying source code and scratch files alongside its tests.

The previous default prompt was self-contradictory:

* it said _"DON'T have to modify the actual logic and ONLY have to update test logic and tests"_…
* …but then step 2 said _"Create a script `reproduction.py`"_ and step 3 said _"Edit the sourcecode of the repo to integrate your reproduction script into the test framework"_.

That's a lot of the failure mode on qwen3-coder-next (#708 found 78% of patches touch source or scratch files; the test-only subset solves at 45.5%, mixed at 1.2%).

This PR edits `default.j2` to:

- add an `IMPORTANT` block stating exactly which paths are scored and *why* touching source files silences the F2P signal;
- ban scratch files at the repo root (`reproduction.py`, `test_repro.py`, `FIX_SUMMARY.md`), and `build/`, `docs/`, `pyproject.toml`, etc.;
- replace step 2 (`create reproduction.py`) with "use BashTool to confirm the buggy behavior";
- replace step 3 (`edit sourcecode`) with "edit only existing test files inside the test directory";
- add a final step: run `git diff --name-only` and revert anything outside the test directory.

Diff is 13 added / 4 removed lines, no new files.

## Scope

- Single file changed: `benchmarks/swtbench/prompts/default.j2`.
- Applies to every SWT-bench run that doesn't pass `--prompt-path` explicitly — including the SDK [`run-eval.yml`](https://github.com/OpenHands/software-agent-sdk/actions/workflows/run-eval.yml), which doesn't thread `--prompt-path` through, so the change activates automatically once merged.

## How to test

Re-run any SWT-bench config — no extra flags needed. Compare the resulting `output.swtbench.jsonl` patch-shape distribution to the baseline run linked in #708: the "mixed test + source" share should drop substantially. Score lift only materializes if the agent actually follows the instructions; if it doesn't, #711 (post-processing strip) is the safety net.

## Risks / caveats

- This is a behavior nudge to *every* model running SWT-bench, not just qwen3-coder-next. Models that were already test-only are unaffected by the new rules. Models that produced "useful" source-code fixes for some other reason would lose them — but those edits aren't scored anyway, so the only downside is the agent might try harder to comply and waste more turns on test edits. Acceptable IMO; happy to revisit if a strong model regresses.
- Wording is intentionally direct ("DO NOT", "earns zero credit"); if you'd rather keep the tone softer let me know and I'll soften it.
- Does NOT address the agent that ignores instructions entirely — that case is what #711 handles.

Refs #708. Supersedes the earlier version of this PR that added a separate `qwen3_coder_next.j2` template.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._