### PR TITLE
Fix tool preset wiring in benchmark runners

### DIFF
--- a/benchmarks/commit0/run_infer.py
+++ b/benchmarks/commit0/run_infer.py
@@ -42,11 +42,11 @@ from benchmarks.utils.models import (
     EvalMetadata,
     EvalOutput,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
@@ -386,7 +386,9 @@ class Commit0Evaluation(Evaluation):
             agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model)
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
-            tools = get_default_tools(enable_browser=False)
+            tools = get_tools_for_preset(
+                self.metadata.tool_preset, enable_browser=False
+            )
             if self.metadata.enable_delegation:
                 tools.append(Tool(name=TaskToolSet.name))
             condenser = None
@@ -650,6 +652,10 @@ def main() -> None:
         eval_note=args.note,
     )
 
+    critic = create_critic(args)
+    logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
+
     metadata = EvalMetadata(
         llm=llm,
         dataset=args.dataset,
@@ -661,10 +667,11 @@ def main() -> None:
         eval_limit=args.n_limit,
         env_setup_commands=None,
         n_critic_runs=args.n_critic_runs,
-        critic=create_critic(args),
+        critic=critic,
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
         enable_delegation=args.enable_delegation,
         agent_type=args.agent_type,
     )

--- a/benchmarks/gaia/run_infer.py
+++ b/benchmarks/gaia/run_infer.py
@@ -40,6 +40,7 @@ from benchmarks.utils.image_utils import create_docker_workspace, remote_image_e
 from benchmarks.utils.litellm_proxy import build_eval_llm
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import (
     Agent,
@@ -57,7 +58,6 @@ from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.event import ActionEvent
 from openhands.sdk.tool.builtins.finish import FinishAction
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
@@ -326,7 +326,7 @@ class GAIAEvaluation(Evaluation):
             agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model)
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
-            tools = get_default_tools(enable_browser=True)
+            tools = get_tools_for_preset(self.metadata.tool_preset, enable_browser=True)
             if self.metadata.enable_delegation:
                 tools.append(Tool(name=TaskToolSet.name))
             tavily_api_key = os.getenv("TAVILY_API_KEY", "")
@@ -611,6 +611,7 @@ def main() -> None:
     # Create critic instance from parsed arguments
     critic = create_critic(args)
     logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
 
     # Validate arguments
     if args.n_critic_runs < 1:
@@ -645,6 +646,7 @@ def main() -> None:
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
         enable_delegation=args.enable_delegation,
         agent_type=args.agent_type,
     )

--- a/benchmarks/hybridgym_depsearch/run_infer.py
+++ b/benchmarks/hybridgym_depsearch/run_infer.py
@@ -34,11 +34,11 @@ from benchmarks.utils.models import (
     EvalOutput,
     ToolPresetType,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
@@ -261,20 +261,7 @@ class DepSearchEvaluation(Evaluation):
 
     def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
         """Get tools for the given preset."""
-        if preset == "gemini":
-            from openhands.tools.preset.gemini import get_gemini_tools
-
-            return get_gemini_tools(enable_browser=False)
-        elif preset == "gpt5":
-            from openhands.tools.preset.gpt5 import get_gpt5_tools
-
-            return get_gpt5_tools(enable_browser=False)
-        elif preset == "planning":
-            from openhands.tools.preset.planning import get_planning_tools
-
-            return get_planning_tools()
-        else:
-            return get_default_tools(enable_browser=False)
+        return get_tools_for_preset(preset, enable_browser=False)
 
 
 def main() -> None:

--- a/benchmarks/hybridgym_funcgen/run_infer.py
+++ b/benchmarks/hybridgym_funcgen/run_infer.py
@@ -35,11 +35,11 @@ from benchmarks.utils.models import (
     EvalOutput,
     ToolPresetType,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
@@ -362,20 +362,7 @@ class FuncGenEvaluation(Evaluation):
 
     def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
         """Get tools for the given preset."""
-        if preset == "gemini":
-            from openhands.tools.preset.gemini import get_gemini_tools
-
-            return get_gemini_tools(enable_browser=False)
-        elif preset == "gpt5":
-            from openhands.tools.preset.gpt5 import get_gpt5_tools
-
-            return get_gpt5_tools(enable_browser=False)
-        elif preset == "planning":
-            from openhands.tools.preset.planning import get_planning_tools
-
-            return get_planning_tools()
-        else:
-            return get_default_tools(enable_browser=False)
+        return get_tools_for_preset(preset, enable_browser=False)
 
 
 def main() -> None:

--- a/benchmarks/hybridgym_funclocalize/run_infer.py
+++ b/benchmarks/hybridgym_funclocalize/run_infer.py
@@ -35,11 +35,11 @@ from benchmarks.utils.models import (
     EvalOutput,
     ToolPresetType,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
@@ -347,20 +347,7 @@ class FuncLocalizeEvaluation(Evaluation):
 
     def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
         """Get tools for the given preset."""
-        if preset == "gemini":
-            from openhands.tools.preset.gemini import get_gemini_tools
-
-            return get_gemini_tools(enable_browser=False)
-        elif preset == "gpt5":
-            from openhands.tools.preset.gpt5 import get_gpt5_tools
-
-            return get_gpt5_tools(enable_browser=False)
-        elif preset == "planning":
-            from openhands.tools.preset.planning import get_planning_tools
-
-            return get_planning_tools()
-        else:
-            return get_default_tools(enable_browser=False)
+        return get_tools_for_preset(preset, enable_browser=False)
 
 
 def main() -> None:

--- a/benchmarks/hybridgym_issuelocalize/run_infer.py
+++ b/benchmarks/hybridgym_issuelocalize/run_infer.py
@@ -34,11 +34,11 @@ from benchmarks.utils.models import (
     EvalOutput,
     ToolPresetType,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
@@ -256,20 +256,7 @@ class IssueLocalizeEvaluation(Evaluation):
 
     def _get_tools(self, preset: ToolPresetType = "default") -> list[Tool]:
         """Get tools for the given preset."""
-        if preset == "gemini":
-            from openhands.tools.preset.gemini import get_gemini_tools
-
-            return get_gemini_tools(enable_browser=False)
-        elif preset == "gpt5":
-            from openhands.tools.preset.gpt5 import get_gpt5_tools
-
-            return get_gpt5_tools(enable_browser=False)
-        elif preset == "planning":
-            from openhands.tools.preset.planning import get_planning_tools
-
-            return get_planning_tools()
-        else:
-            return get_default_tools(enable_browser=False)
+        return get_tools_for_preset(preset, enable_browser=False)
 
 
 def main() -> None:

--- a/benchmarks/multiswebench/run_infer.py
+++ b/benchmarks/multiswebench/run_infer.py
@@ -34,11 +34,11 @@ from benchmarks.utils.models import (
     EvalMetadata,
     EvalOutput,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
@@ -279,7 +279,8 @@ class MultiSWEBenchEvaluation(Evaluation):
         Create conversation, run agent, collect history and git patch.
         Do not write files here; just return EvalOutput.
         """
-        tools = get_default_tools(
+        tools = get_tools_for_preset(
+            self.metadata.tool_preset,
             # Disable browser tools in CLI mode
             enable_browser=False,
         )
@@ -448,6 +449,7 @@ def main() -> None:
     # Create critic instance from parsed arguments
     critic = create_critic(args)
     logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
 
     # Handle condenser configuration
     # --disable-condenser takes precedence over --enable-condenser and defaults
@@ -471,6 +473,7 @@ def main() -> None:
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
         enable_delegation=args.enable_delegation,
         enable_condenser=enable_condenser,
         condenser_max_size=args.condenser_max_size,

--- a/benchmarks/openagentsafety/run_infer.py
+++ b/benchmarks/openagentsafety/run_infer.py
@@ -29,9 +29,9 @@ from benchmarks.utils.fake_user_response import run_conversation_with_fake_user_
 from benchmarks.utils.litellm_proxy import build_eval_llm
 from benchmarks.utils.llm_config import load_llm_config
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import DockerWorkspace
 
@@ -449,7 +449,8 @@ class OpenAgentSafetyEvaluation(Evaluation):
         from pydantic import ValidationError
 
         # Setup tools
-        tools = get_default_tools(
+        tools = get_tools_for_preset(
+            self.metadata.tool_preset,
             enable_browser=False,
         )
 
@@ -668,6 +669,8 @@ def main() -> None:
 
     # Create critic instance from parsed arguments
     critic = create_critic(args)
+    logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
 
     # Create metadata
     metadata = EvalMetadata(
@@ -685,6 +688,7 @@ def main() -> None:
         critic=critic,
         selected_instances_file=args.select,
         max_retries=args.max_retries,
+        tool_preset=args.tool_preset,
         enable_delegation=args.enable_delegation,
     )
 

--- a/benchmarks/programbench/run_infer.py
+++ b/benchmarks/programbench/run_infer.py
@@ -61,6 +61,7 @@ from benchmarks.utils.models import (
     EvalMetadata,
     EvalOutput,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
@@ -71,7 +72,6 @@ from openhands.sdk.hooks import (
     HookType,
 )
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import DockerDevWorkspace
 
@@ -108,7 +108,9 @@ def _load_upstream_instances() -> list[dict]:
     user gets an actionable message instead of an opaque ImportError.
     """
     try:
-        from programbench.utils.load_data import load_all_instances
+        from programbench.utils.load_data import (  # pyright: ignore[reportMissingImports]
+            load_all_instances,
+        )
     except ImportError as exc:
         raise RuntimeError(
             "The 'programbench' package is not installed. Add it to your "
@@ -266,7 +268,9 @@ class ProgramBenchEvaluation(Evaluation):
             agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model)
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
-            tools = get_default_tools(enable_browser=False)
+            tools = get_tools_for_preset(
+                self.metadata.tool_preset, enable_browser=False
+            )
             if self.metadata.enable_delegation:
                 tools.append(Tool(name=TaskToolSet.name))
             condenser = None
@@ -775,6 +779,10 @@ def main() -> None:
         args.condenser_keep_first if args.condenser_keep_first is not None else 2
     )
 
+    critic = create_critic(args)
+    logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
+
     metadata = EvalMetadata(
         llm=llm,
         dataset=args.dataset,
@@ -793,10 +801,11 @@ def main() -> None:
         eval_limit=args.n_limit,
         env_setup_commands=None,
         n_critic_runs=args.n_critic_runs,
-        critic=create_critic(args),
+        critic=critic,
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
         enable_delegation=args.enable_delegation,
         agent_type=args.agent_type,
         enable_condenser=enable_condenser,

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -41,8 +41,8 @@ from benchmarks.utils.models import (
     EvalInstance,
     EvalMetadata,
     EvalOutput,
-    ToolPresetType,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import get_phased_image_tag_prefix
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.agent import ACPAgent
@@ -53,37 +53,6 @@ from openhands.workspace import APIRemoteWorkspace, ApptainerWorkspace, DockerWo
 
 
 logger = get_logger(__name__)
-
-
-def get_tools_for_preset(
-    preset: ToolPresetType, enable_browser: bool = False
-) -> list[Tool]:
-    """Get the list of tools for the given preset.
-
-    Args:
-        preset: The tool preset to use (default, gemini, gpt5, or planning).
-        enable_browser: Whether to include browser tools.
-
-    Returns:
-        List of Tool instances for the given preset.
-    """
-    if preset == "gemini":
-        from openhands.tools.preset.gemini import get_gemini_tools
-
-        return get_gemini_tools(enable_browser=enable_browser)
-    elif preset == "gpt5":
-        from openhands.tools.preset.gpt5 import get_gpt5_tools
-
-        return get_gpt5_tools(enable_browser=enable_browser)
-    elif preset == "planning":
-        from openhands.tools.preset.planning import get_planning_tools
-
-        # Planning preset doesn't support browser tools
-        return get_planning_tools()
-    else:  # default
-        from openhands.tools.preset.default import get_default_tools
-
-        return get_default_tools(enable_browser=enable_browser)
 
 
 def get_instruction(

--- a/benchmarks/swebenchmultilingual/run_infer.py
+++ b/benchmarks/swebenchmultilingual/run_infer.py
@@ -33,8 +33,8 @@ from benchmarks.utils.models import (
     EvalInstance,
     EvalMetadata,
     EvalOutput,
-    ToolPresetType,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import Agent, Conversation, Tool, get_logger
 from openhands.sdk.workspace import RemoteWorkspace
@@ -43,37 +43,6 @@ from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
 
 logger = get_logger(__name__)
-
-
-def get_tools_for_preset(
-    preset: ToolPresetType, enable_browser: bool = False
-) -> list[Tool]:
-    """Get the list of tools for the given preset.
-
-    Args:
-        preset: The tool preset to use (default, gemini, gpt5, or planning).
-        enable_browser: Whether to include browser tools.
-
-    Returns:
-        List of Tool instances for the given preset.
-    """
-    if preset == "gemini":
-        from openhands.tools.preset.gemini import get_gemini_tools
-
-        return get_gemini_tools(enable_browser=enable_browser)
-    elif preset == "gpt5":
-        from openhands.tools.preset.gpt5 import get_gpt5_tools
-
-        return get_gpt5_tools(enable_browser=enable_browser)
-    elif preset == "planning":
-        from openhands.tools.preset.planning import get_planning_tools
-
-        # Planning preset doesn't support browser tools
-        return get_planning_tools()
-    else:  # default
-        from openhands.tools.preset.default import get_default_tools
-
-        return get_default_tools(enable_browser=enable_browser)
 
 
 def get_instruction(

--- a/benchmarks/swebenchmultimodal/run_infer.py
+++ b/benchmarks/swebenchmultimodal/run_infer.py
@@ -40,6 +40,7 @@ from benchmarks.utils.models import (
     EvalMetadata,
     EvalOutput,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import get_phased_image_tag_prefix
 from openhands.sdk import (
     Agent,
@@ -53,7 +54,6 @@ from openhands.sdk import (
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
@@ -243,7 +243,8 @@ class SWEBenchEvaluation(Evaluation):
             agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model)
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
-            tools = get_default_tools(
+            tools = get_tools_for_preset(
+                self.metadata.tool_preset,
                 # Enable browser tools for frontend development tasks
                 enable_browser=True,
             )
@@ -457,6 +458,7 @@ def main() -> None:
     # Create critic instance from parsed arguments
     critic = create_critic(args)
     logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
 
     # Handle condenser configuration
     # --disable-condenser takes precedence over --enable-condenser and defaults
@@ -479,6 +481,7 @@ def main() -> None:
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
         enable_delegation=args.enable_delegation,
         agent_type=args.agent_type,
         enable_condenser=enable_condenser,

--- a/benchmarks/swefficiency/run_infer.py
+++ b/benchmarks/swefficiency/run_infer.py
@@ -29,10 +29,10 @@ from benchmarks.utils.models import (
     EvalMetadata,
     EvalOutput,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import IMAGE_TAG_PREFIX
 from openhands.sdk import LLM, Agent, Conversation, get_logger
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace
 
 
@@ -308,7 +308,7 @@ class SWEfficiencyEvaluation(Evaluation):
         """
         Create conversation, run agent, collect history and git patch.
         """
-        tools = get_default_tools(enable_browser=False)
+        tools = get_tools_for_preset(self.metadata.tool_preset, enable_browser=False)
         # Load public skills (respects EXTENSIONS_REF env var)
         agent_context = create_agent_context()
 
@@ -482,6 +482,7 @@ def main() -> None:
     # Create critic instance from parsed arguments
     critic = create_critic(args)
     logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
 
     metadata = EvalMetadata(
         llm=llm,
@@ -498,6 +499,7 @@ def main() -> None:
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
     )
 
     # Set up CPU groups queue for Docker workspace

--- a/benchmarks/swesmith/run_infer.py
+++ b/benchmarks/swesmith/run_infer.py
@@ -31,10 +31,10 @@ from benchmarks.utils.models import (
     EvalMetadata,
     EvalOutput,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import SDK_SHORT_SHA
 from openhands.sdk import LLM, Agent, Conversation, get_logger
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.workspace import APIRemoteWorkspace, DockerWorkspace
 
 
@@ -276,7 +276,8 @@ class SWESmithEvaluation(Evaluation):
         Create conversation, run agent, collect history and git patch.
         Do not write files here; just return EvalOutput.
         """
-        tools = get_default_tools(
+        tools = get_tools_for_preset(
+            self.metadata.tool_preset,
             # Disable browser tools in CLI mode
             enable_browser=False,
         )
@@ -453,6 +454,7 @@ def main() -> None:
     # Create critic instance from parsed arguments
     critic = create_critic(args)
     logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
 
     metadata = EvalMetadata(
         llm=llm,
@@ -469,6 +471,7 @@ def main() -> None:
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
     )
 
     # Run orchestrator with a simple JSONL writer

--- a/benchmarks/swtbench/run_infer.py
+++ b/benchmarks/swtbench/run_infer.py
@@ -37,12 +37,12 @@ from benchmarks.utils.models import (
     EvalMetadata,
     EvalOutput,
 )
+from benchmarks.utils.tool_presets import get_tools_for_preset
 from benchmarks.utils.version import get_phased_image_tag_prefix
 from openhands.sdk import Agent, Conversation, Tool, __version__, get_logger
 from openhands.sdk.agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.workspace import RemoteWorkspace
-from openhands.tools.preset.default import get_default_tools
 from openhands.tools.task import TaskToolSet
 from openhands.workspace import APIRemoteWorkspace
 
@@ -252,7 +252,8 @@ class SWTBenchEvaluation(Evaluation):
             agent = build_acp_agent(self.metadata.agent_type, self.metadata.llm.model)
         else:
             agent_llm = build_eval_llm(self.metadata.llm)
-            tools = get_default_tools(
+            tools = get_tools_for_preset(
+                self.metadata.tool_preset,
                 # Disable browser tools in CLI mode
                 enable_browser=False,
             )
@@ -396,6 +397,8 @@ def main() -> None:
     )
 
     critic = create_critic(args)
+    logger.info(f"Using critic: {type(critic).__name__}")
+    logger.info(f"Using tool preset: {args.tool_preset}")
 
     # Handle condenser configuration
     # --disable-condenser takes precedence over --enable-condenser and defaults
@@ -418,6 +421,7 @@ def main() -> None:
         selected_instances_file=args.select,
         max_retries=args.max_retries,
         workspace_type=args.workspace,
+        tool_preset=args.tool_preset,
         enable_delegation=args.enable_delegation,
         agent_type=args.agent_type,
         enable_condenser=enable_condenser,

--- a/benchmarks/utils/tool_presets.py
+++ b/benchmarks/utils/tool_presets.py
@@ -1,5 +1,7 @@
 """Shared tool-preset selection for benchmark runners."""
 
+from typing import assert_never
+
 from benchmarks.utils.models import ToolPresetType
 from openhands.sdk import Tool
 
@@ -8,20 +10,23 @@ def get_tools_for_preset(
     preset: ToolPresetType, enable_browser: bool = False
 ) -> list[Tool]:
     """Return tools for a benchmark tool preset."""
-    if preset == "gemini":
-        from openhands.tools.preset.gemini import get_gemini_tools
+    match preset:
+        case "gemini":
+            from openhands.tools.preset.gemini import get_gemini_tools
 
-        return get_gemini_tools(enable_browser=enable_browser)
-    if preset == "gpt5":
-        from openhands.tools.preset.gpt5 import get_gpt5_tools
+            return get_gemini_tools(enable_browser=enable_browser)
+        case "gpt5":
+            from openhands.tools.preset.gpt5 import get_gpt5_tools
 
-        return get_gpt5_tools(enable_browser=enable_browser)
-    if preset == "planning":
-        from openhands.tools.preset.planning import get_planning_tools
+            return get_gpt5_tools(enable_browser=enable_browser)
+        case "planning":
+            from openhands.tools.preset.planning import get_planning_tools
 
-        # Planning preset does not support browser tools.
-        return get_planning_tools()
+            # Planning preset does not support browser tools.
+            return get_planning_tools()
+        case "default":
+            from openhands.tools.preset.default import get_default_tools
 
-    from openhands.tools.preset.default import get_default_tools
+            return get_default_tools(enable_browser=enable_browser)
 
-    return get_default_tools(enable_browser=enable_browser)
+    assert_never(preset)

--- a/benchmarks/utils/tool_presets.py
+++ b/benchmarks/utils/tool_presets.py
@@ -1,0 +1,27 @@
+"""Shared tool-preset selection for benchmark runners."""
+
+from benchmarks.utils.models import ToolPresetType
+from openhands.sdk import Tool
+
+
+def get_tools_for_preset(
+    preset: ToolPresetType, enable_browser: bool = False
+) -> list[Tool]:
+    """Return tools for a benchmark tool preset."""
+    if preset == "gemini":
+        from openhands.tools.preset.gemini import get_gemini_tools
+
+        return get_gemini_tools(enable_browser=enable_browser)
+    if preset == "gpt5":
+        from openhands.tools.preset.gpt5 import get_gpt5_tools
+
+        return get_gpt5_tools(enable_browser=enable_browser)
+    if preset == "planning":
+        from openhands.tools.preset.planning import get_planning_tools
+
+        # Planning preset does not support browser tools.
+        return get_planning_tools()
+
+    from openhands.tools.preset.default import get_default_tools
+
+    return get_default_tools(enable_browser=enable_browser)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -620,6 +620,14 @@ def _get_evaluation_module_name(evaluation_class: type[Evaluation]) -> str:
     return evaluation_class.evaluate_instance.__module__
 
 
+def _tools_mock_target(evaluation_module_name: str) -> str:
+    """Return the tool factory symbol used by an evaluation module."""
+    module = importlib.import_module(evaluation_module_name)
+    if hasattr(module, "get_tools_for_preset"):
+        return f"{evaluation_module_name}.get_tools_for_preset"
+    return f"{evaluation_module_name}.get_default_tools"
+
+
 @pytest.mark.parametrize("benchmark_name,evaluation_class", BENCHMARKS)
 def test_benchmark_metrics_collection(
     benchmark_name: str,
@@ -656,15 +664,7 @@ def test_benchmark_metrics_collection(
 
     # Mock common dependencies to avoid actual LLM calls.
     evaluation_module_name = _get_evaluation_module_name(evaluation_class)
-    tools_mock_target = (
-        f"{evaluation_module_name}.get_tools_for_preset"
-        if evaluation_module_name
-        in {
-            "benchmarks.swebench.run_infer",
-            "benchmarks.swebenchmultilingual.run_infer",
-        }
-        else f"{evaluation_module_name}.get_default_tools"
-    )
+    tools_mock_target = _tools_mock_target(evaluation_module_name)
     with (
         patch(
             f"{evaluation_module_name}.Conversation",
@@ -786,7 +786,7 @@ def test_openagentsafety_error_path_uses_conversation_metrics(
             return_value=mock_conversation,
         ),
         patch("benchmarks.openagentsafety.run_infer.Agent"),
-        patch("benchmarks.openagentsafety.run_infer.get_default_tools"),
+        patch("benchmarks.openagentsafety.run_infer.get_tools_for_preset"),
         patch(
             "benchmarks.openagentsafety.run_infer.generate_instruction",
             return_value="Test instruction",
@@ -832,15 +832,7 @@ def test_metrics_with_zero_cost(mock_workspace):
     mock_conversation = _setup_mocks_for_benchmark(benchmark_name, zero_metrics)
 
     evaluation_module_name = _get_evaluation_module_name(evaluation_class)
-    tools_mock_target = (
-        f"{evaluation_module_name}.get_tools_for_preset"
-        if evaluation_module_name
-        in {
-            "benchmarks.swebench.run_infer",
-            "benchmarks.swebenchmultilingual.run_infer",
-        }
-        else f"{evaluation_module_name}.get_default_tools"
-    )
+    tools_mock_target = _tools_mock_target(evaluation_module_name)
     with (
         patch(
             f"{evaluation_module_name}.Conversation",

--- a/tests/test_tool_presets.py
+++ b/tests/test_tool_presets.py
@@ -4,25 +4,29 @@ from benchmarks.hybridgym_depsearch.run_infer import DepSearchEvaluation
 from benchmarks.hybridgym_funcgen.run_infer import FuncGenEvaluation
 from benchmarks.hybridgym_funclocalize.run_infer import FuncLocalizeEvaluation
 from benchmarks.hybridgym_issuelocalize.run_infer import IssueLocalizeEvaluation
-from benchmarks.swebench.run_infer import get_tools_for_preset as get_swebench_tools
-from benchmarks.swebenchmultilingual.run_infer import (
-    get_tools_for_preset as get_swebenchmultilingual_tools,
-)
 from benchmarks.utils.args_parser import get_parser
+from benchmarks.utils.tool_presets import get_tools_for_preset
+from openhands.tools.preset.gemini import get_gemini_tools
 from openhands.tools.preset.gpt5 import get_gpt5_tools
 
 
-@pytest.mark.parametrize(
-    "getter",
-    [
-        get_swebench_tools,
-        get_swebenchmultilingual_tools,
-    ],
-)
-def test_swebench_tool_helpers_support_gpt5(getter):
+def test_shared_tool_helper_supports_gemini_file_tools():
+    expected = [tool.name for tool in get_gemini_tools(enable_browser=False)]
+    actual = [
+        tool.name for tool in get_tools_for_preset("gemini", enable_browser=False)
+    ]
+
+    assert actual == expected
+    assert {"read_file", "write_file", "edit", "list_directory"}.issubset(actual)
+    assert "file_editor" not in actual
+
+
+def test_shared_tool_helper_supports_gpt5():
     expected = [tool.name for tool in get_gpt5_tools(enable_browser=False)]
 
-    assert [tool.name for tool in getter("gpt5", enable_browser=False)] == expected
+    assert [
+        tool.name for tool in get_tools_for_preset("gpt5", enable_browser=False)
+    ] == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a shared `benchmarks.utils.tool_presets.get_tools_for_preset()` helper
- wire SDK-agent benchmark runners through `metadata.tool_preset` instead of hardcoding default tools
- persist/log `tool_preset=args.tool_preset` in runners that were falling back to metadata default
- update tests to cover the shared helper, including a Gemini-specific assertion that `file_editor` is absent and Gemini file tools are present

Fixes #738.

## Validation

- `uv run pytest tests/test_tool_presets.py tests/test_metrics.py -q`
- `uv run ruff check benchmarks tests/test_metrics.py tests/test_tool_presets.py`
- pre-commit hooks on commit:
  - Ruff format
  - Ruff lint
  - pycodestyle
  - Pyright

## Note

The current eval-job shell wrappers in `OpenHands/evaluation` still need a matching follow-up so non-SWE-bench jobs pass `--tool-preset` into the benchmark infer commands.
