### PR TITLE
swtbench: don't lose a whole run when upstream grading.py crashes on one bad log

### DIFF
--- a/benchmarks/swtbench/image_utils.py
+++ b/benchmarks/swtbench/image_utils.py
@@ -15,6 +15,132 @@ from openhands.sdk import get_logger
 logger = get_logger(__name__)
 
 
+_GRADING_PATCH_MARKER = "# openhands-benchmarks: defensive coverage-marker split"
+_REPORT_ISOLATION_MARKER = "# openhands-benchmarks: per-instance report isolation"
+
+
+def _patch_grading_get_logs_eval(swt_bench_dir: Path) -> None:
+    """
+    Make upstream ``src/grading.py::get_logs_eval`` defensive against missing
+    coverage-trace markers.
+
+    Upstream code:
+
+        if "trace.py --count -C coverage.cover" in raw_content:
+            content = re.split(
+                r"\\n\\+ python3 [^\\n]*trace.py --count -C coverage.cover [^\\n]*\\n",
+                raw_content,
+                flags=re.MULTILINE,
+            )[1]
+
+    The substring guard is weaker than the regex (different line prefix,
+    truncated logs, etc.), so ``re.split(...)`` can return a single-element
+    list and ``[1]`` raises ``IndexError``. A single bad instance log then
+    aborts ``make_run_report`` for the entire run.
+
+    This patch falls back to the full ``raw_content`` when the marker line
+    is not present, matching the ``else`` branch's behavior. Idempotent.
+    """
+    grading_py = swt_bench_dir / "src" / "grading.py"
+    if not grading_py.exists():
+        logger.warning(
+            "Cannot patch swt-bench grading.py: %s does not exist", grading_py
+        )
+        return
+
+    text = grading_py.read_text(encoding="utf-8")
+    if _GRADING_PATCH_MARKER in text:
+        return
+
+    old = (
+        '        content = re.split(r"\\n\\+ python3 [^\\n]*trace.py --count -C '
+        'coverage.cover [^\\n]*\\n", raw_content, flags=re.MULTILINE)[1]\n'
+    )
+    new = (
+        f"        {_GRADING_PATCH_MARKER}\n"
+        '        _parts = re.split(r"\\n\\+ python3 [^\\n]*trace.py --count -C '
+        'coverage.cover [^\\n]*\\n", raw_content, flags=re.MULTILINE)\n'
+        "        content = _parts[1] if len(_parts) > 1 else raw_content\n"
+    )
+
+    if old not in text:
+        logger.warning(
+            "Could not find expected get_logs_eval snippet to patch in %s; "
+            "upstream may have changed",
+            grading_py,
+        )
+        return
+
+    grading_py.write_text(text.replace(old, new), encoding="utf-8")
+    logger.info("Patched %s to guard against missing coverage marker", grading_py)
+
+
+def _patch_grading_report_results_isolation(swt_bench_dir: Path) -> None:
+    """
+    Isolate per-instance failures inside upstream ``src/grading.py::report_results``.
+
+    Upstream calls ``report_results`` once per instance from ``make_run_report``.
+    If grading raises for any one instance, the exception propagates out of the
+    loop, ``make_run_report`` aborts, ``report.json`` is never written, and the
+    whole benchmark run is lost.
+
+    This patch wraps ``report_results`` so any uncaught exception is logged and
+    the instance is reported as unresolved (with ``coverage_pred=None`` so the
+    aggregator skips it), letting the run finish and produce a final report.
+    Idempotent.
+    """
+    grading_py = swt_bench_dir / "src" / "grading.py"
+    if not grading_py.exists():
+        logger.warning(
+            "Cannot patch swt-bench grading.py: %s does not exist", grading_py
+        )
+        return
+
+    text = grading_py.read_text(encoding="utf-8")
+    if _REPORT_ISOLATION_MARKER in text:
+        return
+
+    old = "def report_results(\n"
+    if text.count(old) != 1:
+        logger.warning(
+            "Could not find unique `def report_results(` in %s; upstream may "
+            "have changed",
+            grading_py,
+        )
+        return
+
+    wrapper = (
+        f"{_REPORT_ISOLATION_MARKER}\n"
+        "def report_results(*args, **kwargs):\n"
+        "    try:\n"
+        "        return _openhands_unsafe_report_results(*args, **kwargs)\n"
+        "    except Exception as _exc:\n"
+        "        import sys, traceback\n"
+        '        _iid = kwargs.get("instance_id")\n'
+        "        if _iid is None and len(args) > 4:\n"
+        "            _iid = args[4]\n"
+        "        if _iid is None:\n"
+        '            _iid = "unknown"\n'
+        "        sys.stderr.write(\n"
+        '            f"[openhands-benchmarks] report_results failed for "\n'
+        '            f"{_iid}: {_exc!r}; marking as unresolved and continuing\\n"\n'
+        "        )\n"
+        "        traceback.print_exc(file=sys.stderr)\n"
+        "        return {_iid: {\n"
+        '            "resolved": False,\n'
+        '            "coverage_pred": None,\n'
+        '            "coverage_delta_pred": 0,\n'
+        '            "added_f2p": [],\n'
+        "        }}\n"
+        "\n"
+        "\n"
+        "def _openhands_unsafe_report_results(\n"
+    )
+
+    grading_py.write_text(text.replace(old, wrapper), encoding="utf-8")
+    logger.info("Patched %s to isolate per-instance report failures", grading_py)
+
+
 def ensure_swt_bench_repo(cache_dir: Path | None = None) -> Path:
     """
     Ensure the SWT-bench sources are available locally.
@@ -24,24 +150,27 @@ def ensure_swt_bench_repo(cache_dir: Path | None = None) -> Path:
     cache_dir = cache_dir or Path.home() / ".cache" / "openhands" / "swt-bench"
     swt_bench_dir = cache_dir / "swt-bench"
 
-    if swt_bench_dir.exists():
-        return swt_bench_dir
+    if not swt_bench_dir.exists():
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        logger.info("Cloning SWT-Bench repository into %s", swt_bench_dir)
+        result = subprocess.run(
+            [
+                "git",
+                "clone",
+                "https://github.com/logic-star-ai/swt-bench.git",
+                str(swt_bench_dir),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            logger.error("Failed to clone swt-bench: %s", result.stderr)
+            raise RuntimeError("Unable to clone swt-bench repository")
 
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    logger.info("Cloning SWT-Bench repository into %s", swt_bench_dir)
-    result = subprocess.run(
-        [
-            "git",
-            "clone",
-            "https://github.com/logic-star-ai/swt-bench.git",
-            str(swt_bench_dir),
-        ],
-        text=True,
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        logger.error("Failed to clone swt-bench: %s", result.stderr)
-        raise RuntimeError("Unable to clone swt-bench repository")
+    # Always (re)apply local patches — idempotent — so cached clones from
+    # earlier runs also pick up the fix.
+    _patch_grading_get_logs_eval(swt_bench_dir)
+    _patch_grading_report_results_isolation(swt_bench_dir)
 
     return swt_bench_dir
 

--- a/tests/test_swtbench_grading_patches.py
+++ b/tests/test_swtbench_grading_patches.py
@@ -1,0 +1,181 @@
+"""Tests for the local patches applied to upstream swt-bench grading code.
+
+The upstream ``src/grading.py::get_logs_eval`` crashes with ``IndexError`` when
+a test log contains the substring ``"trace.py --count -C coverage.cover"`` but
+not the full shell-trace marker line. A single bad log then aborts
+``make_run_report``, which throws away the whole benchmark report.
+
+We patch the cloned upstream source in
+``benchmarks.swtbench.image_utils.ensure_swt_bench_repo`` to:
+
+1. Fall back to ``raw_content`` when the regex split returns a single chunk.
+2. Wrap ``report_results`` so any per-instance grading exception becomes an
+   "unresolved" marker instead of killing the run.
+
+These tests construct a minimal fake upstream layout, apply the patches, and
+verify both behaviors. They are intentionally hermetic — no network, no docker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchmarks.swtbench.image_utils import (
+    _GRADING_PATCH_MARKER,
+    _REPORT_ISOLATION_MARKER,
+    _patch_grading_get_logs_eval,
+    _patch_grading_report_results_isolation,
+)
+
+
+_UPSTREAM_GRADING_SNIPPET = """\
+import re
+
+APPLY_PATCH_FAIL = "PATCH_APPLY_FAIL"
+RESET_FAILED = "RESET_FAILED"
+TESTS_ERROR = "TESTS_ERROR"
+TESTS_TIMEOUT = "TESTS_TIMEOUT"
+
+
+def get_logs_eval(log_fp, repo, exec_mode):
+    with open(log_fp) as f:
+        raw_content = f.read()
+    if "trace.py --count -C coverage.cover" in raw_content:
+        # NOTE: does not work when not computing coverage
+        content = re.split(r"\\n\\+ python3 [^\\n]*trace.py --count -C coverage.cover [^\\n]*\\n", raw_content, flags=re.MULTILINE)[1]
+    else:
+        content = raw_content
+    if "+ cat coverage.cover" in content:
+        content = content.split("\\n+ cat coverage.cover")[0]
+    if any(x in raw_content for x in [APPLY_PATCH_FAIL, RESET_FAILED, TESTS_ERROR, TESTS_TIMEOUT]):
+        return {}, False
+    return {"some-test": "PASSED"}, True
+
+
+def report_results(
+        patch_id,
+        run_id,
+        golden_code_patch,
+        output_paths,
+        instance_id,
+        repo,
+        exec_mode,
+):
+    # Simulates upstream — calls get_logs_eval; on real bad logs this can raise.
+    if output_paths:
+        for p in output_paths:
+            get_logs_eval(p, repo, exec_mode)
+    return {instance_id: {"resolved": True, "coverage_pred": 0.5, "coverage_delta_pred": 0.1, "added_f2p": []}}
+"""
+
+
+def _write_fake_upstream(root: Path) -> Path:
+    """Create swt-bench/src/grading.py mimicking the upstream structure."""
+    src = root / "src"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("")
+    grading = src / "grading.py"
+    grading.write_text(_UPSTREAM_GRADING_SNIPPET)
+    return root
+
+
+def _import_grading(swt_bench_dir: Path, monkeypatch):
+    """Import the patched grading module from the fake upstream tree."""
+    import importlib
+    import sys
+
+    monkeypatch.syspath_prepend(str(swt_bench_dir))
+    # Make sure we re-import after the source file was rewritten
+    for name in [k for k in sys.modules if k.startswith("src")]:
+        del sys.modules[name]
+    return importlib.import_module("src.grading")
+
+
+def test_unpatched_get_logs_eval_raises_index_error(tmp_path, monkeypatch):
+    """Confirms our reproducer matches the production bug."""
+    _write_fake_upstream(tmp_path / "swt-bench")
+    g = _import_grading(tmp_path / "swt-bench", monkeypatch)
+
+    bad = tmp_path / "bad.txt"
+    # Substring present, but no real "+ python3 ... trace.py ..." marker line.
+    bad.write_text("noise trace.py --count -C coverage.cover noise\ntruncated")
+
+    import pytest
+
+    with pytest.raises(IndexError):
+        g.get_logs_eval(str(bad), "astropy/astropy", "coverage")
+
+
+def test_patched_get_logs_eval_falls_back_to_raw_content(tmp_path, monkeypatch):
+    swt = _write_fake_upstream(tmp_path / "swt-bench")
+    _patch_grading_get_logs_eval(swt)
+
+    grading_text = (swt / "src" / "grading.py").read_text()
+    assert _GRADING_PATCH_MARKER in grading_text
+    assert "flags=re.MULTILINE)[1]" not in grading_text
+    assert "_parts[1] if len(_parts) > 1 else raw_content" in grading_text
+
+    g = _import_grading(swt, monkeypatch)
+    bad = tmp_path / "bad.txt"
+    bad.write_text("noise trace.py --count -C coverage.cover noise\ntruncated")
+
+    # Must not raise; returns the same shape as the else-branch already does.
+    res, applied = g.get_logs_eval(str(bad), "astropy/astropy", "coverage")
+    assert isinstance(res, dict)
+    assert isinstance(applied, bool)
+
+
+def test_patches_are_idempotent(tmp_path):
+    swt = _write_fake_upstream(tmp_path / "swt-bench")
+    _patch_grading_get_logs_eval(swt)
+    _patch_grading_report_results_isolation(swt)
+    first = (swt / "src" / "grading.py").read_text()
+
+    _patch_grading_get_logs_eval(swt)
+    _patch_grading_report_results_isolation(swt)
+    second = (swt / "src" / "grading.py").read_text()
+
+    assert first == second
+    assert _GRADING_PATCH_MARKER in second
+    assert _REPORT_ISOLATION_MARKER in second
+
+
+def test_patched_report_results_isolates_failures(tmp_path, monkeypatch):
+    swt = _write_fake_upstream(tmp_path / "swt-bench")
+    _patch_grading_report_results_isolation(swt)
+
+    g = _import_grading(swt, monkeypatch)
+    assert hasattr(g, "_openhands_unsafe_report_results")
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("simulated grading bug")
+
+    monkeypatch.setattr(g, "_openhands_unsafe_report_results", _boom)
+
+    out = g.report_results(
+        "patch_id",
+        "run_id",
+        "",
+        None,
+        "fake__instance-1",
+        "astropy/astropy",
+        "coverage",
+    )
+
+    assert out == {
+        "fake__instance-1": {
+            "resolved": False,
+            "coverage_pred": None,
+            "coverage_delta_pred": 0,
+            "added_f2p": [],
+        }
+    }
+
+
+def test_patch_helpers_no_op_when_grading_missing(tmp_path):
+    """Patch helpers must not raise if the upstream source is unexpectedly absent."""
+    empty = tmp_path / "swt-bench"
+    empty.mkdir()
+    # Should log a warning but not raise.
+    _patch_grading_get_logs_eval(empty)
+    _patch_grading_report_results_isolation(empty)


### PR DESCRIPTION
## What

Patches the cloned upstream `swt-bench/src/grading.py` from `ensure_swt_bench_repo` so a single malformed test log can't sink an entire benchmark report.

## Why

In run [25868145876](https://github.com/OpenHands/evaluation/actions/runs/25868145876) ([eval monitor](https://openhands-eval-monitor.vercel.app/?run=swtbench%2Flitellm_proxy-trinity-large-thinking%2F25868145876%2F&days=15)), inference completed cleanly (`100%|██████████| 432/432`), but the reporting pass crashed at instance ~236/432 with:

```
File "/root/.cache/openhands/swt-bench/swt-bench/src/grading.py", line 76, in get_logs_eval
    content = re.split(r"\n\+ python3 [^\n]*trace.py --count -C coverage.cover [^\n]*\n",
                       raw_content, flags=re.MULTILINE)[1]
IndexError: list index out of range
```

Upstream code:

```python
if "trace.py --count -C coverage.cover" in raw_content:
    content = re.split(
        r"\n\+ python3 [^\n]*trace.py --count -C coverage.cover [^\n]*\n",
        raw_content, flags=re.MULTILINE,
    )[1]
else:
    content = raw_content
```

The substring guard is **strictly weaker** than the regex it gates: a log can contain the substring `trace.py --count -C coverage.cover` without containing the full shell-trace marker line `\n+ python3 … trace.py --count -C coverage.cover …\n` (e.g. when the test container died or got truncated mid-run, or the prefix is `+ python` instead of `+ python3`). `re.split` then returns a single-element list and `[1]` raises `IndexError`. Because the exception is uncaught, it propagates `get_logs_eval → report_results → make_run_report → src/main.py`, so **one bad log aborts the report for all 432 instances** and `report.json` is never written. The whole 2h+ run is lost.

## How

Two idempotent in-place patches applied right after `git clone` in `ensure_swt_bench_repo`:

1. **`get_logs_eval` defensive split** — fall back to `content = raw_content` when `re.split(...)` returns fewer than two chunks. Same behavior as the existing `else` branch.

2. **`report_results` per-instance isolation** — wrap the function so any uncaught grading exception is logged with a full traceback and the instance is reported as `{"resolved": False, "coverage_pred": None, ...}`. This is belt-and-suspenders: even if a future grading bug shows up in some other code path, the run still produces a report.

Both helpers:
- Are guarded by a marker comment → safe to re-apply on a cached clone.
- No-op with a warning if the upstream snippet shape changes, so we never wedge the run if upstream rewrites that code.

## Tests

New `tests/test_swtbench_grading_patches.py` (5 tests, all hermetic — no network/docker):

- `test_unpatched_get_logs_eval_raises_index_error` — reproduces the exact production bug against a minimal fake upstream layout.
- `test_patched_get_logs_eval_falls_back_to_raw_content` — same input no longer raises.
- `test_patches_are_idempotent` — applying twice produces identical bytes.
- `test_patched_report_results_isolates_failures` — simulated `RuntimeError` inside the wrapped function returns a synthetic unresolved dict instead of propagating.
- `test_patch_helpers_no_op_when_grading_missing` — defensive against unexpected upstream layout.

```
tests/test_swtbench_grading_patches.py::test_unpatched_get_logs_eval_raises_index_error PASSED
tests/test_swtbench_grading_patches.py::test_patched_get_logs_eval_falls_back_to_raw_content PASSED
tests/test_swtbench_grading_patches.py::test_patches_are_idempotent PASSED
tests/test_swtbench_grading_patches.py::test_patched_report_results_isolates_failures PASSED
tests/test_swtbench_grading_patches.py::test_patch_helpers_no_op_when_grading_missing PASSED
============================== 5 passed in 0.04s ==============================
```

Pre-commit (ruff format/lint, pyright strict) clean on changed files.

## Comparability with historical results

This change does not alter the score for any instance whose log was well-formed — `get_logs_eval`'s control flow for valid logs is byte-for-byte unchanged (`_parts[1]` is taken when the regex matches, exactly as before). It only changes behavior for instances that previously caused the entire harness to crash. Those instances now score "unresolved" (which is the truthful outcome — their test container failed to produce a valid log) instead of aborting the run.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini after investigating the failed run together._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cad590eb-a849-465d-aef9-e340346229a1)