### PR TITLE
fix(swebenchmultimodal): skip evaluation when predictions file is empty

### DIFF
--- a/benchmarks/swebenchmultimodal/eval_infer.py
+++ b/benchmarks/swebenchmultimodal/eval_infer.py
@@ -279,7 +279,7 @@ def run_swebench_multimodal_evaluation(
     # clear log message instead of a misleading
     # "SWE-Bench harness output naming may have changed" FileNotFoundError.
     num_predictions = sum(
-        1 for line in predictions_path.read_text().splitlines() if line.strip()
+        1 for line in predictions_path.open(encoding="utf-8") if line.strip()
     )
     if num_predictions == 0:
         logger.warning(

--- a/benchmarks/swebenchmultimodal/eval_infer.py
+++ b/benchmarks/swebenchmultimodal/eval_infer.py
@@ -272,6 +272,24 @@ def run_swebench_multimodal_evaluation(
     # Default for run_id if not provided
     run_id = run_id or predictions_path.stem
 
+    # If the predictions file has no entries (e.g. every inference attempt
+    # failed and produced no patches), the SWE-Bench harness prints
+    # "No instances to run." and exits successfully without writing a
+    # report file. Detect this up-front and short-circuit so we surface a
+    # clear log message instead of a misleading
+    # "SWE-Bench harness output naming may have changed" FileNotFoundError.
+    num_predictions = sum(
+        1 for line in predictions_path.read_text().splitlines() if line.strip()
+    )
+    if num_predictions == 0:
+        logger.warning(
+            f"No predictions found in {predictions_file}; "
+            "skipping SWE-Bench Multimodal evaluation. "
+            "This usually means every inference attempt failed "
+            "(e.g. LLM errors) and no patches were produced."
+        )
+        return None
+
     # The key difference from regular SWE-Bench is the --modal true flag
     cmd = [
         "uv",


### PR DESCRIPTION
## Summary

When every inference attempt for a `swebenchmultimodal` run fails (for example, the LiteLLM proxy returns 5xx errors for every conversation), the OpenHands `output.jsonl` is empty and the converted SWE-Bench predictions file is empty too. The SWE-Bench harness then sees `if not dataset: print("No instances to run.")` and exits cleanly **without** calling `make_run_report`, so the per-model `report.json` is never written.

Today, `benchmarks/swebenchmultimodal/eval_infer.py` proceeds to look for that report unconditionally and raises a misleading error:

```
ERROR Script failed: Expected report file not found: .../OpenHands.<run_id>.json.
       SWE-Bench harness output naming may have changed.
```

That hides the real failure (every inference attempt errored) and incorrectly suggests an upstream harness regression.

## Repro

Failing run from the eval monitor:

- Run: [`swebenchmultimodal/litellm_proxy-gemini-3-5-flash/26595627813`](https://openhands-eval-monitor.vercel.app/?run=swebenchmultimodal%2Flitellm_proxy-gemini-3-5-flash%2F26595627813&days=15&text=gemini)
- Model: `litellm_proxy/gemini-3.5-flash`, `eval_limit=1`
- The single instance `Automattic__wp-calypso-25725` failed on all 4 retries with `LLMServiceUnavailableError: Vertex_aiException InternalServerError - { code: 500 ... }` while sending the multimodal message (`Sending instruction with 1 valid images`).
- `output.jsonl` ended at 0 bytes → "Conversion complete: 0 entries converted, 0 errors" → harness exited 0 → eval script crashed with the bogus "harness output naming may have changed" error.

## Fix

`run_swebench_multimodal_evaluation` now:

1. Counts non-empty lines in the converted predictions file before invoking the harness.
2. If there are 0 predictions, logs a clear warning explaining that every inference attempt likely failed, and returns `None`.
3. `main()` already handles `report_path is None` — it skips component scoring, still runs `generate_cost_report`, and emits `{"report_json": ""}` on stdout. Pipeline output stays well-formed; the real failure (inference errors) is surfaced cleanly.

No change for the normal happy path: if predictions exist, behaviour is unchanged.

## Out of scope / follow-up

The same defensive check would benefit `benchmarks/swebench/eval_infer.py` and other SWE-Bench-style variants (`swebenchpro`, `swesmith`, `swebenchmultilingual`, `swtbench`, etc.), which share the same pattern. Happy to follow up in a separate PR — keeping this one focused on the reported regression.

## Links

- Tracking issue: OpenHands/software-agent-sdk#3435

---
_This PR was opened by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ba181e56-bae0-4e16-8203-fc2b4631df25)