### PR TITLE
fix(iterative): tolerate unknown history kinds in aggregate_results (empty output.jsonl on resumed runs)

### DIFF
--- a/benchmarks/utils/iterative.py
+++ b/benchmarks/utils/iterative.py
@@ -33,6 +33,15 @@ class _AggregatedEntry:
     output: EvalOutput | None
     raw_line: str | None
 
+    def beats(self, other: "_AggregatedEntry") -> bool:
+        """Return True if this entry should replace ``other`` for its instance.
+
+        Mirrors the pre-existing "highest rank wins" tie-break used by
+        ``aggregate_results`` before this refactor, and centralises it so both
+        the parseable and raw-line fallback paths use identical semantics.
+        """
+        return self.rank > other.rank
+
     def serialize(self) -> str:
         """Return the JSONL representation to write to the final output file."""
         if self.output is not None:
@@ -190,13 +199,17 @@ def aggregate_results(
                         # rank 2.
                         has_error = bool(data.get("error"))
                         fallback_count += 1
+                        # Log only the exception type at debug level — a single
+                        # pydantic ``ValidationError`` can carry dozens of
+                        # sub-errors each containing the offending ``input_value``
+                        # and would blow up log size in high-volume aggregations.
                         logger.debug(
                             "Falling back to raw-line preservation for line "
                             "%d in %s (instance %s): %s",
                             line_num,
                             attempt_file,
                             instance_id,
-                            e,
+                            type(e).__name__,
                         )
                         entry = _AggregatedEntry(
                             instance_id=instance_id,
@@ -207,7 +220,7 @@ def aggregate_results(
                         )
 
                     current = best_results.get(instance_id)
-                    if current is None or entry.rank > current.rank:
+                    if current is None or entry.beats(current):
                         best_results[instance_id] = entry
 
         except Exception as e:

--- a/benchmarks/utils/iterative.py
+++ b/benchmarks/utils/iterative.py
@@ -7,6 +7,7 @@ using SDK critics to determine if an instance succeeded.
 
 import json
 import os
+from dataclasses import dataclass
 from typing import Set
 
 from benchmarks.utils.critics import CriticBase, evaluate_output
@@ -15,6 +16,32 @@ from openhands.sdk import get_logger
 
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class _AggregatedEntry:
+    """Internal representation of a per-instance candidate during aggregation.
+
+    Holds either a fully-parsed ``EvalOutput`` (preferred) or, when pydantic
+    validation fails for a line we still want to preserve, the raw JSONL line
+    plus enough metadata to rank and filter it.
+    """
+
+    instance_id: EvalInstanceID
+    rank: int
+    error: bool
+    output: EvalOutput | None
+    raw_line: str | None
+
+    def serialize(self) -> str:
+        """Return the JSONL representation to write to the final output file."""
+        if self.output is not None:
+            return self.output.model_dump_json() + "\n"
+        # Fallback: write the original line verbatim (already includes content
+        # that may not round-trip cleanly through the current EvalOutput model,
+        # e.g. tool kinds from plugins not registered in this process).
+        assert self.raw_line is not None
+        return self.raw_line if self.raw_line.endswith("\n") else self.raw_line + "\n"
 
 
 def _get_output_rank(critic: CriticBase, output: EvalOutput) -> int:
@@ -99,8 +126,13 @@ def aggregate_results(
     """
     logger.info(f"Aggregating results from {n_critic_runs} critic runs")
 
-    # Dictionary to store the best result for each instance
-    best_results: dict[EvalInstanceID, EvalOutput] = {}
+    # Dictionary to store the best candidate for each instance
+    best_results: dict[EvalInstanceID, _AggregatedEntry] = {}
+    # Track how many entries fell back to raw-line preservation because
+    # full EvalOutput validation failed (e.g. resumed runs where the carried
+    # over history references discriminated-union "kind"s not registered in
+    # this process). Reported in a single summary log to avoid log spam.
+    fallback_count = 0
 
     # Work backwards from the last attempt to the first
     for attempt in range(n_critic_runs, 0, -1):
@@ -119,32 +151,75 @@ def aggregate_results(
                 for line_num, line in enumerate(f, 1):
                     try:
                         data = json.loads(line.strip())
-                        output = EvalOutput.model_validate(data)
-
-                        instance_id = output.instance_id
-                        output_rank = _get_output_rank(critic, output)
-
-                        if instance_id not in best_results:
-                            # First time seeing this instance
-                            best_results[instance_id] = output
-                        else:
-                            # Replace if this output has a higher rank
-                            current_best = best_results[instance_id]
-                            current_rank = _get_output_rank(critic, current_best)
-                            if output_rank > current_rank:
-                                best_results[instance_id] = output
-
                     except json.JSONDecodeError as e:
                         logger.warning(
                             f"Invalid JSON on line {line_num} in {attempt_file}: {e}"
                         )
-                    except Exception as e:
+                        continue
+
+                    instance_id = data.get("instance_id")
+                    if not instance_id:
                         logger.warning(
-                            f"Error processing line {line_num} in {attempt_file}: {e}"
+                            f"Missing instance_id on line {line_num} in "
+                            f"{attempt_file}; skipping"
                         )
+                        continue
+
+                    # Prefer full pydantic validation so the critic can rank
+                    # parseable rows accurately. If that fails, fall back to a
+                    # minimal-parse path that preserves the entry as a raw line
+                    # so downstream consumers still see the carried-over data.
+                    entry: _AggregatedEntry
+                    try:
+                        output = EvalOutput.model_validate(data)
+                        entry = _AggregatedEntry(
+                            instance_id=output.instance_id,
+                            rank=_get_output_rank(critic, output),
+                            error=bool(output.error),
+                            output=output,
+                            raw_line=None,
+                        )
+                    except Exception as e:
+                        # Most common cause is a discriminated-union kind in
+                        # ``history`` that is not registered in this process
+                        # (e.g. browser tools after a resume on a pod that does
+                        # not load the browser plugin). Conservative rank: 0 if
+                        # the row recorded an error, otherwise 1 (non-error,
+                        # non-critic-successful). A fully-parseable row for the
+                        # same instance from another attempt can still win with
+                        # rank 2.
+                        has_error = bool(data.get("error"))
+                        fallback_count += 1
+                        logger.debug(
+                            "Falling back to raw-line preservation for line "
+                            "%d in %s (instance %s): %s",
+                            line_num,
+                            attempt_file,
+                            instance_id,
+                            e,
+                        )
+                        entry = _AggregatedEntry(
+                            instance_id=instance_id,
+                            rank=0 if has_error else 1,
+                            error=has_error,
+                            output=None,
+                            raw_line=line,
+                        )
+
+                    current = best_results.get(instance_id)
+                    if current is None or entry.rank > current.rank:
+                        best_results[instance_id] = entry
 
         except Exception as e:
             logger.error(f"Error reading attempt file {attempt_file}: {e}")
+
+    if fallback_count:
+        logger.warning(
+            "Preserved %d entries via raw-line fallback (pydantic validation "
+            "failed, likely due to history kinds not registered in this "
+            "process — e.g. plugin tools from a different run).",
+            fallback_count,
+        )
 
     # Write the aggregated results
     final_path = os.path.join(output_dir, final_output_file)
@@ -155,10 +230,11 @@ def aggregate_results(
     try:
         successful_count = 0
         with open(final_path, "w", encoding="utf-8") as f:
-            for output in best_results.values():
-                if not output.error:  # Skip outputs with errors
-                    f.write(output.model_dump_json() + "\n")
-                    successful_count += 1
+            for entry in best_results.values():
+                if entry.error:  # Skip outputs with errors
+                    continue
+                f.write(entry.serialize())
+                successful_count += 1
 
         logger.info(
             f"Successfully wrote {successful_count} successful results to {final_path}"

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -236,3 +236,106 @@ class TestAggregateResults:
         with open(final_output_file, "r") as f:
             lines = f.readlines()
         assert len(lines) == 0
+
+    def test_preserves_entries_with_unknown_history_kinds(self, temp_output_dir):
+        """
+        Resumed runs may carry over critic-attempt entries whose ``history``
+        references discriminated-union ``kind``s not registered in the current
+        process (e.g. browser tools when the resume pod loads only the default
+        toolset). Pydantic validation of those entries raises, and prior to
+        this fix every such entry was silently dropped — emptying out
+        ``output.jsonl`` and causing the eval phase to see zero instances.
+
+        Verify that all non-error entries are preserved as-is, that error
+        entries are still dropped, and that fully-parseable entries from a
+        later attempt can still win the rank tie-break.
+        """
+        critic = PassCritic()
+        attempt_1_file = os.path.join(temp_output_dir, "output.critic_attempt_1.jsonl")
+
+        # Two carried-over rows whose history contains an unregistered action
+        # kind, plus one carried-over row marked as an error.
+        unparseable_ok_row = {
+            "instance_id": "instance_ok",
+            "instruction": "carried over",
+            "instance": {"test": "data"},
+            "test_result": {"git_patch": "carried patch"},
+            "error": None,
+            "history": [{"kind": "ThisActionKindIsNotRegisteredAnywhere"}],
+        }
+        unparseable_error_row = {
+            "instance_id": "instance_err",
+            "instruction": "carried over",
+            "instance": {"test": "data"},
+            "test_result": None,
+            "error": "Timed out",
+            "history": [{"kind": "ThisActionKindIsNotRegisteredAnywhere"}],
+        }
+        # And one cleanly parseable row from the resumed run's new attempt.
+        clean_row = create_output("instance_new", error=None)
+
+        with open(attempt_1_file, "w") as f:
+            f.write(json.dumps(unparseable_ok_row) + "\n")
+            f.write(json.dumps(unparseable_error_row) + "\n")
+            f.write(clean_row.model_dump_json() + "\n")
+
+        aggregate_results(temp_output_dir, n_critic_runs=3, critic=critic)
+
+        final_output_file = os.path.join(temp_output_dir, "output.jsonl")
+        with open(final_output_file, "r") as f:
+            written = [json.loads(line) for line in f if line.strip()]
+
+        written_ids = {row["instance_id"] for row in written}
+        # The non-error unparseable carry-over MUST be preserved (regression
+        # for the empty-output.jsonl bug observed on resumed gaia runs).
+        assert "instance_ok" in written_ids
+        # The cleanly parseable new attempt is included.
+        assert "instance_new" in written_ids
+        # The errored carry-over is still filtered out.
+        assert "instance_err" not in written_ids
+        assert len(written) == 2
+
+        # Round-tripped carry-over must preserve the history (i.e. raw line
+        # is written verbatim, not re-serialised through EvalOutput which
+        # would silently drop the unknown kind).
+        ok_row = next(row for row in written if row["instance_id"] == "instance_ok")
+        assert ok_row["history"] == unparseable_ok_row["history"]
+
+    def test_parseable_critic_success_beats_unparseable_carryover(
+        self, temp_output_dir
+    ):
+        """
+        A fully-parseable, critic-successful attempt for the same instance
+        must out-rank the unparseable raw-line fallback so the freshest result
+        wins, mirroring the pre-existing rank semantics for parseable rows.
+        """
+        critic = PassCritic()
+
+        # Attempt 1: carried-over, unparseable, non-error → falls back to rank 1.
+        attempt_1_file = os.path.join(temp_output_dir, "output.critic_attempt_1.jsonl")
+        carryover = {
+            "instance_id": "instance_1",
+            "instruction": "carried",
+            "instance": {"test": "data"},
+            "test_result": {"git_patch": "old patch"},
+            "error": None,
+            "history": [{"kind": "ThisActionKindIsNotRegisteredAnywhere"}],
+        }
+        with open(attempt_1_file, "w") as f:
+            f.write(json.dumps(carryover) + "\n")
+
+        # Attempt 2: cleanly parseable, critic-successful (PassCritic) → rank 2.
+        attempt_2_file = os.path.join(temp_output_dir, "output.critic_attempt_2.jsonl")
+        fresh = create_output("instance_1", error=None)
+        with open(attempt_2_file, "w") as f:
+            f.write(fresh.model_dump_json() + "\n")
+
+        aggregate_results(temp_output_dir, n_critic_runs=3, critic=critic)
+
+        final_output_file = os.path.join(temp_output_dir, "output.jsonl")
+        with open(final_output_file, "r") as f:
+            written = [json.loads(line) for line in f if line.strip()]
+
+        assert len(written) == 1
+        # Fresh, critic-successful row wins → its test_result is kept.
+        assert written[0]["test_result"] == {"git_patch": "mock patch"}


### PR DESCRIPTION
## What this fixes

On resumed gaia runs we were observing reports with **only the 1 instance that errored** and no completed instances, even though the partial-archive carry-over included **165 entries** in `output.critic_attempt_1.jsonl` (164 success + 1 error) and 165 conversations.

Concrete repro that surfaced this: `gaia/litellm_proxy-nemotron-3-ultra-550b-a55b/26899606112/` (resume of `26860418038`). After the resumed infer phase, `output.jsonl` was **0 bytes** even though `output.critic_attempt_1.jsonl` still held all 165 entries from the original run. The downstream eval report consequently showed `total_instances: 1`.

## Root cause

`aggregate_results` in `benchmarks/utils/iterative.py` calls `EvalOutput.model_validate(data)` on every line of every `output.critic_attempt_*.jsonl`. The `history` field validates as a list of discriminated-union `Action`/`Observation`/`ToolDefinition` instances, keyed by their `kind`.

When the resume process loads only the default gaia toolset, `kind`s like `BrowserNavigateTool`, `BrowserGetStateAction`, `BrowserObservation`, etc. — produced by the original agent server that did load the browser plugin — are **not registered** in the current process's discriminated-union registry. Validation raises and the per-line `except Exception` swallows the entry.

Reproduced locally against the actual archive:

```
ok=1, fail=164
failure top-level locs: {('history',): 164}
```

The one row that did parse was the errored one; it was then filtered out by `if not output.error`, and the file got truncated to 0 bytes by `open(final_path, "w")`.

## The fix

Make `aggregate_results` robust to per-entry validation failures:

1. **Preferred path (unchanged behaviour for parseable rows):** `EvalOutput.model_validate(data)` → rank via `_get_output_rank(critic, output)` → serialise via `model_dump_json()`.
2. **Fallback path (new):** when validation raises, parse just `instance_id` and `error` from the raw dict. Assign a conservative rank (0 if error else 1 — a fully-parseable critic-success from another attempt still wins with rank 2). Write the **original JSON line verbatim** to `output.jsonl`, preserving every field including the unknown history kinds.
3. Emit a single summary `WARNING` with the fallback count instead of one log per line.

This preserves the existing ranking semantics for parseable data while no longer dropping data the current process happens to not know how to round-trip.

### Verified against the real archive

After the fix, with the same `output.critic_attempt_1.jsonl` from the partial archive:

```
output.jsonl: size=193321355, lines=164
unique instance_ids: 164
```

i.e. all 164 successful carryover entries land in `output.jsonl`, ready for the eval phase.

## Tests

- All 8 existing `tests/test_aggregate_results.py` cases still pass (semantics for parseable rows are unchanged).
- Two new regression tests:
  - `test_preserves_entries_with_unknown_history_kinds` — synthesises rows whose `history` references an unregistered kind, asserts non-error rows are preserved verbatim and error rows are still dropped.
  - `test_parseable_critic_success_beats_unparseable_carryover` — asserts the rank tie-break still favours a cleanly parseable, critic-successful attempt over an unparseable raw-line fallback for the same instance.
- `tests/test_iterative_resume.py` + `tests/test_async_evaluation.py` still green (28 passed across the three files).
- `ruff check`, `ruff format --check`, and `pyright` all clean on the touched files.

## Risk

Low. The change only adds a fallback for the case where the previous code silently dropped data. Parseable rows take the same path as before, including `model_dump_json()` serialisation.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini, who reported the empty-resume report in the eval-monitor UI._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d744f6eb-7fb7-4ee4-bedb-786a019035b9)