### PR TITLE
fix(critics): read instance_id from raw JSON in get_completed_instances

### DIFF
--- a/benchmarks/utils/critics.py
+++ b/benchmarks/utils/critics.py
@@ -150,11 +150,12 @@ def get_completed_instances(output_file: str) -> Set[EvalInstanceID]:
     Get all instance IDs present in output file
     (completed, regardless of success/failure).
 
-    Args:
-        output_file: Path to the JSONL output file
-
-    Returns:
-        Set of instance IDs that were completed (processed)
+    Reads ``instance_id`` directly from each JSON line WITHOUT validating the
+    full ``EvalOutput`` model. Resume must recognise prior completion across
+    schema drift — e.g. archives written with an older SDK whose
+    tool/observation events no longer match current pydantic models — so a
+    stale archive still causes completed instances to be skipped instead of
+    silently being re-run from scratch.
     """
     completed_instances: Set[EvalInstanceID] = set()
 
@@ -164,19 +165,26 @@ def get_completed_instances(output_file: str) -> Set[EvalInstanceID]:
     try:
         with open(output_file, "r", encoding="utf-8") as f:
             for line_num, line in enumerate(f, 1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
                 try:
-                    data = json.loads(line.strip())
-                    output = EvalOutput.model_validate(data)
-                    completed_instances.add(output.instance_id)
-
+                    data = json.loads(stripped)
                 except json.JSONDecodeError as e:
                     logger.warning(
                         f"Invalid JSON on line {line_num} in {output_file}: {e}"
                     )
-                except Exception as e:
+                    continue
+
+                instance_id = (
+                    data.get("instance_id") if isinstance(data, dict) else None
+                )
+                if not instance_id:
                     logger.warning(
-                        f"Error processing line {line_num} in {output_file}: {e}"
+                        f"Missing 'instance_id' on line {line_num} in {output_file}"
                     )
+                    continue
+                completed_instances.add(instance_id)
 
     except Exception as e:
         logger.warning(f"Error reading output file {output_file}: {e}")

--- a/tests/test_iterative_resume.py
+++ b/tests/test_iterative_resume.py
@@ -507,4 +507,3 @@ def test_get_completed_instances_tolerates_stale_archive_schema():
             f"Expected both stale-schema and fresh rows to be recognised as "
             f"completed, got: {completed}"
         )
-

--- a/tests/test_iterative_resume.py
+++ b/tests/test_iterative_resume.py
@@ -443,3 +443,68 @@ def test_passed_instances_not_retried_in_later_attempts():
         assert result_ids == {"D"}, (
             f"Expected to retry only D (failed in attempt 2), but got: {result_ids}"
         )
+
+
+def test_get_completed_instances_tolerates_stale_archive_schema():
+    """
+    Resume must skip instances that were completed by an older SDK whose
+    EvalOutput schema has since drifted (e.g. browser tool/observation
+    events whose pydantic discriminators no longer match current models).
+
+    Reading instance_id from raw JSON avoids treating those rows as
+    "never completed" and re-running them from scratch. Regression test
+    for evaluation#515.
+    """
+    from benchmarks.utils.critics import get_completed_instances
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "output.critic_attempt_1.jsonl")
+        with open(path, "w") as f:
+            # 1) Stale row: has instance_id but a history event with a
+            #    discriminator value the current SDK no longer knows about.
+            #    EvalOutput.model_validate would raise on this; raw JSON
+            #    parsing must not.
+            stale = {
+                "instance_id": "instance_stale",
+                "instruction": "old instruction",
+                "instance": {"x": 1},
+                "test_result": {"git_patch": "old patch"},
+                "error": None,
+                "history": [
+                    {
+                        "kind": "BrowserNavigateTool",
+                        "tool_name": "browser",
+                        "args": {"url": "https://example.com"},
+                    }
+                ],
+            }
+            f.write(json.dumps(stale) + "\n")
+
+            # 2) Fresh row written via current EvalOutput model. Must also
+            #    still be detected.
+            fresh = EvalOutput(
+                instance_id="instance_fresh",
+                test_result={"git_patch": "p"},
+                instruction="i",
+                error=None,
+                history=[],
+                instance={"x": 2},
+            )
+            f.write(fresh.model_dump_json() + "\n")
+
+            # 3) Blank line: must be tolerated, not counted.
+            f.write("\n")
+
+            # 4) Malformed JSON: must be skipped with a warning, not raise.
+            f.write("{not valid json}\n")
+
+            # 5) JSON object missing instance_id: must be skipped.
+            f.write(json.dumps({"foo": "bar"}) + "\n")
+
+        completed = get_completed_instances(path)
+
+        assert completed == {"instance_stale", "instance_fresh"}, (
+            f"Expected both stale-schema and fresh rows to be recognised as "
+            f"completed, got: {completed}"
+        )
+


### PR DESCRIPTION
Root-cause half of the swebenchmultimodal resume failure tracked as [evaluation#515](https://github.com/OpenHands/evaluation/issues/515). The other half is [evaluation#576](https://github.com/OpenHands/evaluation/pull/576) (revert of a wrapper-script workaround that made things worse); the two PRs together restore working resume for both fresh and stale archives.

### Bug

`get_completed_instances()` calls `EvalOutput.model_validate(data)` on every line and silently swallows any exception:

```python
try:
    data = json.loads(line.strip())
    output = EvalOutput.model_validate(data)
    completed_instances.add(output.instance_id)
except Exception as e:
    logger.warning(...)
```

When a resume run loads a partial archive written by an older SDK whose tool/observation event schema has since drifted (e.g. `BrowserNavigateTool`, `BrowserObservation` entries that the current pydantic models no longer recognise), every completed row hits the `except` branch and gets dropped. `_get_instances_for_attempt()` then computes `all_instances - completed_in_attempt` and concludes that nothing has been completed, so the iterative loop re-runs every selected instance from scratch.

### Fix

Read `instance_id` directly from the parsed JSON dict. We do not need a fully validated `EvalOutput` to decide whether an instance was already processed — we just need its id. Malformed JSON, blank lines, and objects missing `instance_id` are still skipped with a warning.

`get_failed_instances()` legitimately needs the full model (to hand to `critic.evaluate()`), so it's left as is. On a stale archive it will find zero failed instances; combined with the now-correct completed set this produces an empty retry list — the conservative "trust the prior completion" choice, which matches what a resume is supposed to do.

### Test

Added `test_get_completed_instances_tolerates_stale_archive_schema` which writes a JSONL with:

1. a stale-schema row with a `BrowserNavigateTool` history event that fails `EvalOutput.model_validate`
2. a fresh row written via the current `EvalOutput`
3. a blank line
4. a malformed JSON line
5. a JSON object missing `instance_id`

Asserts only rows 1 and 2 land in the returned set. The test **fails on `main`** (row 1 gets dropped, set is `{"instance_fresh"}`) and **passes with this PR**.

```
$ uv run pytest tests/test_iterative_resume.py -p no:cacheprovider
======================== 5 passed, 2 warnings in 0.46s ========================
```

### Companion PR

- evaluation#576 — Revert evaluation#520; the `--output-dir "$OUTPUT_DIR_PATH"` line it added was nesting `<dataset>/<model_folder>` under an already-leaf path, so the restored archive was sitting at one path while the benchmark was looking at another. That bug also surfaces as #515.

Either PR alone fixes one shape of the bug; landing both fixes the user-visible "swebenchmultimodal resume runs all 67 instances anyway" problem (e.g. eval-monitor run [`27027881388`](https://openhands-eval-monitor.vercel.app/?run=swebenchmultimodal%2Flitellm_proxy-gemini-3-5-flash%2F27027881388%2F)) end-to-end.

cc @simonrosenberg @juanmichelini

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3c7135ec-94c1-415c-94c2-d990112c7c0a)