### PR TITLE
fix: replace DelegateTool with TaskToolSet (removed in SDK v1.23.0)

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -46,8 +46,8 @@ from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
 

--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -46,7 +46,7 @@ from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
@@ -388,7 +388,7 @@ class Commit0Evaluation(Evaluation):
             agent_llm = build_eval_llm(self.metadata.llm)
             tools = get_default_tools(enable_browser=False)
             if self.metadata.enable_delegation:
-                tools.append(Tool(name=DelegateTool.name))
+                tools.append(Tool(name=TaskToolSet.name))
             condenser = None
             if self.metadata.enable_condenser:
                 condenser = LLMSummarizingCondenser(

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -57,8 +57,8 @@ from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.event import ActionEvent
 from openhands.sdk.tool.builtins.finish import FinishAction
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
 

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -57,7 +57,7 @@ from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.event import ActionEvent
 from openhands.sdk.tool.builtins.finish import FinishAction
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
@@ -328,7 +328,7 @@ class GAIAEvaluation(Evaluation):
             agent_llm = build_eval_llm(self.metadata.llm)
             tools = get_default_tools(enable_browser=True)
             if self.metadata.enable_delegation:
-                tools.append(Tool(name=DelegateTool.name))
+                tools.append(Tool(name=TaskToolSet.name))
             tavily_api_key = os.getenv("TAVILY_API_KEY", "")
             assert tavily_api_key, "TAVILY_API_KEY environment variable is not set"
             condenser = None

--- a/benchmarks/hybridgym_depsearch/run_infer.py
+++ b/benchmarks/hybridgym_depsearch/run_infer.py
@@ -38,7 +38,7 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
@@ -152,7 +152,7 @@ class DepSearchEvaluation(Evaluation):
         agent_llm = build_eval_llm(self.metadata.llm)
         tools = self._get_tools(preset=self.metadata.tool_preset)
         if self.metadata.enable_delegation:
-            tools.append(Tool(name=DelegateTool.name))
+            tools.append(Tool(name=TaskToolSet.name))
         condenser = None
         if self.metadata.enable_condenser:
             condenser = LLMSummarizingCondenser(

--- a/benchmarks/hybridgym_depsearch/run_infer.py
+++ b/benchmarks/hybridgym_depsearch/run_infer.py
@@ -38,8 +38,8 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
 

--- a/benchmarks/hybridgym_funcgen/run_infer.py
+++ b/benchmarks/hybridgym_funcgen/run_infer.py
@@ -39,7 +39,7 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
@@ -233,7 +233,7 @@ class FuncGenEvaluation(Evaluation):
         agent_llm = build_eval_llm(self.metadata.llm)
         tools = self._get_tools(preset=self.metadata.tool_preset)
         if self.metadata.enable_delegation:
-            tools.append(Tool(name=DelegateTool.name))
+            tools.append(Tool(name=TaskToolSet.name))
         condenser = None
         if self.metadata.enable_condenser:
             condenser = LLMSummarizingCondenser(

--- a/benchmarks/hybridgym_funcgen/run_infer.py
+++ b/benchmarks/hybridgym_funcgen/run_infer.py
@@ -39,8 +39,8 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
 

--- a/benchmarks/hybridgym_funclocalize/run_infer.py
+++ b/benchmarks/hybridgym_funclocalize/run_infer.py
@@ -39,7 +39,7 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
@@ -213,7 +213,7 @@ class FuncLocalizeEvaluation(Evaluation):
         agent_llm = build_eval_llm(self.metadata.llm)
         tools = self._get_tools(preset=self.metadata.tool_preset)
         if self.metadata.enable_delegation:
-            tools.append(Tool(name=DelegateTool.name))
+            tools.append(Tool(name=TaskToolSet.name))
         condenser = None
         if self.metadata.enable_condenser:
             condenser = LLMSummarizingCondenser(

--- a/benchmarks/hybridgym_funclocalize/run_infer.py
+++ b/benchmarks/hybridgym_funclocalize/run_infer.py
@@ -39,8 +39,8 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
 

--- a/benchmarks/hybridgym_issuelocalize/run_infer.py
+++ b/benchmarks/hybridgym_issuelocalize/run_infer.py
@@ -38,8 +38,8 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
 

--- a/benchmarks/hybridgym_issuelocalize/run_infer.py
+++ b/benchmarks/hybridgym_issuelocalize/run_infer.py
@@ -38,7 +38,7 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
@@ -147,7 +147,7 @@ class IssueLocalizeEvaluation(Evaluation):
         agent_llm = build_eval_llm(self.metadata.llm)
         tools = self._get_tools(preset=self.metadata.tool_preset)
         if self.metadata.enable_delegation:
-            tools.append(Tool(name=DelegateTool.name))
+            tools.append(Tool(name=TaskToolSet.name))
         condenser = None
         if self.metadata.enable_condenser:
             condenser = LLMSummarizingCondenser(

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -38,8 +38,8 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
 

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -38,7 +38,7 @@ from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
@@ -284,7 +284,7 @@ class MultiSWEBenchEvaluation(Evaluation):
             enable_browser=False,
         )
         if self.metadata.enable_delegation:
-            tools.append(Tool(name=DelegateTool.name))
+            tools.append(Tool(name=TaskToolSet.name))
 
         # Create condenser if enabled
         agent_llm = build_eval_llm(self.metadata.llm)

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -31,8 +31,8 @@ from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import DockerWorkspace
 
 

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -31,7 +31,7 @@ from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import DockerWorkspace
 
@@ -454,7 +454,7 @@ class OpenAgentSafetyEvaluation(Evaluation):
         )
 
         if self.metadata.enable_delegation:
-            tools.append(Tool(name=DelegateTool.name))
+            tools.append(Tool(name=TaskToolSet.name))
 
         # Load public skills (respects EXTENSIONS_REF env var)
         agent_context = create_agent_context()

--- a/benchmarks/programbench/run_infer.py
+++ b/benchmarks/programbench/run_infer.py
@@ -71,8 +71,8 @@ from openhands.sdk.hooks import (
     HookType,
 )
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import DockerDevWorkspace
 
 

--- a/benchmarks/programbench/run_infer.py
+++ b/benchmarks/programbench/run_infer.py
@@ -71,7 +71,7 @@ from openhands.sdk.hooks import (
     HookType,
 )
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import DockerDevWorkspace
 
@@ -268,7 +268,7 @@ class ProgramBenchEvaluation(Evaluation):
             agent_llm = build_eval_llm(self.metadata.llm)
             tools = get_default_tools(enable_browser=False)
             if self.metadata.enable_delegation:
-                tools.append(Tool(name=DelegateTool.name))
+                tools.append(Tool(name=TaskToolSet.name))
             condenser = None
             if self.metadata.enable_condenser:
                 condenser = LLMSummarizingCondenser(

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -48,7 +48,7 @@ from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace, ApptainerWorkspace, DockerWorkspace
 
 
@@ -300,7 +300,7 @@ class SWEBenchEvaluation(Evaluation):
                 enable_browser=False,
             )
             if self.metadata.enable_delegation:
-                tools.append(Tool(name=DelegateTool.name))
+                tools.append(Tool(name=TaskToolSet.name))
             condenser = None
             if self.metadata.enable_condenser:
                 condenser = LLMSummarizingCondenser(

--- a/benchmarks/swebenchmultilingual/run_infer.py
+++ b/benchmarks/swebenchmultilingual/run_infer.py
@@ -38,7 +38,7 @@ from benchmarks.utils.models import (
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
 
@@ -254,7 +254,7 @@ class SWEBenchEvaluation(Evaluation):
             enable_browser=False,
         )
         if self.metadata.enable_delegation:
-            tools.append(Tool(name=DelegateTool.name))
+            tools.append(Tool(name=TaskToolSet.name))
         # Load public skills (respects EXTENSIONS_REF env var)
         agent_context = create_agent_context()
 

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -53,7 +53,7 @@ from openhands.sdk import (
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
@@ -248,7 +248,7 @@ class SWEBenchEvaluation(Evaluation):
                 enable_browser=True,
             )
             if self.metadata.enable_delegation:
-                tools.append(Tool(name=DelegateTool.name))
+                tools.append(Tool(name=TaskToolSet.name))
             condenser = None
             if self.metadata.enable_condenser:
                 condenser = LLMSummarizingCondenser(

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -53,8 +53,8 @@ from openhands.sdk import (
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
 

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -42,8 +42,8 @@ from openhands.sdk import Agent, Conversation, Tool, __version__, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
+from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
 

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -42,7 +42,7 @@ from openhands.sdk import Agent, Conversation, Tool, __version__, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.delegate import DelegateTool
+from openhands.tools.task import TaskToolSet
 from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
@@ -257,7 +257,7 @@ class SWTBenchEvaluation(Evaluation):
                 enable_browser=False,
             )
             if self.metadata.enable_delegation:
-                tools.append(Tool(name=DelegateTool.name))
+                tools.append(Tool(name=TaskToolSet.name))
             condenser = None
             if self.metadata.enable_condenser:
                 condenser = LLMSummarizingCondenser(


### PR DESCRIPTION
## Summary

Fixes #715

All benchmark runs are failing with an `ImportError` because `DelegateTool` was removed from the SDK in v1.23.0.

```
ImportError: cannot import name 'DelegateTool' from 'openhands.tools.delegate'
Did you mean: 'DelegateAction'?
```

### Root Cause

The SDK deprecated `DelegateTool` in v1.16.0 ([PR #2668](https://github.com/OpenHands/software-agent-sdk/pull/2668)) in favor of `TaskToolSet`, and fully removed it in v1.23.0 ([PR #3296](https://github.com/OpenHands/software-agent-sdk/pull/3296)). The benchmarks code still referenced the removed class.

### Changes

Replaced in all 13 affected benchmark `run_infer.py` files:

```python
# Before
from openhands.tools.delegate import DelegateTool
tools.append(Tool(name=DelegateTool.name))

# After
from openhands.tools.task import TaskToolSet
tools.append(Tool(name=TaskToolSet.name))
```

### Affected Benchmarks

- swebench
- swebenchmultilingual
- swebenchmultimodal
- multiswebench
- hybridgym_funcgen
- hybridgym_depsearch
- hybridgym_issuelocalize
- hybridgym_funclocalize
- commit0
- gaia
- programbench
- openagentsafety
- swtbench

### Example Failed Run

- Eval monitor: https://openhands-eval-monitor.vercel.app/?run=swebench%2Flitellm_proxy-amber-vector-3542%2F26431450862%2F&days=15
- GitHub Actions: https://github.com/OpenHands/evaluation/actions/runs/26431450862

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/268b940a-6c6a-4cb4-b916-b5be8a28342c)