### PR TITLE
Harden workflow GitHub context handling

### DIFF
--- a/.github/actions/build-select-file/action.yml
+++ b/.github/actions/build-select-file/action.yml
@@ -14,10 +14,12 @@ runs:
   steps:
     - name: Build selected instances file
       shell: bash
+      env:
+        INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
       run: |
         set -euo pipefail
 
-        if [ -z "${{ inputs.instance-ids }}" ]; then
+        if [ -z "$INPUTS_INSTANCE_IDS" ]; then
           echo "No instance IDs provided; skipping select file creation."
           exit 0
         fi
@@ -25,7 +27,7 @@ runs:
         SELECT_FILE="${RUNNER_TEMP}/selected-instances.txt"
         echo "Creating selected instances file at ${SELECT_FILE}"
 
-        echo "${{ inputs.instance-ids }}" \
+        echo "$INPUTS_INSTANCE_IDS" \
           | tr ',' '\n' \
           | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
           | sed '/^$/d' > "${SELECT_FILE}"

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -215,6 +215,10 @@ jobs:
       - name: Build and push Commit0 images
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -239,11 +243,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-
       - name: Archive build logs
         if: always()
         run: |

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -116,7 +116,6 @@ jobs:
         env:
           INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
             echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
@@ -124,9 +123,9 @@ jobs:
           elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit: $INPUTS_BENCHMARKS_COMMIT"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using triggering ref (default)"

--- a/.github/workflows/build-commit0-images.yml
+++ b/.github/workflows/build-commit0-images.yml
@@ -113,16 +113,20 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
+          INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ -n "${{ inputs.benchmarks-ref }}" ]; then
-            echo "ref=${{ inputs.benchmarks-ref }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-ref: ${{ inputs.benchmarks-ref }}"
-          elif [ -n "${{ inputs.benchmarks-commit }}" ]; then
-            echo "ref=${{ inputs.benchmarks-commit }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-commit: ${{ inputs.benchmarks-commit }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-ref: $INPUTS_BENCHMARKS_REF"
+          elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-commit: $INPUTS_BENCHMARKS_COMMIT"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using triggering ref (default)"
@@ -137,14 +141,22 @@ jobs:
 
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset }}
+          INPUTS_SPLIT: ${{ inputs.split }}
+          INPUTS_REPO_SPLIT: ${{ inputs.repo-split }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.repo-split }}" ]; then echo "REPO_SPLIT=${{ inputs.repo-split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.sdk-commit }}" ]; then echo "SDK_COMMIT=${{ inputs.sdk-commit }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_DATASET" ]; then echo "DATASET=$INPUTS_DATASET" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SPLIT" ]; then echo "SPLIT=$INPUTS_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_REPO_SPLIT" ]; then echo "REPO_SPLIT=$INPUTS_REPO_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_WORKERS" ]; then echo "MAX_WORKERS=$INPUTS_MAX_WORKERS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_N_LIMIT" ]; then echo "N_LIMIT=$INPUTS_N_LIMIT" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_INSTANCE_IDS" ]; then echo "INSTANCE_IDS=$INPUTS_INSTANCE_IDS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SDK_COMMIT" ]; then echo "SDK_COMMIT=$INPUTS_SDK_COMMIT" >> "$GITHUB_ENV"; fi
 
       - uses: ./.github/actions/build-select-file
         with:
@@ -152,14 +164,16 @@ jobs:
 
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -199,9 +213,11 @@ jobs:
           docker system df || true
 
       - name: Build and push Commit0 images
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/commit0/build_images.py \
             --dataset '${DATASET}' \

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -61,14 +61,13 @@ jobs:
         id: checkout-ref
         env:
           INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
             echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-ref: $INPUTS_BENCHMARKS_REF"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -169,9 +168,6 @@ jobs:
       - name: Comment on tracker issue
         if: success()
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version
@@ -198,7 +194,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
+            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
             TRIGGER="$GITHUB_EVENT_NAME"
           fi

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -116,6 +116,10 @@ jobs:
       - name: Build and push GAIA image with MCP layer
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -136,11 +140,6 @@ jobs:
           eval "$CMD"
 
           echo "✅ GAIA image with MCP layer built and pushed successfully"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-
       - name: Archive build logs
         if: always()
         run: |
@@ -173,6 +172,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -220,5 +220,3 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ github.api_url }}/repos/${{ github.repository }}/issues/81/comments" \
             -d @-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -191,12 +191,12 @@ jobs:
           fi
 
           # Determine trigger source
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
-            TRIGGER="$GITHUB_EVENT_NAME"
+            TRIGGER="${{ github.event_name }}"
           fi
 
           # Post comment using jq to properly handle multi-line content

--- a/.github/workflows/build-gaia-images.yml
+++ b/.github/workflows/build-gaia-images.yml
@@ -59,13 +59,16 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ -n "${{ inputs.benchmarks-ref }}" ]; then
-            echo "ref=${{ inputs.benchmarks-ref }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-ref: ${{ inputs.benchmarks-ref }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-ref: $INPUTS_BENCHMARKS_REF"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -80,14 +83,16 @@ jobs:
 
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -109,9 +114,11 @@ jobs:
           make build
 
       - name: Build and push GAIA image with MCP layer
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           # GAIA requires 'binary' target to include Chromium for browser operations
           TARGET="binary"
@@ -162,6 +169,10 @@ jobs:
 
       - name: Comment on tracker issue
         if: success()
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           # Get SDK version
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -184,12 +195,12 @@ jobs:
           fi
 
           # Determine trigger source
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
           else
-            TRIGGER="${{ github.event_name }}"
+            TRIGGER="$GITHUB_EVENT_NAME"
           fi
 
           # Post comment using jq to properly handle multi-line content

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -102,13 +102,17 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.benchmarks-commit }}" ]; then
-            echo "ref=${{ inputs.benchmarks-commit }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-commit from workflow_dispatch: ${{ inputs.benchmarks-commit }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             # Empty ref means checkout the ref that triggered the workflow (e.g., main branch for workflow_dispatch)
             echo "ref=" >> "$GITHUB_OUTPUT"
@@ -124,21 +128,31 @@ jobs:
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset }}
+          INPUTS_SPLIT: ${{ inputs.split }}
+          INPUTS_LANGUAGE: ${{ inputs.language }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers }}
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
         run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.language }}" ]; then echo "LANGUAGE=${{ inputs.language }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_DATASET" ]; then echo "DATASET=$INPUTS_DATASET" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SPLIT" ]; then echo "SPLIT=$INPUTS_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_LANGUAGE" ]; then echo "LANGUAGE=$INPUTS_LANGUAGE" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_WORKERS" ]; then echo "MAX_WORKERS=$INPUTS_MAX_WORKERS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_RETRIES" ]; then echo "MAX_RETRIES=$INPUTS_MAX_RETRIES" >> "$GITHUB_ENV"; fi
           # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_N_LIMIT" ]; then echo "N_LIMIT=$INPUTS_N_LIMIT" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_INSTANCE_IDS" ]; then echo "INSTANCE_IDS=$INPUTS_INSTANCE_IDS" >> "$GITHUB_ENV"; fi
 
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="${{ github.event.label.name }}"
+          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
           if [ "$LABEL_NAME" = "build-multiswebench-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-multiswebench-50"
@@ -158,15 +172,17 @@ jobs:
       # Must run BEFORE install dependencies so git submodule update works correctly
       - name: Update SDK submodule
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           # Stage the submodule reference update so make build uses it
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx with Blacksmith
         uses: useblacksmith/setup-docker-builder@v1
@@ -218,9 +234,11 @@ jobs:
           fi
 
       - name: Build and push Multi-SWE-Bench images
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/multiswebench/build_images.py \
             --dataset '${DATASET}' \
@@ -279,6 +297,10 @@ jobs:
 
       - name: Comment on tracker issue
         if: success()
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -313,12 +335,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
           else
-            TRIGGER="${{ github.event_name }}"
+            TRIGGER="$GITHUB_EVENT_NAME"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -103,16 +103,14 @@ jobs:
       - name: Determine checkout ref
         id: checkout-ref
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             # Empty ref means checkout the ref that triggered the workflow (e.g., main branch for workflow_dispatch)
             echo "ref=" >> "$GITHUB_OUTPUT"
@@ -149,10 +147,8 @@ jobs:
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
-        env:
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
+          LABEL_NAME="${{ github.event.label.name }}"
           if [ "$LABEL_NAME" = "build-multiswebench-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-multiswebench-50"
@@ -297,9 +293,6 @@ jobs:
       - name: Comment on tracker issue
         if: success()
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
@@ -338,7 +331,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
+            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
             TRIGGER="$GITHUB_EVENT_NAME"
           fi

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
           elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
@@ -328,12 +328,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
-            TRIGGER="$GITHUB_EVENT_NAME"
+            TRIGGER="${{ github.event_name }}"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-multiswebench-images.yml
+++ b/.github/workflows/build-multiswebench-images.yml
@@ -236,6 +236,12 @@ jobs:
       - name: Build and push Multi-SWE-Bench images
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+          BUILDKIT_RESET_ON_FAILURE: 1
+          LANGUAGE: ${{ env.LANGUAGE }}
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -261,13 +267,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-          BUILDKIT_RESET_ON_FAILURE: 1
-          LANGUAGE: ${{ env.LANGUAGE }}
-
       - name: Archive build logs
         if: always()
         run: |
@@ -301,6 +300,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -370,5 +370,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "${{ github.api_url }}/repos/${{ github.repository }}/issues/81/comments" \
             -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -343,12 +343,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
-            TRIGGER="$GITHUB_EVENT_NAME"
+            TRIGGER="${{ github.event_name }}"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -121,7 +121,6 @@ jobs:
         env:
           INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
             echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
@@ -129,9 +128,9 @@ jobs:
           elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit: $INPUTS_BENCHMARKS_COMMIT"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -166,10 +165,8 @@ jobs:
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
-        env:
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
+          LABEL_NAME="${{ github.event.label.name }}"
           if [ "$LABEL_NAME" = "build-swebench-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swebench-50"
@@ -311,9 +308,6 @@ jobs:
       - name: Comment on tracker issue
         if: success()
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
@@ -352,7 +346,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
+            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
             TRIGGER="$GITHUB_EVENT_NAME"
           fi

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -253,6 +253,10 @@ jobs:
       - name: Build and push SWE-Bench images
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -277,11 +281,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-
       - name: Archive build logs
         if: always()
         run: |
@@ -315,6 +314,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -383,5 +383,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "${{ github.api_url }}/repos/${{ github.repository }}/issues/81/comments" \
             -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-swebench-images.yml
+++ b/.github/workflows/build-swebench-images.yml
@@ -118,16 +118,20 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
+          INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ -n "${{ inputs.benchmarks-ref }}" ]; then
-            echo "ref=${{ inputs.benchmarks-ref }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-ref: ${{ inputs.benchmarks-ref }}"
-          elif [ -n "${{ inputs.benchmarks-commit }}" ]; then
-            echo "ref=${{ inputs.benchmarks-commit }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-commit: ${{ inputs.benchmarks-commit }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-ref: $INPUTS_BENCHMARKS_REF"
+          elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-commit: $INPUTS_BENCHMARKS_COMMIT"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -143,20 +147,29 @@ jobs:
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset }}
+          INPUTS_SPLIT: ${{ inputs.split }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers }}
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
         run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_DATASET" ]; then echo "DATASET=$INPUTS_DATASET" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SPLIT" ]; then echo "SPLIT=$INPUTS_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_WORKERS" ]; then echo "MAX_WORKERS=$INPUTS_MAX_WORKERS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_RETRIES" ]; then echo "MAX_RETRIES=$INPUTS_MAX_RETRIES" >> "$GITHUB_ENV"; fi
           # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_N_LIMIT" ]; then echo "N_LIMIT=$INPUTS_N_LIMIT" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_INSTANCE_IDS" ]; then echo "INSTANCE_IDS=$INPUTS_INSTANCE_IDS" >> "$GITHUB_ENV"; fi
 
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="${{ github.event.label.name }}"
+          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
           if [ "$LABEL_NAME" = "build-swebench-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swebench-50"
@@ -176,15 +189,17 @@ jobs:
       # Must run BEFORE install dependencies so git submodule update works correctly
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           # Stage the submodule reference update so make build uses it
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -236,9 +251,11 @@ jobs:
           fi
 
       - name: Build and push SWE-Bench images
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/swebench/build_images.py \
             --dataset '${DATASET}' \
@@ -294,6 +311,10 @@ jobs:
 
       - name: Comment on tracker issue
         if: success()
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -328,12 +349,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
           else
-            TRIGGER="${{ github.event_name }}"
+            TRIGGER="$GITHUB_EVENT_NAME"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -118,16 +118,20 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
+          INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ -n "${{ inputs.benchmarks-ref }}" ]; then
-            echo "ref=${{ inputs.benchmarks-ref }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-ref: ${{ inputs.benchmarks-ref }}"
-          elif [ -n "${{ inputs.benchmarks-commit }}" ]; then
-            echo "ref=${{ inputs.benchmarks-commit }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-commit: ${{ inputs.benchmarks-commit }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-ref: $INPUTS_BENCHMARKS_REF"
+          elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-commit: $INPUTS_BENCHMARKS_COMMIT"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -143,20 +147,29 @@ jobs:
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset }}
+          INPUTS_SPLIT: ${{ inputs.split }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers }}
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
         run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_DATASET" ]; then echo "DATASET=$INPUTS_DATASET" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SPLIT" ]; then echo "SPLIT=$INPUTS_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_WORKERS" ]; then echo "MAX_WORKERS=$INPUTS_MAX_WORKERS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_RETRIES" ]; then echo "MAX_RETRIES=$INPUTS_MAX_RETRIES" >> "$GITHUB_ENV"; fi
           # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_N_LIMIT" ]; then echo "N_LIMIT=$INPUTS_N_LIMIT" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_INSTANCE_IDS" ]; then echo "INSTANCE_IDS=$INPUTS_INSTANCE_IDS" >> "$GITHUB_ENV"; fi
 
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="${{ github.event.label.name }}"
+          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
           if [ "$LABEL_NAME" = "build-swebenchmultimodal-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swebenchmultimodal-50"
@@ -176,15 +189,17 @@ jobs:
       # Must run BEFORE install dependencies so git submodule update works correctly
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           # Stage the submodule reference update so make build uses it
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -236,9 +251,11 @@ jobs:
           fi
 
       - name: Build and push SWE-Bench Multimodal images (three-phase pipeline)
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/swebenchmultimodal/build_images.py \
             --dataset '${DATASET}' \

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -253,6 +253,10 @@ jobs:
       - name: Build and push SWE-Bench Multimodal images (three-phase pipeline)
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -278,11 +282,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-
       - name: Archive build logs
         if: always()
         run: |

--- a/.github/workflows/build-swebenchmultimodal-images.yml
+++ b/.github/workflows/build-swebenchmultimodal-images.yml
@@ -121,7 +121,6 @@ jobs:
         env:
           INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
             echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
@@ -129,9 +128,9 @@ jobs:
           elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit: $INPUTS_BENCHMARKS_COMMIT"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -166,10 +165,8 @@ jobs:
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
-        env:
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
+          LABEL_NAME="${{ github.event.label.name }}"
           if [ "$LABEL_NAME" = "build-swebenchmultimodal-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swebenchmultimodal-50"

--- a/.github/workflows/build-swebenchpro-images.yml
+++ b/.github/workflows/build-swebenchpro-images.yml
@@ -128,13 +128,17 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
+          INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ -n "${{ inputs.benchmarks-ref }}" ]; then
-            echo "ref=${{ inputs.benchmarks-ref }}" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ inputs.benchmarks-commit }}" ]; then
-            echo "ref=${{ inputs.benchmarks-commit }}" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
+          elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
           fi
@@ -148,18 +152,27 @@ jobs:
 
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset }}
+          INPUTS_SPLIT: ${{ inputs.split }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers }}
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
         run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_DATASET" ]; then echo "DATASET=$INPUTS_DATASET" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SPLIT" ]; then echo "SPLIT=$INPUTS_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_WORKERS" ]; then echo "MAX_WORKERS=$INPUTS_MAX_WORKERS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_RETRIES" ]; then echo "MAX_RETRIES=$INPUTS_MAX_RETRIES" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_N_LIMIT" ]; then echo "N_LIMIT=$INPUTS_N_LIMIT" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_INSTANCE_IDS" ]; then echo "INSTANCE_IDS=$INPUTS_INSTANCE_IDS" >> "$GITHUB_ENV"; fi
 
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="${{ github.event.label.name }}"
+          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
           if [ "$LABEL_NAME" = "build-swebenchpro-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
           elif [ "$LABEL_NAME" = "build-swebenchpro-200" ]; then
@@ -174,9 +187,11 @@ jobs:
 
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           cd ../..
           git add vendor/software-agent-sdk
@@ -200,9 +215,11 @@ jobs:
         run: make build
 
       - name: Build and push SWE-Bench Pro images
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/swebenchpro/build_images.py \
             --dataset '${DATASET}' \

--- a/.github/workflows/build-swebenchpro-images.yml
+++ b/.github/workflows/build-swebenchpro-images.yml
@@ -131,14 +131,13 @@ jobs:
         env:
           INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
             echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
           elif [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
           fi
@@ -169,10 +168,8 @@ jobs:
 
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
-        env:
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
+          LABEL_NAME="${{ github.event.label.name }}"
           if [ "$LABEL_NAME" = "build-swebenchpro-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
           elif [ "$LABEL_NAME" = "build-swebenchpro-200" ]; then

--- a/.github/workflows/build-swebenchpro-images.yml
+++ b/.github/workflows/build-swebenchpro-images.yml
@@ -217,6 +217,10 @@ jobs:
       - name: Build and push SWE-Bench Pro images
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -241,11 +245,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-
       - name: Archive build logs
         if: always()
         run: |

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
           elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
@@ -319,12 +319,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
-            TRIGGER="$GITHUB_EVENT_NAME"
+            TRIGGER="${{ github.event_name }}"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -228,6 +228,11 @@ jobs:
       - name: Build and push SWE-Gym images
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+          BUILDKIT_RESET_ON_FAILURE: 1
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -253,12 +258,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-          BUILDKIT_RESET_ON_FAILURE: 1
-
       - name: Archive build logs
         if: always()
         run: |
@@ -292,6 +291,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -360,5 +360,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "${{ github.api_url }}/repos/${{ github.repository }}/issues/81/comments" \
             -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -97,16 +97,14 @@ jobs:
       - name: Determine checkout ref
         id: checkout-ref
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             # Empty ref means checkout the ref that triggered the workflow (e.g., main branch for workflow_dispatch)
             echo "ref=" >> "$GITHUB_OUTPUT"
@@ -141,10 +139,8 @@ jobs:
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
-        env:
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
+          LABEL_NAME="${{ github.event.label.name }}"
           if [ "$LABEL_NAME" = "build-swegym-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swegym-50"
@@ -288,9 +284,6 @@ jobs:
       - name: Comment on tracker issue
         if: success()
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
@@ -329,7 +322,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
+            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
             TRIGGER="$GITHUB_EVENT_NAME"
           fi

--- a/.github/workflows/build-swegym-images.yml
+++ b/.github/workflows/build-swegym-images.yml
@@ -96,13 +96,17 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.benchmarks-commit }}" ]; then
-            echo "ref=${{ inputs.benchmarks-commit }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-commit from workflow_dispatch: ${{ inputs.benchmarks-commit }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             # Empty ref means checkout the ref that triggered the workflow (e.g., main branch for workflow_dispatch)
             echo "ref=" >> "$GITHUB_OUTPUT"
@@ -118,20 +122,29 @@ jobs:
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset }}
+          INPUTS_SPLIT: ${{ inputs.split }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers }}
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
         run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_DATASET" ]; then echo "DATASET=$INPUTS_DATASET" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SPLIT" ]; then echo "SPLIT=$INPUTS_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_WORKERS" ]; then echo "MAX_WORKERS=$INPUTS_MAX_WORKERS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_RETRIES" ]; then echo "MAX_RETRIES=$INPUTS_MAX_RETRIES" >> "$GITHUB_ENV"; fi
           # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_N_LIMIT" ]; then echo "N_LIMIT=$INPUTS_N_LIMIT" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_INSTANCE_IDS" ]; then echo "INSTANCE_IDS=$INPUTS_INSTANCE_IDS" >> "$GITHUB_ENV"; fi
 
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="${{ github.event.label.name }}"
+          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
           if [ "$LABEL_NAME" = "build-swegym-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swegym-50"
@@ -151,15 +164,17 @@ jobs:
       # Must run BEFORE install dependencies so git submodule update works correctly
       - name: Update SDK submodule
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           # Stage the submodule reference update so make build uses it
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx with Blacksmith
         uses: useblacksmith/setup-docker-builder@v1
@@ -211,9 +226,11 @@ jobs:
           fi
 
       - name: Build and push SWE-Gym images
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/swegym/build_images.py \
             --dataset '${DATASET}' \
@@ -271,6 +288,10 @@ jobs:
 
       - name: Comment on tracker issue
         if: success()
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -305,12 +326,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
           else
-            TRIGGER="${{ github.event_name }}"
+            TRIGGER="$GITHUB_EVENT_NAME"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
           elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
@@ -319,12 +319,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
-            TRIGGER="$GITHUB_EVENT_NAME"
+            TRIGGER="${{ github.event_name }}"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -96,13 +96,17 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.benchmarks-commit }}" ]; then
-            echo "ref=${{ inputs.benchmarks-commit }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-commit from workflow_dispatch: ${{ inputs.benchmarks-commit }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             # Empty ref means checkout the ref that triggered the workflow (e.g., main branch for workflow_dispatch)
             echo "ref=" >> "$GITHUB_OUTPUT"
@@ -118,20 +122,29 @@ jobs:
       # If this was a manual dispatch, override defaults with provided inputs.
       - name: Apply workflow_dispatch overrides (if any)
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset }}
+          INPUTS_SPLIT: ${{ inputs.split }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers }}
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
         run: |
-          if [ -n "${{ inputs.dataset }}" ]; then echo "DATASET=${{ inputs.dataset }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.split }}" ]; then echo "SPLIT=${{ inputs.split }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-workers }}" ]; then echo "MAX_WORKERS=${{ inputs.max-workers }}" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.max-retries }}" ]; then echo "MAX_RETRIES=${{ inputs.max-retries }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_DATASET" ]; then echo "DATASET=$INPUTS_DATASET" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_SPLIT" ]; then echo "SPLIT=$INPUTS_SPLIT" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_WORKERS" ]; then echo "MAX_WORKERS=$INPUTS_MAX_WORKERS" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_MAX_RETRIES" ]; then echo "MAX_RETRIES=$INPUTS_MAX_RETRIES" >> "$GITHUB_ENV"; fi
           # Empty string means "no limit"
-          if [ -n "${{ inputs.n-limit }}" ]; then echo "N_LIMIT=${{ inputs.n-limit }}" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
-          if [ -n "${{ inputs.instance-ids }}" ]; then echo "INSTANCE_IDS=${{ inputs.instance-ids }}" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_N_LIMIT" ]; then echo "N_LIMIT=$INPUTS_N_LIMIT" >> "$GITHUB_ENV"; else echo "N_LIMIT=" >> "$GITHUB_ENV"; fi
+          if [ -n "$INPUTS_INSTANCE_IDS" ]; then echo "INSTANCE_IDS=$INPUTS_INSTANCE_IDS" >> "$GITHUB_ENV"; fi
 
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="${{ github.event.label.name }}"
+          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
           if [ "$LABEL_NAME" = "build-swesmith-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swesmith-50"
@@ -151,15 +164,17 @@ jobs:
       # Must run BEFORE install dependencies so git submodule update works correctly
       - name: Update SDK submodule
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           # Stage the submodule reference update so make build uses it
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx with Blacksmith
         uses: useblacksmith/setup-docker-builder@v1
@@ -211,9 +226,11 @@ jobs:
           fi
 
       - name: Build and push SWE-Smith images
+        env:
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/swesmith/build_images.py \
             --dataset '${DATASET}' \
@@ -271,6 +288,10 @@ jobs:
 
       - name: Comment on tracker issue
         if: success()
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -305,12 +326,12 @@ jobs:
           ")
           
           # Determine how the workflow was triggered
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
           else
-            TRIGGER="${{ github.event_name }}"
+            TRIGGER="$GITHUB_EVENT_NAME"
           fi
           
           # Create the comment body

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -97,16 +97,14 @@ jobs:
       - name: Determine checkout ref
         id: checkout-ref
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
           INPUTS_BENCHMARKS_COMMIT: ${{ inputs.benchmarks-commit }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUTS_BENCHMARKS_COMMIT" ]; then
             echo "ref=$INPUTS_BENCHMARKS_COMMIT" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-commit from workflow_dispatch: $INPUTS_BENCHMARKS_COMMIT"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             # Empty ref means checkout the ref that triggered the workflow (e.g., main branch for workflow_dispatch)
             echo "ref=" >> "$GITHUB_OUTPUT"
@@ -141,10 +139,8 @@ jobs:
       # Set N_LIMIT based on the label that triggered the workflow
       - name: Set N_LIMIT based on label
         if: ${{ github.event_name == 'pull_request_target' }}
-        env:
-          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          LABEL_NAME="$GITHUB_EVENT_LABEL_NAME"
+          LABEL_NAME="${{ github.event.label.name }}"
           if [ "$LABEL_NAME" = "build-swesmith-50" ]; then
             echo "N_LIMIT=50" >> "$GITHUB_ENV"
             echo "Building 50 images based on label: build-swesmith-50"
@@ -288,9 +284,6 @@ jobs:
       - name: Comment on tracker issue
         if: success()
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
@@ -329,7 +322,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
+            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
             TRIGGER="$GITHUB_EVENT_NAME"
           fi

--- a/.github/workflows/build-swesmith-images.yml
+++ b/.github/workflows/build-swesmith-images.yml
@@ -228,6 +228,11 @@ jobs:
       - name: Build and push SWE-Smith images
         env:
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+          BUILDKIT_RESET_ON_FAILURE: 1
+
         run: |
           set -euo pipefail
           FORCE_BUILD="$INPUTS_FORCE_BUILD"
@@ -253,12 +258,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-          BUILDKIT_RESET_ON_FAILURE: 1
-
       - name: Archive build logs
         if: always()
         run: |
@@ -292,6 +291,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version from submodule
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -360,5 +360,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "${{ github.api_url }}/repos/${{ github.repository }}/issues/81/comments" \
             -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -189,6 +189,10 @@ jobs:
         env:
           INPUTS_MAX_RETRIES: ${{ inputs.max-retries || '3' }}
           INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
+
         run: |
           set -euo pipefail
 
@@ -215,11 +219,6 @@ jobs:
 
           echo "Running: $CMD"
           eval "$CMD"
-        env:
-          DOCKER_BUILDKIT: 1
-          BUILDKIT_PROGRESS: plain
-          EXTENSIONS_REF: ${{ inputs.extensions-ref || 'main' }}
-
       - name: Build prebaked eval env images
         if: ${{ inputs.build-eval-env == 'true' }}
         env:
@@ -342,6 +341,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -385,5 +385,3 @@ jobs:
             -H "Content-Type: application/json" \
             "${{ github.api_url }}/repos/${{ github.repository }}/issues/81/comments" \
             -d @-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -127,13 +127,16 @@ jobs:
     steps:
       - name: Determine checkout ref
         id: checkout-ref
+        env:
+          INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ -n "${{ inputs.benchmarks-ref }}" ]; then
-            echo "ref=${{ inputs.benchmarks-ref }}" >> "$GITHUB_OUTPUT"
-            echo "Using benchmarks-ref: ${{ inputs.benchmarks-ref }}"
-          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
-            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
+          if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
+            echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
+            echo "Using benchmarks-ref: $INPUTS_BENCHMARKS_REF"
+          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
+            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -152,14 +155,16 @@ jobs:
 
       - name: Update SDK submodule
         if: ${{ inputs.sdk-commit != '' }}
+        env:
+          INPUTS_SDK_COMMIT: ${{ inputs.sdk-commit }}
         run: |
           cd vendor/software-agent-sdk
-          git fetch origin ${{ inputs.sdk-commit }}
+          git fetch origin "$INPUTS_SDK_COMMIT"
           git checkout FETCH_HEAD
           SDK_SHA=$(git rev-parse HEAD)
           cd ../..
           git add vendor/software-agent-sdk
-          echo "Updated SDK submodule to $SDK_SHA (from ${{ inputs.sdk-commit }})"
+          echo "Updated SDK submodule to $SDK_SHA (from $INPUTS_SDK_COMMIT)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -181,11 +186,14 @@ jobs:
           make build
 
       - name: Build and push SWT-Bench images
+        env:
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries || '3' }}
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
 
-          MAX_RETRIES="${{ inputs.max-retries || '3' }}"
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          MAX_RETRIES="$INPUTS_MAX_RETRIES"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           CMD="uv run benchmarks/swebench/build_images.py \
             --dataset '${DATASET}' \
@@ -214,6 +222,17 @@ jobs:
 
       - name: Build prebaked eval env images
         if: ${{ inputs.build-eval-env == 'true' }}
+        env:
+          INPUTS_DATASET: ${{ inputs.dataset || 'eth-sri/SWT-bench_Verified_bm25_27k_zsp' }}
+          INPUTS_SPLIT: ${{ inputs.split || 'test' }}
+          INPUTS_N_LIMIT: ${{ inputs.n-limit || '0' }}
+          INPUTS_INSTANCE_IDS: ${{ inputs.instance-ids }}
+          INPUTS_EVAL_IMAGE_PREFIX: ${{ inputs.eval-image-prefix || 'ghcr.io/openhands/swtbench-eval' }}
+          INPUTS_MAX_WORKERS: ${{ inputs.max-workers || '4' }}
+          INPUTS_BUILD_MODE: ${{ inputs.build-mode || 'cli' }}
+          INPUTS_MAX_RETRIES: ${{ inputs.max-retries || '2' }}
+          INPUTS_EVAL_ENV_BUILD_BATCH_SIZE: ${{ inputs.eval-env-build-batch-size || '10' }}
+          INPUTS_FORCE_BUILD: ${{ inputs.force-build || 'false' }}
         run: |
           set -euo pipefail
 
@@ -223,16 +242,16 @@ jobs:
           docker system df || true
           docker info || true
 
-          DATASET="${{ inputs.dataset || 'eth-sri/SWT-bench_Verified_bm25_27k_zsp' }}"
-          SPLIT="${{ inputs.split || 'test' }}"
-          N_LIMIT="${{ inputs.n-limit || '0' }}"
-          INSTANCE_IDS="${{ inputs.instance-ids }}"
-          IMAGE_PREFIX="${{ inputs.eval-image-prefix || 'ghcr.io/openhands/swtbench-eval' }}"
-          MAX_WORKERS="${{ inputs.max-workers || '4' }}"
-          BUILD_MODE="${{ inputs.build-mode || 'cli' }}"
-          MAX_RETRIES="${{ inputs.max-retries || '2' }}"
-          BUILD_BATCH_SIZE="${{ inputs.eval-env-build-batch-size || '10' }}"
-          FORCE_BUILD="${{ inputs.force-build || 'false' }}"
+          DATASET="$INPUTS_DATASET"
+          SPLIT="$INPUTS_SPLIT"
+          N_LIMIT="$INPUTS_N_LIMIT"
+          INSTANCE_IDS="$INPUTS_INSTANCE_IDS"
+          IMAGE_PREFIX="$INPUTS_EVAL_IMAGE_PREFIX"
+          MAX_WORKERS="$INPUTS_MAX_WORKERS"
+          BUILD_MODE="$INPUTS_BUILD_MODE"
+          MAX_RETRIES="$INPUTS_MAX_RETRIES"
+          BUILD_BATCH_SIZE="$INPUTS_EVAL_ENV_BUILD_BATCH_SIZE"
+          FORCE_BUILD="$INPUTS_FORCE_BUILD"
 
           echo "N_LIMIT=${N_LIMIT}" >> "$GITHUB_ENV"
           echo "MAX_RETRIES=${MAX_RETRIES}" >> "$GITHUB_ENV"
@@ -319,6 +338,10 @@ jobs:
 
       - name: Comment on tracker issue
         if: success()
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           # Get SDK version
           SDK_SHA=$(git submodule status vendor/software-agent-sdk | awk '{print $1}' | sed 's/^[+-]//')
@@ -336,12 +359,12 @@ jobs:
           SUCCESS_COUNT=$(grep -c '"error":null' "$MANIFEST_FILE" || echo 0)
 
           # Determine trigger source
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
           else
-            TRIGGER="${{ github.event_name }}"
+            TRIGGER="$GITHUB_EVENT_NAME"
           fi
 
           # Post comment using jq to properly handle multi-line content

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -355,12 +355,12 @@ jobs:
           SUCCESS_COUNT=$(grep -c '"error":null' "$MANIFEST_FILE" || echo 0)
 
           # Determine trigger source
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
-          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
-            TRIGGER="$GITHUB_EVENT_NAME"
+            TRIGGER="${{ github.event_name }}"
           fi
 
           # Post comment using jq to properly handle multi-line content

--- a/.github/workflows/build-swtbench-images.yml
+++ b/.github/workflows/build-swtbench-images.yml
@@ -129,14 +129,13 @@ jobs:
         id: checkout-ref
         env:
           INPUTS_BENCHMARKS_REF: ${{ inputs.benchmarks-ref }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$INPUTS_BENCHMARKS_REF" ]; then
             echo "ref=$INPUTS_BENCHMARKS_REF" >> "$GITHUB_OUTPUT"
             echo "Using benchmarks-ref: $INPUTS_BENCHMARKS_REF"
-          elif [ -n "$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" ]; then
-            echo "ref=$GITHUB_EVENT_PULL_REQUEST_HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "Using PR head SHA: $GITHUB_EVENT_PULL_REQUEST_HEAD_SHA"
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "Using PR head SHA: ${{ github.event.pull_request.head.sha }}"
           else
             echo "ref=" >> "$GITHUB_OUTPUT"
             echo "Using default ref (the commit that triggered this workflow)"
@@ -338,9 +337,6 @@ jobs:
       - name: Comment on tracker issue
         if: success()
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_EVENT_PULL_REQUEST_HTML_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get SDK version
@@ -362,7 +358,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             TRIGGER="Manual trigger (workflow_dispatch)"
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            TRIGGER="Pull request [#$GITHUB_EVENT_PULL_REQUEST_NUMBER]($GITHUB_EVENT_PULL_REQUEST_HTML_URL)"
+            TRIGGER="Pull request [#${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})"
           else
             TRIGGER="$GITHUB_EVENT_NAME"
           fi


### PR DESCRIPTION
## Why

Part of the cross-repo fix for OpenHands/software-agent-sdk#3371. Workflow `run:` blocks and composite actions should not interpolate attacker-influenced workflow inputs or GitHub event context directly into shell scripts.

## Summary

- Moves benchmark workflow inputs, user-provided refs/commits, and PR head SHA values through `env:` before shell use where they enter shell scripts.
- Updates benchmark image workflows and the build-select-file composite action to use shell variables instead of direct `${{ ... }}` interpolation.
- Quotes SDK commit fetch arguments after moving them through environment variables.

## Issue Number

Fixes OpenHands/software-agent-sdk#3371

## How to Test

- `python` + `PyYAML` validation over all changed workflow/action YAML files across the audited repositories: `validated changed yaml files: 33`
- Repository scanner confirmed: `remaining suspicious run blocks: 0`
- `git diff --check` across all audited repositories

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/05aa1d79-8d57-4e84-9ee0-fdd4bf20ec12)