### PR TITLE
fix(eval-image): bump pinned codex-acp 0.11.1 → 0.15.0

### DIFF
--- a/benchmarks/utils/Dockerfile.agent-layer-commit0
+++ b/benchmarks/utils/Dockerfile.agent-layer-commit0
@@ -66,7 +66,7 @@ RUN set -eux; \
     node --version; \
     npm install -g \
       @agentclientprotocol/claude-agent-acp@0.30.0 \
-      @zed-industries/codex-acp@0.11.1 \
+      @zed-industries/codex-acp@0.15.0 \
       @google/gemini-cli@0.38.0; \
     for bin in claude-agent-acp codex-acp gemini; do \
       if [ -e "$ACP_NODE_DIR/bin/$bin" ]; then \


### PR DESCRIPTION
> ## ⚠️ Correction (post-merge, 2026-06-03)
> The **"Why" below was a misdiagnosis**, and the bump had an unintended side effect. Verified by A/B against the live `@zed-industries/codex-acp` binaries:
>
> - **0.11.1 is NOT too old for the ChatGPT backend.** It completes turns fine today with a model the account supports (`gpt-5.4` / `gpt-5.4-mini`). The e2e failure was because 0.11.1 *defaults* to **`gpt-5.3-codex`**, which ChatGPT **subscription** accounts don't serve → HTTP 400 → the opaque `-32603 Internal error`. 0.15.0 "fixed" it only because it defaults to a supported model. The "suddenly broke today" was OpenAI rotating which models a ChatGPT account is offered — not a CLI/backend incompatibility.
> - **The bump regressed codex base-URL routing.** codex **0.15.0 ignores `OPENAI_BASE_URL`** (0.11.1 honored it — A/B: 0.11.1 routes to the configured endpoint; 0.15.0 always hits `api.openai.com`). This broke every codex-via-gateway/proxy flow (eval, canvas, cloud) and is the real root cause of OpenHands/benchmarks#736. Fixed in OpenHands/software-agent-sdk#3493.
>
> Net: keeping 0.15.0 is fine (newer default model, supports `gpt-5.5`), but the stated rationale was wrong and the bump needed the follow-up fix #3493. Original description preserved below.

---

## What
Bump `@zed-industries/codex-acp@0.11.1 → 0.15.0` in `benchmarks/utils/Dockerfile.agent-layer-commit0` (the eval-agent-server ACP install layer).

## Why
The pin `0.11.1` (published 2026-03-31) is the same stale version the agent-server image carried. In a **real in-container e2e** against the current ChatGPT subscription backend:
- `codex-acp@0.11.1` → auth OK, then **`-32603 Internal error` on every turn**.
- `codex-acp@0.15.0` (2026-05-22, the latest release) → full turn succeeds with the identical materialised credential, **including a tool-using turn under codex's `full-access` session mode** (validated that `set_session_mode("full-access")` is still accepted and write/read tools execute).

So containerized Codex ACP eval runs on this image currently can't complete a turn; the bump fixes that.

## Scope
Only `codex-acp` (the one that was broken). `claude-agent-acp@0.30.0` / `gemini-cli@0.38.0` left as-is.

Pairs with the same fix in the agent-server Dockerfile: OpenHands/software-agent-sdk#3478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
