### PR TITLE
DRAFT: swtbench: strip non-test files from model_patch in post-processing (option 2 of #708)

### DIFF
--- a/benchmarks/swtbench/eval_infer.py
+++ b/benchmarks/swtbench/eval_infer.py
@@ -25,7 +25,10 @@ from benchmarks.swtbench.image_utils import (
 )
 from benchmarks.utils.constants import MODEL_NAME_OR_PATH
 from benchmarks.utils.laminar import LaminarService
-from benchmarks.utils.patch_utils import remove_files_from_patch
+from benchmarks.utils.patch_utils import (
+    keep_only_test_files,
+    remove_files_from_patch,
+)
 from benchmarks.utils.report_costs import generate_cost_report
 from openhands.sdk import get_logger
 
@@ -205,6 +208,13 @@ def convert_to_swtbench_format(input_file: str, output_file: str) -> None:
                 # postprocess git_patch
                 setup_files = ["pyproject.toml", "tox.ini", "setup.py"]
                 git_patch = remove_files_from_patch(git_patch, setup_files)
+                # SWT-bench only scores diffs to existing test files. Strip
+                # everything else (source-code "fix" attempts, scratch files
+                # like reproduction.py / FIX_SUMMARY.md, build/, docs/, etc.):
+                # a non-test diff that lands in model_patch can silence the
+                # F2P signal because the test then runs against the agent's
+                # own patched code instead of the buggy code.
+                git_patch = keep_only_test_files(git_patch)
 
                 # Create SWT-Bench format entry
                 swtbench_entry = {

--- a/benchmarks/swtbench/eval_infer.py
+++ b/benchmarks/swtbench/eval_infer.py
@@ -206,6 +206,9 @@ def convert_to_swtbench_format(input_file: str, output_file: str) -> None:
                     git_patch = ""
 
                 # postprocess git_patch
+                # NOTE: this setup-files strip is now belt-and-suspenders --
+                # ``keep_only_test_files`` below would drop these files anyway
+                # since they aren't tests. Kept for explicit intent.
                 setup_files = ["pyproject.toml", "tox.ini", "setup.py"]
                 git_patch = remove_files_from_patch(git_patch, setup_files)
                 # SWT-bench only scores diffs to existing test files. Strip

--- a/benchmarks/utils/patch_utils.py
+++ b/benchmarks/utils/patch_utils.py
@@ -88,7 +88,7 @@ def _is_test_path(path: str) -> bool:
         return True
     base = parts[-1]
     return (
-        base.startswith("test_") or base.endswith("_test.py") or base == "conftest.py"
+        (base.startswith("test_") and base.endswith(".py")) or base.endswith("_test.py") or base == "conftest.py"
     )
 
 

--- a/benchmarks/utils/patch_utils.py
+++ b/benchmarks/utils/patch_utils.py
@@ -88,7 +88,9 @@ def _is_test_path(path: str) -> bool:
         return True
     base = parts[-1]
     return (
-        (base.startswith("test_") and base.endswith(".py")) or base.endswith("_test.py") or base == "conftest.py"
+        (base.startswith("test_") and base.endswith(".py"))
+        or base.endswith("_test.py")
+        or base == "conftest.py"
     )
 
 
@@ -101,6 +103,14 @@ def keep_only_test_files(git_patch: str) -> str:
 
     The implementation mirrors :func:`remove_files_from_patch` so the two
     helpers behave consistently.
+
+    Note: a more precise alternative would be to intersect with the gold
+    ``test_patch`` file set per instance. That data is in the upstream SWT
+    dataset, not in ``output.jsonl``, so wiring it into ``eval_infer.py``
+    would mean re-loading the dataset on the post-processing path. The
+    path-based heuristic here is intentionally local to the patch text and
+    good enough in practice; tightening to ground truth is tracked
+    separately.
     """
     if not git_patch:
         return git_patch

--- a/benchmarks/utils/patch_utils.py
+++ b/benchmarks/utils/patch_utils.py
@@ -69,6 +69,62 @@ def remove_files_from_patch(git_patch, files):
     return result
 
 
+def _is_test_path(path: str) -> bool:
+    """Heuristic: does ``path`` look like a project test file?
+
+    A path counts as a test if it lives under a ``tests``/``test``/``testing``
+    directory anywhere in its tree, or if its basename matches the standard
+    pytest/unittest discovery patterns (``test_*.py``, ``*_test.py``,
+    ``conftest.py``).
+
+    Files at the repository root are *not* considered tests even when they
+    match the naming pattern (e.g. ``test_repro.py``), because in SWT-bench
+    those are agent-authored scratch files that the harness ignores.
+    """
+    if "/" not in path:
+        return False
+    parts = path.split("/")
+    if any(seg in ("tests", "test", "testing") for seg in parts[:-1]):
+        return True
+    base = parts[-1]
+    return (
+        base.startswith("test_") or base.endswith("_test.py") or base == "conftest.py"
+    )
+
+
+def keep_only_test_files(git_patch: str) -> str:
+    """Return ``git_patch`` with every non-test file diff removed.
+
+    Useful for benchmarks that only score test-file changes (e.g. SWT-bench).
+    A file is kept iff :func:`_is_test_path` returns ``True`` for either the
+    pre- or post-image path in its ``diff --git`` header.
+
+    The implementation mirrors :func:`remove_files_from_patch` so the two
+    helpers behave consistently.
+    """
+    if not git_patch:
+        return git_patch
+
+    diff_pattern = r"diff --git [^\n]*\n"
+    diff_matches = list(re.finditer(diff_pattern, git_patch))
+    if not diff_matches:
+        return git_patch
+
+    kept = []
+    for i, match in enumerate(diff_matches):
+        start = match.start()
+        end = (
+            diff_matches[i + 1].start() if i + 1 < len(diff_matches) else len(git_patch)
+        )
+        diff = git_patch[start:end]
+        header = diff.split("\n", 1)[0]
+        m = re.match(r"diff --git a/(.+) b/(.+)", header)
+        if m and (_is_test_path(m.group(1)) or _is_test_path(m.group(2))):
+            kept.append(diff)
+
+    return "".join(kept)
+
+
 def remove_binary_diffs(patch_text):
     """
     Remove binary file diffs from a git patch.

--- a/tests/test_patch_utils_keep_test_files.py
+++ b/tests/test_patch_utils_keep_test_files.py
@@ -1,0 +1,74 @@
+"""Tests for patch_utils.keep_only_test_files."""
+
+from benchmarks.utils.patch_utils import keep_only_test_files
+
+
+def _diff(path: str, body: str = "@@ -1 +1 @@\n-old\n+new\n") -> str:
+    """Build a minimal ``diff --git`` block for ``path``."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"{body}"
+    )
+
+
+class TestKeepOnlyTestFiles:
+    def test_empty_returns_empty(self):
+        assert keep_only_test_files("") == ""
+
+    def test_passthrough_when_no_diff_header(self):
+        patch = "not a real patch\n"
+        assert keep_only_test_files(patch) == patch
+
+    def test_keeps_files_under_tests_dir(self):
+        patch = _diff("tests/foo/test_bar.py") + _diff("sympy/core/basic.py")
+        out = keep_only_test_files(patch)
+        assert "tests/foo/test_bar.py" in out
+        assert "sympy/core/basic.py" not in out
+
+    def test_keeps_files_under_testing_dir(self):
+        patch = _diff("django/testing/helpers.py")
+        assert "django/testing/helpers.py" in keep_only_test_files(patch)
+
+    def test_keeps_conftest(self):
+        patch = _diff("pkg/conftest.py")
+        assert "pkg/conftest.py" in keep_only_test_files(patch)
+
+    def test_keeps_test_prefix_outside_test_dir(self):
+        patch = _diff("pkg/sub/test_helpers.py")
+        assert "pkg/sub/test_helpers.py" in keep_only_test_files(patch)
+
+    def test_keeps_underscore_test_suffix(self):
+        patch = _diff("pkg/sub/helpers_test.py")
+        assert "pkg/sub/helpers_test.py" in keep_only_test_files(patch)
+
+    def test_drops_root_level_scratch_repros(self):
+        # Agent scratch files at the repo root are not real tests even when
+        # they match the naming convention.
+        patch = (
+            _diff("reproduction.py")
+            + _diff("test_repro.py")
+            + _diff("FIX_SUMMARY.md")
+            + _diff("tests/test_real.py")
+        )
+        out = keep_only_test_files(patch)
+        assert "reproduction.py" not in out
+        assert "test_repro.py" not in out
+        assert "FIX_SUMMARY.md" not in out
+        assert "tests/test_real.py" in out
+
+    def test_drops_build_and_docs(self):
+        patch = (
+            _diff("build/lib/requests/__init__.py")
+            + _diff("docs/intro.rst")
+            + _diff("tests/test_real.py")
+        )
+        out = keep_only_test_files(patch)
+        assert "build/lib/requests/__init__.py" not in out
+        assert "docs/intro.rst" not in out
+        assert "tests/test_real.py" in out
+
+    def test_all_non_test_returns_empty_string(self):
+        patch = _diff("sympy/core/basic.py") + _diff("django/db/models/base.py")
+        assert keep_only_test_files(patch) == ""

--- a/tests/test_patch_utils_keep_test_files.py
+++ b/tests/test_patch_utils_keep_test_files.py
@@ -5,12 +5,7 @@ from benchmarks.utils.patch_utils import keep_only_test_files
 
 def _diff(path: str, body: str = "@@ -1 +1 @@\n-old\n+new\n") -> str:
     """Build a minimal ``diff --git`` block for ``path``."""
-    return (
-        f"diff --git a/{path} b/{path}\n"
-        f"--- a/{path}\n"
-        f"+++ b/{path}\n"
-        f"{body}"
-    )
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n{body}"
 
 
 class TestKeepOnlyTestFiles:
@@ -30,6 +25,12 @@ class TestKeepOnlyTestFiles:
     def test_keeps_files_under_testing_dir(self):
         patch = _diff("django/testing/helpers.py")
         assert "django/testing/helpers.py" in keep_only_test_files(patch)
+
+    def test_keeps_files_under_singular_test_dir(self):
+        # ``test/`` (singular) at a non-root level is a valid test layout
+        # too (used by e.g. requests, pytest itself); document that it's kept.
+        patch = _diff("test/unit/helpers.py")
+        assert "test/unit/helpers.py" in keep_only_test_files(patch)
 
     def test_keeps_conftest(self):
         patch = _diff("pkg/conftest.py")
@@ -57,6 +58,16 @@ class TestKeepOnlyTestFiles:
         assert "test_repro.py" not in out
         assert "FIX_SUMMARY.md" not in out
         assert "tests/test_real.py" in out
+
+    def test_drops_root_level_conftest(self):
+        # A root-level ``conftest.py`` is treated as agent scratch (the SWT
+        # repos we evaluate keep conftest under a package), not as a real
+        # test file. This test pins that trade-off so a future loosening of
+        # the root-exclusion guard is intentional, not accidental.
+        patch = _diff("conftest.py") + _diff("tests/conftest.py")
+        out = keep_only_test_files(patch)
+        assert "diff --git a/conftest.py b/conftest.py" not in out
+        assert "tests/conftest.py" in out
 
     def test_drops_build_and_docs(self):
         patch = (


### PR DESCRIPTION
Addresses option 2 from #708.

## What

Extends the existing setup-file strip in `benchmarks/swtbench/eval_infer.py` with a positive whitelist that keeps **only** test-file diffs in `model_patch`. SWT-bench scores nothing else, and non-test diffs in `model_patch` actively hurt the score because the agent's own source "fix" runs against the test and silences the F2P signal.

### Changes

- `benchmarks/utils/patch_utils.py`: new `keep_only_test_files(git_patch)` helper that mirrors the structure of the existing `remove_files_from_patch`. A file is kept iff its path lives under `tests/`, `test/`, `testing/`, or its basename matches `test_*.py` / `*_test.py` / `conftest.py`. Repo-root paths are intentionally rejected so agent-authored scratch files (`reproduction.py`, `test_repro.py`, `FIX_SUMMARY.md`, …) are dropped even when they look testy.
- `benchmarks/swtbench/eval_infer.py`: call `keep_only_test_files` immediately after the existing `remove_files_from_patch(setup_files)` call. Same place, same shape as the tox.ini/pyproject.toml/setup.py strip.
- `tests/test_patch_utils_keep_test_files.py`: unit tests covering tests-dir, testing-dir, conftest, suffix/prefix names, repo-root scratch rejection, build/docs rejection, and the all-non-test case.

## Why

From run `litellm_proxy-openrouter-qwen-qwen3-coder-next/24103435463` (424 instances), cross-tabbing patch shape against the resolved set:

| Patch category                | # instances | Resolved | Rate      |
| ----------------------------- | ----------: | -------: | --------- |
| Only test files               |          22 |       10 | **45.5 %** |
| Mixed test + source code      |         332 |        4 | 1.2 %     |
| Only source code / no test    |          64 |        0 | 0 %       |
| Empty                         |           3 |        0 | 0 %       |
| **Total**                     |         424 |       14 | **3.3 %** |

Stripping non-test diffs converts most mixed patches into the "only test files" shape — the population that already resolves at 45.5 %. Not every mixed patch will recover (some tests are calibrated to the agent's own fix or import symbols the agent added), but even a conservative recovery is multiples of the current score.

## How to test

No re-inference required. Run `benchmarks/swtbench/eval_infer.py` against the existing `output.jsonl` from the bad run; the regenerated `output.swtbench.jsonl` will have only test-file diffs and the harness will rescore accordingly.

Unit tests:

```
pytest tests/test_patch_utils_keep_test_files.py
```

## Risks / caveats

- **Heuristic, not ground truth.** The whitelist is path-based. A more precise version would intersect with the gold `test_patch` file set per instance; deferred to a follow-up to keep this PR minimal.
- **Doesn't fix the root cause** — the agent still wastes tokens on source-code fixes. Option 1 (prompt change, opened separately as #710) is complementary, not an alternative.
- **Existing runs change behavior.** Any past SWT-bench run rescored on this code will see different numbers. Numbers reported on the benchmark monitor will need a re-eval pass to be consistent. Existing `output.swtbench.jsonl` files in completed runs are untouched on disk; only future invocations of `eval_infer.py` change.
- The new test file lives at `tests/test_patch_utils_keep_test_files.py`; happy to move/rename if the repo has a different convention I missed.

Refs #708.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fa97cf13-7953-4227-8abc-cd2f6ad5d3dd)