### PR TITLE
Add SWE-bench Apptainer image builds and runtime wiring

### DIFF
--- a/benchmarks/swebench/README.md
+++ b/benchmarks/swebench/README.md
@@ -199,17 +199,17 @@ uv run python -m benchmarks.swebench.build_images \
 
 The wrapper layer (`docutils<0.21`, `roman`) is applied in-place for allowlisted repos during this build pipeline (currently `sphinx-doc`).
 
-#### Option 2: Build local Apptainer sandboxes on the HPC machine
+#### Option 2: Build local Apptainer SIFs on the HPC machine
 
 If a pre-built agent-server image is missing from the registry, Apptainer mode
-falls back to building a local sandbox from the official SWE-Bench image and the
+falls back to building a local SIF from the official SWE-Bench image and the
 checked-out OpenHands SDK submodule. This does not require a Docker daemon.
 
 ```bash
 export OPENHANDS_APPTAINER_BUILD_ROOT=/scratch/$USER/swebench-apptainer-agent-images
 ```
 
-Set `OPENHANDS_APPTAINER_FORCE_BUILD=1` to rebuild a local sandbox even when a
+Set `OPENHANDS_APPTAINER_FORCE_BUILD=1` to rebuild a local SIF even when a
 matching registry image exists.
 
 #### Run on HPC with Apptainer
@@ -229,7 +229,7 @@ uv run swebench-infer path/to/llm_config.json \
 ```
 
 In `apptainer` mode, SWE-Bench first tries to use pre-built registry images. If
-the expected registry tag is unavailable, it builds a local Apptainer sandbox
+the expected registry tag is unavailable, it builds a local Apptainer SIF
 instead.
 
 ## Evaluation

--- a/benchmarks/swebench/README.md
+++ b/benchmarks/swebench/README.md
@@ -186,7 +186,7 @@ uv run swebench-infer .llm_config/sonnet-4-5.json \
 
 ### Apptainer Workspace for HPC Clusters
 
-#### Step 1: Build and push images using a separate machine with Docker support
+#### Option 1: Pre-build and push images using a separate machine with Docker support
 
 ```bash
 uv run python -m benchmarks.swebench.build_images \
@@ -199,7 +199,20 @@ uv run python -m benchmarks.swebench.build_images \
 
 The wrapper layer (`docutils<0.21`, `roman`) is applied in-place for allowlisted repos during this build pipeline (currently `sphinx-doc`).
 
-#### Step 2: Run on HPC with Apptainer
+#### Option 2: Build local Apptainer sandboxes on the HPC machine
+
+If a pre-built agent-server image is missing from the registry, Apptainer mode
+falls back to building a local sandbox from the official SWE-Bench image and the
+checked-out OpenHands SDK submodule. This does not require a Docker daemon.
+
+```bash
+export OPENHANDS_APPTAINER_BUILD_ROOT=/scratch/$USER/swebench-apptainer-agent-images
+```
+
+Set `OPENHANDS_APPTAINER_FORCE_BUILD=1` to rebuild a local sandbox even when a
+matching registry image exists.
+
+#### Run on HPC with Apptainer
 
 **Optionally**, you can override the default location where Apptainer cache is saved using the below environment variables:
 
@@ -215,7 +228,9 @@ uv run swebench-infer path/to/llm_config.json \
     --workspace apptainer
 ```
 
-In `apptainer` mode, SWE-Bench uses pre-built registry images as-is and does not run local Docker builds.
+In `apptainer` mode, SWE-Bench first tries to use pre-built registry images. If
+the expected registry tag is unavailable, it builds a local Apptainer sandbox
+instead.
 
 ## Evaluation
 

--- a/benchmarks/swebench/apptainer_build.py
+++ b/benchmarks/swebench/apptainer_build.py
@@ -1,0 +1,311 @@
+"""Local Apptainer builds for SWE-bench agent-server images."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from benchmarks.swebench import constants
+from benchmarks.swebench.build_base_images import dockerfile_content_hash
+from benchmarks.utils.build_utils import BuildOutput, _get_sdk_submodule_info
+from openhands.sdk import get_logger
+
+
+logger = get_logger(__name__)
+
+DEFAULT_APPTAINER_BUILD_ROOT = (
+    Path.home() / ".cache" / "openhands" / "swebench-apptainer-agent-images"
+)
+SUPPORTED_APPTAINER_TARGETS = {constants.BUILD_TARGET_SOURCE_MINIMAL}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _sdk_root() -> Path:
+    return _repo_root() / "vendor" / "software-agent-sdk"
+
+
+def _sanitize_filename(value: str) -> str:
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in value)
+
+
+def _build_root() -> Path:
+    return Path(
+        os.getenv("OPENHANDS_APPTAINER_BUILD_ROOT", str(DEFAULT_APPTAINER_BUILD_ROOT))
+    ).expanduser()
+
+
+def _force_build_enabled() -> bool:
+    return os.getenv("OPENHANDS_APPTAINER_FORCE_BUILD", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def apptainer_agent_image_path(
+    custom_tag: str,
+    target: constants.TargetType = constants.DEFAULT_BUILD_TARGET,
+) -> Path:
+    """Return the local Apptainer sandbox path for a SWE-bench agent image."""
+    _, git_sha, _ = _get_sdk_submodule_info()
+    sdk_short_sha = git_sha[:7] if git_sha != "unknown" else "unknown"
+    content_hash = dockerfile_content_hash()
+    name = _sanitize_filename(f"{sdk_short_sha}-{content_hash}-{custom_tag}-{target}")
+    return _build_root() / f"{name}.sandbox"
+
+
+def _package_install_script() -> str:
+    """Return package setup shell matching the minimal Docker target."""
+    return r"""
+export DEBIAN_FRONTEND=noninteractive
+if command -v apt-get >/dev/null 2>&1; then
+    apt-get -o Acquire::Retries=5 update
+    apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
+        bash ca-certificates curl wget sudo apt-utils git jq tmux tar \
+        build-essential coreutils util-linux procps findutils grep sed \
+        apt-transport-https gnupg lsb-release xz-utils
+    rm -rf /var/lib/apt/lists/*
+elif command -v apk >/dev/null 2>&1; then
+    apk add --no-cache \
+        bash ca-certificates curl wget sudo git jq tmux tar build-base \
+        coreutils util-linux procps findutils grep sed gnupg shadow xz
+elif command -v microdnf >/dev/null 2>&1; then
+    microdnf install -y \
+        bash ca-certificates curl wget sudo git jq tmux tar make gcc gcc-c++ \
+        coreutils util-linux procps-ng findutils grep sed shadow-utils \
+        gnupg2 xz
+    microdnf clean all
+elif command -v dnf >/dev/null 2>&1; then
+    dnf install -y \
+        bash ca-certificates curl wget sudo git jq tmux tar make gcc gcc-c++ \
+        coreutils util-linux procps-ng findutils grep sed shadow-utils \
+        gnupg2 xz
+    dnf clean all
+elif command -v yum >/dev/null 2>&1; then
+    yum install -y \
+        bash ca-certificates curl wget sudo git jq tmux tar make gcc gcc-c++ \
+        coreutils util-linux procps-ng findutils grep sed shadow-utils \
+        gnupg2 xz
+    yum clean all
+elif command -v zypper >/dev/null 2>&1; then
+    zypper --non-interactive install --no-recommends \
+        bash ca-certificates curl wget sudo git jq tmux tar make gcc gcc-c++ \
+        coreutils util-linux procps findutils grep sed shadow gpg2 xz
+    zypper clean --all
+else
+    echo "Unsupported base image: no known package manager found" >&2
+    exit 1
+fi
+"""
+
+
+def _wrap_swebench_deps_script() -> str:
+    """Return optional Sphinx dependency wrapper shell."""
+    return r"""
+if command -v conda >/dev/null 2>&1; then
+    conda run -n testbed pip install --no-deps --force-reinstall 'docutils<0.21' 'roman' \
+        || (source /opt/miniconda3/bin/activate testbed && pip install --no-deps --force-reinstall 'docutils<0.21' 'roman')
+elif [ -x /opt/miniconda3/bin/conda ]; then
+    /opt/miniconda3/bin/conda run -n testbed pip install --no-deps --force-reinstall 'docutils<0.21' 'roman' \
+        || (source /opt/miniconda3/bin/activate testbed && pip install --no-deps --force-reinstall 'docutils<0.21' 'roman')
+fi
+if command -v pip >/dev/null 2>&1; then
+    pip install --no-deps --force-reinstall 'docutils<0.21' 'roman'
+fi
+"""
+
+
+def _definition_file_content(
+    base_image: str,
+    git_sha: str,
+    git_ref: str,
+    wrap_swebench_deps: bool,
+    uv_path: Path,
+    uvx_path: Path | None,
+) -> str:
+    sdk_root = _sdk_root()
+    wrap_script = _wrap_swebench_deps_script() if wrap_swebench_deps else ""
+    uvx_files = f"    {uvx_path} /usr/local/bin/uvx\n" if uvx_path else ""
+    return f"""Bootstrap: docker
+From: {base_image}
+
+%files
+    {uv_path} /usr/local/bin/uv
+{uvx_files}\
+    {sdk_root / "pyproject.toml"} /agent-server/pyproject.toml
+    {sdk_root / "uv.lock"} /agent-server/uv.lock
+    {sdk_root / "README.md"} /agent-server/README.md
+    {sdk_root / "LICENSE"} /agent-server/LICENSE
+    {sdk_root / "openhands-sdk"} /agent-server/openhands-sdk
+    {sdk_root / "openhands-tools"} /agent-server/openhands-tools
+    {sdk_root / "openhands-workspace"} /agent-server/openhands-workspace
+    {sdk_root / "openhands-agent-server"} /agent-server/openhands-agent-server
+
+%post
+    set -eux
+    {_package_install_script()}
+
+    USERNAME=openhands
+    UID=10001
+    GID=10001
+    grep -Eq "^[^:]*:[^:]*:${{GID}}:" /etc/group || groupadd -g "${{GID}}" "${{USERNAME}}"
+    grep -Eq "^${{USERNAME}}:" /etc/passwd || useradd -m -u "${{UID}}" -g "${{GID}}" -s /bin/bash "${{USERNAME}}"
+    usermod -aG sudo "${{USERNAME}}" 2>/dev/null || true
+    echo "${{USERNAME}} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    mkdir -p /workspace/project /agent-server/uv-managed-python
+    chown -R "${{USERNAME}}:${{USERNAME}}" /workspace /agent-server
+
+    chmod 0755 /usr/local/bin/uv
+    if [ -e /usr/local/bin/uvx ]; then chmod 0755 /usr/local/bin/uvx; fi
+
+    su "${{USERNAME}}" -s /bin/bash -c 'cd /agent-server && \\
+        export HOME=/home/openhands && \\
+        export UV_PROJECT_ENVIRONMENT=/agent-server/.venv && \\
+        export UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python && \\
+        uv python install 3.13 && \\
+        uv venv --python-preference only-managed --python 3.13 .venv && \\
+        uv sync --frozen --no-editable --managed-python --extra boto3 && \\
+        readlink -f .venv/bin/python | grep -q "^/agent-server/uv-managed-python/"'
+
+    {wrap_script}
+
+%environment
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
+    export OH_ENABLE_VNC=false
+    export LOG_JSON=true
+    export OPENHANDS_BUILD_GIT_SHA={git_sha}
+    export OPENHANDS_BUILD_GIT_REF={git_ref}
+
+%runscript
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
+    export OH_ENABLE_VNC=false
+    export LOG_JSON=true
+    export OPENHANDS_BUILD_GIT_SHA={git_sha}
+    export OPENHANDS_BUILD_GIT_REF={git_ref}
+    exec /agent-server/.venv/bin/python -m openhands.agent_server "$@"
+"""
+
+
+def build_apptainer_agent_image(
+    base_image: str,
+    custom_tag: str,
+    target: constants.TargetType = constants.DEFAULT_BUILD_TARGET,
+    wrap_swebench_deps: bool = False,
+) -> BuildOutput:
+    """Build a local Apptainer agent-server sandbox from a SWE-bench base image."""
+    if target not in SUPPORTED_APPTAINER_TARGETS:
+        return BuildOutput(
+            base_image=base_image,
+            tags=[],
+            error=(
+                f"Apptainer local builds currently support "
+                f"{sorted(SUPPORTED_APPTAINER_TARGETS)}, got {target!r}"
+            ),
+        )
+
+    if shutil.which("apptainer") is None:
+        return BuildOutput(
+            base_image=base_image,
+            tags=[],
+            error="Apptainer is not available on PATH",
+        )
+    uv_bin = shutil.which("uv")
+    if uv_bin is None:
+        return BuildOutput(
+            base_image=base_image,
+            tags=[],
+            error="uv is not available on PATH",
+        )
+    uvx_bin = shutil.which("uvx")
+
+    sandbox = apptainer_agent_image_path(custom_tag, target)
+    if sandbox.exists() and not _force_build_enabled():
+        logger.info("Using existing Apptainer agent sandbox %s", sandbox)
+        return BuildOutput(base_image=base_image, tags=[str(sandbox)], error=None)
+
+    build_root = _build_root()
+    log_dir = build_root / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    build_root.mkdir(parents=True, exist_ok=True)
+
+    tmp_sandbox = sandbox.with_suffix(".tmp")
+    if tmp_sandbox.exists():
+        shutil.rmtree(tmp_sandbox)
+    if sandbox.exists():
+        shutil.rmtree(sandbox)
+
+    git_ref, git_sha, _ = _get_sdk_submodule_info()
+    definition = build_root / f"{sandbox.name}.def"
+    definition.write_text(
+        _definition_file_content(
+            base_image=base_image,
+            git_sha=git_sha,
+            git_ref=git_ref,
+            wrap_swebench_deps=wrap_swebench_deps,
+            uv_path=Path(uv_bin).resolve(),
+            uvx_path=Path(uvx_bin).resolve() if uvx_bin else None,
+        )
+    )
+
+    log_path = log_dir / f"{sandbox.name}.log"
+    cmd = ["apptainer", "build", "--sandbox", str(tmp_sandbox), str(definition)]
+    logger.info("Building Apptainer agent sandbox: %s", " ".join(cmd))
+    env = os.environ.copy()
+    if "APPTAINER_CACHEDIR" not in env:
+        env["APPTAINER_CACHEDIR"] = str(build_root / "cache")
+    for key in ("APPTAINER_CACHEDIR", "APPTAINER_TMPDIR"):
+        if env.get(key):
+            Path(env[key]).expanduser().mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+    )
+    log_path.write_text(proc.stdout)
+    if proc.returncode != 0:
+        shutil.rmtree(tmp_sandbox, ignore_errors=True)
+        return BuildOutput(
+            base_image=base_image,
+            tags=[],
+            error=f"Apptainer build failed with exit code {proc.returncode}",
+            log_path=str(log_path),
+        )
+
+    tmp_sandbox.rename(sandbox)
+    logger.info("Built Apptainer agent sandbox %s", sandbox)
+    return BuildOutput(
+        base_image=base_image,
+        tags=[str(sandbox)],
+        error=None,
+        log_path=str(log_path),
+    )
+
+
+def ensure_apptainer_agent_image(
+    base_image: str,
+    custom_tag: str,
+    target: constants.TargetType = constants.DEFAULT_BUILD_TARGET,
+    wrap_swebench_deps: bool = False,
+) -> Path:
+    """Build or reuse a local Apptainer agent-server sandbox."""
+    output = build_apptainer_agent_image(
+        base_image=base_image,
+        custom_tag=custom_tag,
+        target=target,
+        wrap_swebench_deps=wrap_swebench_deps,
+    )
+    logger.info("Apptainer image build output: %s", output)
+    if output.error is not None:
+        raise RuntimeError(f"Apptainer image build failed: {output.error}")
+    if not output.tags:
+        raise RuntimeError("Apptainer image build produced no image path")
+    return Path(output.tags[0])

--- a/benchmarks/swebench/apptainer_build.py
+++ b/benchmarks/swebench/apptainer_build.py
@@ -255,7 +255,6 @@ def build_apptainer_agent_image(
 
     tmp_image = image_path.with_suffix(".tmp.sif")
     _remove_path(tmp_image)
-    _remove_path(image_path)
 
     git_ref, git_sha, _ = _get_sdk_submodule_info()
     definition = build_root / f"{image_path.name}.def"
@@ -296,7 +295,7 @@ def build_apptainer_agent_image(
             log_path=str(log_path),
         )
 
-    tmp_image.rename(image_path)
+    tmp_image.replace(image_path)
     logger.info("Built Apptainer agent SIF %s", image_path)
     return BuildOutput(
         base_image=base_image,

--- a/benchmarks/swebench/apptainer_build.py
+++ b/benchmarks/swebench/apptainer_build.py
@@ -170,6 +170,7 @@ From: {base_image}
         uv python install 3.13 && \\
         uv venv --python-preference only-managed --python 3.13 .venv && \\
         uv sync --frozen --no-editable --managed-python --extra boto3 && \\
+        uv pip install --python /agent-server/.venv/bin/python "transformers>=4.56.0,<5" && \\
         readlink -f .venv/bin/python | grep -q "^/agent-server/uv-managed-python/"'
 
     {wrap_script}

--- a/benchmarks/swebench/apptainer_build.py
+++ b/benchmarks/swebench/apptainer_build.py
@@ -51,12 +51,19 @@ def apptainer_agent_image_path(
     custom_tag: str,
     target: constants.TargetType = constants.DEFAULT_BUILD_TARGET,
 ) -> Path:
-    """Return the local Apptainer sandbox path for a SWE-bench agent image."""
+    """Return the local Apptainer SIF path for a SWE-bench agent image."""
     _, git_sha, _ = _get_sdk_submodule_info()
     sdk_short_sha = git_sha[:7] if git_sha != "unknown" else "unknown"
     content_hash = dockerfile_content_hash()
     name = _sanitize_filename(f"{sdk_short_sha}-{content_hash}-{custom_tag}-{target}")
-    return _build_root() / f"{name}.sandbox"
+    return _build_root() / f"{name}.sif"
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+    elif path.exists():
+        path.unlink()
 
 
 def _package_install_script() -> str:
@@ -131,6 +138,13 @@ def _definition_file_content(
     sdk_root = _sdk_root()
     wrap_script = _wrap_swebench_deps_script() if wrap_swebench_deps else ""
     uvx_files = f"    {uvx_path} /usr/local/bin/uvx\n" if uvx_path else ""
+    uv_concurrent_downloads = os.getenv(
+        "OPENHANDS_APPTAINER_UV_CONCURRENT_DOWNLOADS", "4"
+    )
+    uv_concurrent_builds = os.getenv("OPENHANDS_APPTAINER_UV_CONCURRENT_BUILDS", "1")
+    uv_concurrent_installs = os.getenv(
+        "OPENHANDS_APPTAINER_UV_CONCURRENT_INSTALLS", "1"
+    )
     return f"""Bootstrap: docker
 From: {base_image}
 
@@ -165,6 +179,9 @@ From: {base_image}
 
     su "${{USERNAME}}" -s /bin/bash -c 'cd /agent-server && \\
         export HOME=/home/openhands && \\
+        export UV_CONCURRENT_DOWNLOADS={uv_concurrent_downloads} && \\
+        export UV_CONCURRENT_BUILDS={uv_concurrent_builds} && \\
+        export UV_CONCURRENT_INSTALLS={uv_concurrent_installs} && \\
         export UV_PROJECT_ENVIRONMENT=/agent-server/.venv && \\
         export UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python && \\
         uv python install 3.13 && \\
@@ -200,7 +217,7 @@ def build_apptainer_agent_image(
     target: constants.TargetType = constants.DEFAULT_BUILD_TARGET,
     wrap_swebench_deps: bool = False,
 ) -> BuildOutput:
-    """Build a local Apptainer agent-server sandbox from a SWE-bench base image."""
+    """Build a local Apptainer agent-server SIF from a SWE-bench base image."""
     if target not in SUPPORTED_APPTAINER_TARGETS:
         return BuildOutput(
             base_image=base_image,
@@ -226,24 +243,22 @@ def build_apptainer_agent_image(
         )
     uvx_bin = shutil.which("uvx")
 
-    sandbox = apptainer_agent_image_path(custom_tag, target)
-    if sandbox.exists() and not _force_build_enabled():
-        logger.info("Using existing Apptainer agent sandbox %s", sandbox)
-        return BuildOutput(base_image=base_image, tags=[str(sandbox)], error=None)
+    image_path = apptainer_agent_image_path(custom_tag, target)
+    if image_path.exists() and not _force_build_enabled():
+        logger.info("Using existing Apptainer agent SIF %s", image_path)
+        return BuildOutput(base_image=base_image, tags=[str(image_path)], error=None)
 
     build_root = _build_root()
     log_dir = build_root / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     build_root.mkdir(parents=True, exist_ok=True)
 
-    tmp_sandbox = sandbox.with_suffix(".tmp")
-    if tmp_sandbox.exists():
-        shutil.rmtree(tmp_sandbox)
-    if sandbox.exists():
-        shutil.rmtree(sandbox)
+    tmp_image = image_path.with_suffix(".tmp.sif")
+    _remove_path(tmp_image)
+    _remove_path(image_path)
 
     git_ref, git_sha, _ = _get_sdk_submodule_info()
-    definition = build_root / f"{sandbox.name}.def"
+    definition = build_root / f"{image_path.name}.def"
     definition.write_text(
         _definition_file_content(
             base_image=base_image,
@@ -255,9 +270,9 @@ def build_apptainer_agent_image(
         )
     )
 
-    log_path = log_dir / f"{sandbox.name}.log"
-    cmd = ["apptainer", "build", "--sandbox", str(tmp_sandbox), str(definition)]
-    logger.info("Building Apptainer agent sandbox: %s", " ".join(cmd))
+    log_path = log_dir / f"{image_path.name}.log"
+    cmd = ["apptainer", "build", str(tmp_image), str(definition)]
+    logger.info("Building Apptainer agent SIF: %s", " ".join(cmd))
     env = os.environ.copy()
     if "APPTAINER_CACHEDIR" not in env:
         env["APPTAINER_CACHEDIR"] = str(build_root / "cache")
@@ -273,7 +288,7 @@ def build_apptainer_agent_image(
     )
     log_path.write_text(proc.stdout)
     if proc.returncode != 0:
-        shutil.rmtree(tmp_sandbox, ignore_errors=True)
+        _remove_path(tmp_image)
         return BuildOutput(
             base_image=base_image,
             tags=[],
@@ -281,11 +296,11 @@ def build_apptainer_agent_image(
             log_path=str(log_path),
         )
 
-    tmp_sandbox.rename(sandbox)
-    logger.info("Built Apptainer agent sandbox %s", sandbox)
+    tmp_image.rename(image_path)
+    logger.info("Built Apptainer agent SIF %s", image_path)
     return BuildOutput(
         base_image=base_image,
-        tags=[str(sandbox)],
+        tags=[str(image_path)],
         error=None,
         log_path=str(log_path),
     )
@@ -297,7 +312,7 @@ def ensure_apptainer_agent_image(
     target: constants.TargetType = constants.DEFAULT_BUILD_TARGET,
     wrap_swebench_deps: bool = False,
 ) -> Path:
-    """Build or reuse a local Apptainer agent-server sandbox."""
+    """Build or reuse a local Apptainer agent-server SIF."""
     output = build_apptainer_agent_image(
         base_image=base_image,
         custom_tag=custom_tag,

--- a/benchmarks/swebench/build_images.py
+++ b/benchmarks/swebench/build_images.py
@@ -14,6 +14,7 @@ Example:
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -37,6 +38,16 @@ def get_official_docker_image(
     instance_id: str,
     docker_image_prefix: str = constants.DOCKER_IMAGE_PREFIX,
 ) -> str:
+    image_template = os.getenv("OPENHANDS_SWEBENCH_IMAGE_TEMPLATE")
+    if image_template:
+        repo, name = instance_id.split("__")
+        return image_template.format(
+            instance_id=instance_id,
+            repo=repo,
+            name=name,
+            arch="x86_64",
+        )
+
     # Official SWE-Bench image
     # swebench/sweb.eval.x86_64.django_1776_django-11333:v1
     repo, name = instance_id.split("__")

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -136,12 +136,19 @@ class SWEBenchEvaluation(Evaluation):
                 f"openhands-apptainer-workspaces-{os.getuid()}",
             )
         safe_instance_id = instance.id.replace("/", "__")
-        mount_dir = os.path.join(
-            workspace_root,
-            f"{safe_instance_id}-attempt{self.current_attempt}-{uuid.uuid4().hex[:8]}",
+        for _ in range(3):
+            mount_dir = os.path.join(
+                workspace_root,
+                f"{safe_instance_id}-attempt{self.current_attempt}-{uuid.uuid4().hex[:8]}",
+            )
+            try:
+                os.makedirs(mount_dir, mode=0o700, exist_ok=False)
+                return mount_dir
+            except FileExistsError:
+                continue
+        raise RuntimeError(
+            f"Could not create a unique Apptainer workspace under {workspace_root}"
         )
-        os.makedirs(mount_dir, mode=0o700, exist_ok=False)
-        return mount_dir
 
     def prepare_instances(self) -> List[EvalInstance]:
         logger.info("Setting up SWE-bench evaluation data")

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -136,10 +136,9 @@ class SWEBenchEvaluation(Evaluation):
                 f"openhands-apptainer-workspaces-{os.getuid()}",
             )
         safe_instance_id = instance.id.replace("/", "__")
-        current_attempt = getattr(self, "current_attempt", 1)
         mount_dir = os.path.join(
             workspace_root,
-            f"{safe_instance_id}-attempt{current_attempt}-{uuid.uuid4().hex[:8]}",
+            f"{safe_instance_id}-attempt{self.current_attempt}-{uuid.uuid4().hex[:8]}",
         )
         os.makedirs(mount_dir, mode=0o700, exist_ok=False)
         return mount_dir

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -1,5 +1,7 @@
 import json
 import os
+import tempfile
+import uuid
 from typing import Any, List
 
 from jinja2 import Environment, FileSystemLoader
@@ -125,6 +127,23 @@ class SWEBenchEvaluation(Evaluation):
                 )
         return bind_mounts
 
+    def get_apptainer_mount_dir(self, instance: EvalInstance) -> str:
+        """Return a writable host directory to bind onto /workspace."""
+        workspace_root = os.getenv("OPENHANDS_APPTAINER_WORKSPACE_ROOT")
+        if not workspace_root:
+            workspace_root = os.path.join(
+                tempfile.gettempdir(),
+                f"openhands-apptainer-workspaces-{os.getuid()}",
+            )
+        safe_instance_id = instance.id.replace("/", "__")
+        current_attempt = getattr(self, "current_attempt", 1)
+        mount_dir = os.path.join(
+            workspace_root,
+            f"{safe_instance_id}-attempt{current_attempt}-{uuid.uuid4().hex[:8]}",
+        )
+        os.makedirs(mount_dir, mode=0o700, exist_ok=False)
+        return mount_dir
+
     def prepare_instances(self) -> List[EvalInstance]:
         logger.info("Setting up SWE-bench evaluation data")
 
@@ -214,6 +233,7 @@ class SWEBenchEvaluation(Evaluation):
                 workspace = ApptainerWorkspace(
                     server_image=agent_server_image,
                     working_dir="/workspace",
+                    mount_dir=self.get_apptainer_mount_dir(instance),
                     forward_env=forward_env or [],
                     extra_bind_mounts=self.get_apptainer_extra_bind_mounts(),
                     cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
@@ -234,6 +254,7 @@ class SWEBenchEvaluation(Evaluation):
                 workspace = ApptainerWorkspace(
                     sif_file=str(local_agent_image),
                     working_dir="/workspace",
+                    mount_dir=self.get_apptainer_mount_dir(instance),
                     forward_env=forward_env or [],
                     extra_bind_mounts=self.get_apptainer_extra_bind_mounts(),
                     cache_dir=os.getenv("APPTAINER_CACHEDIR", None),

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -221,7 +221,7 @@ class SWEBenchEvaluation(Evaluation):
             else:
                 logger.info(
                     "Agent server image %s is not available in the registry; "
-                    "building a local Apptainer sandbox from %s",
+                    "building a local Apptainer SIF from %s",
                     agent_server_image,
                     official_docker_image,
                 )

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -5,6 +5,7 @@ from typing import Any, List
 from jinja2 import Environment, FileSystemLoader
 
 from benchmarks.swebench import constants
+from benchmarks.swebench.apptainer_build import ensure_apptainer_agent_image
 from benchmarks.swebench.build_images import (
     extract_custom_tag,
     get_official_docker_image,
@@ -181,27 +182,44 @@ class SWEBenchEvaluation(Evaluation):
                 forward_env=forward_env or [],
             )
         elif self.metadata.workspace_type == "apptainer":
-            if not remote_image_exists(agent_server_image):
-                raise RuntimeError(
-                    f"Agent server image {agent_server_image} does not exist in container registry, "
-                    "make sure to build, push it, and make it public accessible before using apptainer workspace."
-                )
-
-            logger.info(
-                f"Using apptainer workspace with pre-built image {agent_server_image} "
-                f"(tag prefix: {get_phased_image_tag_prefix()})"
-            )
-            if wrap_needed:
+            force_local_build = os.getenv(
+                "OPENHANDS_APPTAINER_FORCE_BUILD", ""
+            ).lower() in {"1", "true", "yes"}
+            if not force_local_build and remote_image_exists(agent_server_image):
                 logger.info(
-                    "Skipping local wrap for apptainer workspace; expecting image to be pre-wrapped in registry"
+                    f"Using apptainer workspace with pre-built image {agent_server_image} "
+                    f"(tag prefix: {get_phased_image_tag_prefix()})"
                 )
+                if wrap_needed:
+                    logger.info(
+                        "Using pre-built wrapped apptainer image for wrapped repo"
+                    )
 
-            workspace = ApptainerWorkspace(
-                server_image=agent_server_image,
-                working_dir="/workspace",
-                forward_env=forward_env or [],
-                cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
-            )
+                workspace = ApptainerWorkspace(
+                    server_image=agent_server_image,
+                    working_dir="/workspace",
+                    forward_env=forward_env or [],
+                    cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
+                )
+            else:
+                logger.info(
+                    "Agent server image %s is not available in the registry; "
+                    "building a local Apptainer sandbox from %s",
+                    agent_server_image,
+                    official_docker_image,
+                )
+                local_agent_image = ensure_apptainer_agent_image(
+                    base_image=official_docker_image,
+                    custom_tag=custom_tag,
+                    target=build_target,
+                    wrap_swebench_deps=wrap_needed,
+                )
+                workspace = ApptainerWorkspace(
+                    sif_file=str(local_agent_image),
+                    working_dir="/workspace",
+                    forward_env=forward_env or [],
+                    cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
+                )
         elif self.metadata.workspace_type == "remote":
             runtime_api_key = os.getenv("RUNTIME_API_KEY")
             if not runtime_api_key:

--- a/benchmarks/swebench/run_infer.py
+++ b/benchmarks/swebench/run_infer.py
@@ -109,6 +109,22 @@ class SWEBenchEvaluation(Evaluation):
     def get_source_repo_path(self, instance: EvalInstance) -> str:
         return "/testbed"
 
+    def get_apptainer_extra_bind_mounts(self) -> list[str]:
+        """Return host paths that must be visible inside Apptainer agent servers."""
+        bind_mounts: list[str] = []
+        custom_tokenizer = self.metadata.llm.custom_tokenizer
+        if custom_tokenizer:
+            tokenizer_path = os.path.abspath(os.path.expanduser(custom_tokenizer))
+            if os.path.exists(tokenizer_path):
+                bind_mounts.append(f"{tokenizer_path}:{tokenizer_path}:ro")
+            else:
+                logger.warning(
+                    "custom_tokenizer path %s does not exist on host; "
+                    "not adding an Apptainer bind mount",
+                    custom_tokenizer,
+                )
+        return bind_mounts
+
     def prepare_instances(self) -> List[EvalInstance]:
         logger.info("Setting up SWE-bench evaluation data")
 
@@ -199,6 +215,7 @@ class SWEBenchEvaluation(Evaluation):
                     server_image=agent_server_image,
                     working_dir="/workspace",
                     forward_env=forward_env or [],
+                    extra_bind_mounts=self.get_apptainer_extra_bind_mounts(),
                     cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
                 )
             else:
@@ -218,6 +235,7 @@ class SWEBenchEvaluation(Evaluation):
                     sif_file=str(local_agent_image),
                     working_dir="/workspace",
                     forward_env=forward_env or [],
+                    extra_bind_mounts=self.get_apptainer_extra_bind_mounts(),
                     cache_dir=os.getenv("APPTAINER_CACHEDIR", None),
                 )
         elif self.metadata.workspace_type == "remote":
@@ -290,9 +308,23 @@ class SWEBenchEvaluation(Evaluation):
                 tools.append(Tool(name=TaskToolSet.name))
             condenser = None
             if self.metadata.enable_condenser:
+                condenser_llm = build_eval_llm(
+                    self.metadata.llm,
+                    usage_id="condenser",
+                )
+                if self.metadata.condenser_max_output_tokens is not None:
+                    condenser_llm = condenser_llm.model_copy(
+                        deep=True,
+                        update={
+                            "max_output_tokens": (
+                                self.metadata.condenser_max_output_tokens
+                            ),
+                        },
+                    )
                 condenser = LLMSummarizingCondenser(
-                    llm=build_eval_llm(self.metadata.llm, usage_id="condenser"),
+                    llm=condenser_llm,
                     max_size=self.metadata.condenser_max_size,
+                    max_tokens=self.metadata.condenser_max_tokens,
                     keep_first=self.metadata.condenser_keep_first,
                 )
             # Load public skills (respects EXTENSIONS_REF env var)
@@ -458,6 +490,8 @@ def main() -> None:
         agent_type=args.agent_type,
         enable_condenser=enable_condenser,
         condenser_max_size=args.condenser_max_size,
+        condenser_max_tokens=args.condenser_max_tokens,
+        condenser_max_output_tokens=args.condenser_max_output_tokens,
         condenser_keep_first=args.condenser_keep_first,
     )
 

--- a/benchmarks/utils/args_parser.py
+++ b/benchmarks/utils/args_parser.py
@@ -125,6 +125,16 @@ def get_parser(add_llm_config: bool = True) -> argparse.ArgumentParser:
         help="Maximum number of events before the condenser activates",
     )
     parser.add_argument(
+        "--condenser-max-tokens",
+        type=int,
+        help="Maximum number of prompt tokens before the condenser activates",
+    )
+    parser.add_argument(
+        "--condenser-max-output-tokens",
+        type=int,
+        help="Maximum output tokens for LLM-generated condenser summaries",
+    )
+    parser.add_argument(
         "--condenser-keep-first",
         type=int,
         help="Number of initial events to always keep when condensing",

--- a/benchmarks/utils/models.py
+++ b/benchmarks/utils/models.py
@@ -87,6 +87,16 @@ class EvalMetadata(BaseModel):
         ge=1,
         description="Maximum number of events before the condenser activates",
     )
+    condenser_max_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of prompt tokens before the condenser activates",
+    )
+    condenser_max_output_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum output tokens for LLM-generated condenser summaries",
+    )
     condenser_keep_first: int = Field(
         default=2,
         ge=0,

--- a/tests/test_condenser_config.py
+++ b/tests/test_condenser_config.py
@@ -112,10 +112,14 @@ def test_eval_metadata_accepts_condenser_params():
         critic=PassCritic(),
         enable_condenser=True,
         condenser_max_size=100,
+        condenser_max_tokens=12345,
+        condenser_max_output_tokens=512,
         condenser_keep_first=5,
     )
     assert metadata.enable_condenser is True
     assert metadata.condenser_max_size == 100
+    assert metadata.condenser_max_tokens == 12345
+    assert metadata.condenser_max_output_tokens == 512
     assert metadata.condenser_keep_first == 5
 
 
@@ -132,6 +136,8 @@ def test_eval_metadata_condenser_defaults():
     # Should use default values defined in EvalMetadata
     assert metadata.enable_condenser is True
     assert metadata.condenser_max_size == 240
+    assert metadata.condenser_max_tokens is None
+    assert metadata.condenser_max_output_tokens is None
     assert metadata.condenser_keep_first == 2
 
 
@@ -143,6 +149,8 @@ def test_args_parser_has_condenser_args():
     assert hasattr(args, "enable_condenser")
     assert hasattr(args, "disable_condenser")
     assert hasattr(args, "condenser_max_size")
+    assert hasattr(args, "condenser_max_tokens")
+    assert hasattr(args, "condenser_max_output_tokens")
     assert hasattr(args, "condenser_keep_first")
 
 
@@ -168,7 +176,18 @@ def test_condenser_size_args():
     """Test that condenser size arguments can be set."""
     parser = get_parser(add_llm_config=False)
     args = parser.parse_args(
-        ["--condenser-max-size", "120", "--condenser-keep-first", "10"]
+        [
+            "--condenser-max-size",
+            "120",
+            "--condenser-max-tokens",
+            "28000",
+            "--condenser-max-output-tokens",
+            "1024",
+            "--condenser-keep-first",
+            "10",
+        ]
     )
     assert args.condenser_max_size == 120
+    assert args.condenser_max_tokens == 28000
+    assert args.condenser_max_output_tokens == 1024
     assert args.condenser_keep_first == 10

--- a/tests/test_swebench_apptainer_build.py
+++ b/tests/test_swebench_apptainer_build.py
@@ -1,0 +1,85 @@
+"""Tests for SWE-bench Apptainer image build fallback."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from benchmarks.swebench import apptainer_build, run_infer as swebench_run_infer
+from benchmarks.utils.models import EvalInstance
+
+
+class FakeApptainerWorkspace:
+    """Capture ApptainerWorkspace constructor arguments."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _evaluation():
+    metadata = SimpleNamespace(
+        workspace_type="apptainer",
+        agent_type="default",
+        env_setup_commands=[],
+    )
+    evaluation = object.__new__(swebench_run_infer.SWEBenchEvaluation)
+    object.__setattr__(evaluation, "metadata", metadata)
+    return evaluation
+
+
+def test_unsupported_apptainer_build_target_returns_error():
+    output = apptainer_build.build_apptainer_agent_image(
+        base_image="docker.io/swebench/example:latest",
+        custom_tag="example",
+        target="binary",
+    )
+
+    assert output.tags == []
+    assert output.error is not None
+    assert "source-minimal" in output.error
+
+
+def test_apptainer_workspace_uses_registry_image_when_available(monkeypatch):
+    monkeypatch.setattr(swebench_run_infer, "remote_image_exists", lambda image: True)
+    monkeypatch.setattr(
+        swebench_run_infer,
+        "ApptainerWorkspace",
+        FakeApptainerWorkspace,
+    )
+
+    workspace = _evaluation().prepare_workspace(
+        EvalInstance(id="django__django-12345", data={})
+    )
+
+    assert "server_image" in workspace.kwargs
+    assert "sif_file" not in workspace.kwargs
+
+
+def test_apptainer_workspace_builds_local_sandbox_when_registry_image_missing(
+    monkeypatch,
+):
+    built = {}
+
+    def fake_build(**kwargs):
+        built.update(kwargs)
+        return Path("/tmp/local-agent.sandbox")
+
+    monkeypatch.setattr(swebench_run_infer, "remote_image_exists", lambda image: False)
+    monkeypatch.setattr(
+        swebench_run_infer,
+        "ensure_apptainer_agent_image",
+        fake_build,
+    )
+    monkeypatch.setattr(
+        swebench_run_infer,
+        "ApptainerWorkspace",
+        FakeApptainerWorkspace,
+    )
+
+    workspace = _evaluation().prepare_workspace(
+        EvalInstance(id="django__django-12345", data={})
+    )
+
+    assert workspace.kwargs["sif_file"] == "/tmp/local-agent.sandbox"
+    assert "server_image" not in workspace.kwargs
+    assert built["base_image"].startswith("docker.io/swebench/")
+    assert built["custom_tag"] == "sweb.eval.x86_64.django_1776_django-12345"
+    assert built["target"] == "source-minimal"

--- a/tests/test_swebench_apptainer_build.py
+++ b/tests/test_swebench_apptainer_build.py
@@ -28,6 +28,7 @@ def _evaluation():
     )
     evaluation = object.__new__(swebench_run_infer.SWEBenchEvaluation)
     object.__setattr__(evaluation, "metadata", metadata)
+    object.__setattr__(evaluation, "current_attempt", 1)
     return evaluation
 
 

--- a/tests/test_swebench_apptainer_build.py
+++ b/tests/test_swebench_apptainer_build.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from benchmarks.swebench import apptainer_build, run_infer as swebench_run_infer
+from benchmarks.swebench import (
+    apptainer_build,
+    build_images,
+    run_infer as swebench_run_infer,
+)
 from benchmarks.utils.models import EvalInstance
 
 
@@ -95,14 +99,14 @@ def test_apptainer_workspace_binds_existing_custom_tokenizer(monkeypatch, tmp_pa
     ]
 
 
-def test_apptainer_workspace_builds_local_sandbox_when_registry_image_missing(
+def test_apptainer_workspace_builds_local_sif_when_registry_image_missing(
     monkeypatch,
 ):
     built = {}
 
     def fake_build(**kwargs):
         built.update(kwargs)
-        return Path("/tmp/local-agent.sandbox")
+        return Path("/tmp/local-agent.sif")
 
     monkeypatch.setattr(swebench_run_infer, "remote_image_exists", lambda image: False)
     monkeypatch.setattr(
@@ -121,9 +125,22 @@ def test_apptainer_workspace_builds_local_sandbox_when_registry_image_missing(
     )
 
     assert isinstance(workspace, FakeApptainerWorkspace)
-    assert workspace.kwargs["sif_file"] == "/tmp/local-agent.sandbox"
+    assert workspace.kwargs["sif_file"] == "/tmp/local-agent.sif"
     assert "server_image" not in workspace.kwargs
     assert workspace.kwargs["extra_bind_mounts"] == []
     assert built["base_image"].startswith("docker.io/swebench/")
     assert built["custom_tag"] == "sweb.eval.x86_64.django_1776_django-12345"
     assert built["target"] == "source-minimal"
+
+
+def test_swebench_image_template_overrides_official_image(monkeypatch):
+    monkeypatch.setenv(
+        "OPENHANDS_SWEBENCH_IMAGE_TEMPLATE",
+        "ghcr.io/epoch-research/swe-bench.eval.{arch}.{instance_id}:latest",
+    )
+
+    assert (
+        build_images.get_official_docker_image("astropy__astropy-12907")
+        == "ghcr.io/epoch-research/"
+        "swe-bench.eval.x86_64.astropy__astropy-12907:latest"
+    )

--- a/tests/test_swebench_apptainer_build.py
+++ b/tests/test_swebench_apptainer_build.py
@@ -58,6 +58,39 @@ def test_apptainer_definition_installs_transformers_for_token_counting():
     )
 
 
+def test_failed_forced_apptainer_rebuild_keeps_existing_sif(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENHANDS_APPTAINER_BUILD_ROOT", str(tmp_path))
+    monkeypatch.setenv("OPENHANDS_APPTAINER_FORCE_BUILD", "1")
+    monkeypatch.setattr(
+        apptainer_build,
+        "_get_sdk_submodule_info",
+        lambda: ("main", "abcdef123456", ""),
+    )
+    monkeypatch.setattr(apptainer_build, "dockerfile_content_hash", lambda: "hash")
+    monkeypatch.setattr(
+        apptainer_build.shutil,
+        "which",
+        lambda name: f"/usr/bin/{name}" if name in {"apptainer", "uv", "uvx"} else None,
+    )
+    monkeypatch.setattr(
+        apptainer_build.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=42, stdout="build failed"),
+    )
+
+    existing_image = apptainer_build.apptainer_agent_image_path("tag")
+    existing_image.parent.mkdir(parents=True, exist_ok=True)
+    existing_image.write_text("old working image")
+
+    output = apptainer_build.build_apptainer_agent_image(
+        base_image="docker.io/swebench/example:latest",
+        custom_tag="tag",
+    )
+
+    assert output.error == "Apptainer build failed with exit code 42"
+    assert existing_image.read_text() == "old working image"
+
+
 def test_apptainer_workspace_uses_registry_image_when_available(monkeypatch):
     monkeypatch.setattr(swebench_run_infer, "remote_image_exists", lambda image: True)
     monkeypatch.setattr(

--- a/tests/test_swebench_apptainer_build.py
+++ b/tests/test_swebench_apptainer_build.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 from benchmarks.swebench import apptainer_build, run_infer as swebench_run_infer
 from benchmarks.utils.models import EvalInstance
@@ -10,7 +11,7 @@ from benchmarks.utils.models import EvalInstance
 class FakeApptainerWorkspace:
     """Capture ApptainerWorkspace constructor arguments."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
 
 
@@ -65,6 +66,7 @@ def test_apptainer_workspace_uses_registry_image_when_available(monkeypatch):
         EvalInstance(id="django__django-12345", data={})
     )
 
+    assert isinstance(workspace, FakeApptainerWorkspace)
     assert "server_image" in workspace.kwargs
     assert "sif_file" not in workspace.kwargs
     assert workspace.kwargs["extra_bind_mounts"] == []
@@ -87,6 +89,7 @@ def test_apptainer_workspace_binds_existing_custom_tokenizer(monkeypatch, tmp_pa
         EvalInstance(id="django__django-12345", data={})
     )
 
+    assert isinstance(workspace, FakeApptainerWorkspace)
     assert workspace.kwargs["extra_bind_mounts"] == [
         f"{tokenizer_dir}:{tokenizer_dir}:ro"
     ]
@@ -117,6 +120,7 @@ def test_apptainer_workspace_builds_local_sandbox_when_registry_image_missing(
         EvalInstance(id="django__django-12345", data={})
     )
 
+    assert isinstance(workspace, FakeApptainerWorkspace)
     assert workspace.kwargs["sif_file"] == "/tmp/local-agent.sandbox"
     assert "server_image" not in workspace.kwargs
     assert workspace.kwargs["extra_bind_mounts"] == []

--- a/tests/test_swebench_apptainer_build.py
+++ b/tests/test_swebench_apptainer_build.py
@@ -19,6 +19,7 @@ def _evaluation():
         workspace_type="apptainer",
         agent_type="default",
         env_setup_commands=[],
+        llm=SimpleNamespace(custom_tokenizer=None),
     )
     evaluation = object.__new__(swebench_run_infer.SWEBenchEvaluation)
     object.__setattr__(evaluation, "metadata", metadata)
@@ -37,6 +38,21 @@ def test_unsupported_apptainer_build_target_returns_error():
     assert "source-minimal" in output.error
 
 
+def test_apptainer_definition_installs_transformers_for_token_counting():
+    definition = apptainer_build._definition_file_content(
+        base_image="docker.io/swebench/example:latest",
+        git_sha="abc123",
+        git_ref="main",
+        wrap_swebench_deps=False,
+        uv_path=Path("/usr/local/bin/uv"),
+        uvx_path=None,
+    )
+
+    assert 'uv pip install --python /agent-server/.venv/bin/python "transformers' in (
+        definition
+    )
+
+
 def test_apptainer_workspace_uses_registry_image_when_available(monkeypatch):
     monkeypatch.setattr(swebench_run_infer, "remote_image_exists", lambda image: True)
     monkeypatch.setattr(
@@ -51,6 +67,29 @@ def test_apptainer_workspace_uses_registry_image_when_available(monkeypatch):
 
     assert "server_image" in workspace.kwargs
     assert "sif_file" not in workspace.kwargs
+    assert workspace.kwargs["extra_bind_mounts"] == []
+
+
+def test_apptainer_workspace_binds_existing_custom_tokenizer(monkeypatch, tmp_path):
+    tokenizer_dir = tmp_path / "tokenizer"
+    tokenizer_dir.mkdir()
+    evaluation = _evaluation()
+    evaluation.metadata.llm.custom_tokenizer = str(tokenizer_dir)
+
+    monkeypatch.setattr(swebench_run_infer, "remote_image_exists", lambda image: True)
+    monkeypatch.setattr(
+        swebench_run_infer,
+        "ApptainerWorkspace",
+        FakeApptainerWorkspace,
+    )
+
+    workspace = evaluation.prepare_workspace(
+        EvalInstance(id="django__django-12345", data={})
+    )
+
+    assert workspace.kwargs["extra_bind_mounts"] == [
+        f"{tokenizer_dir}:{tokenizer_dir}:ro"
+    ]
 
 
 def test_apptainer_workspace_builds_local_sandbox_when_registry_image_missing(
@@ -80,6 +119,7 @@ def test_apptainer_workspace_builds_local_sandbox_when_registry_image_missing(
 
     assert workspace.kwargs["sif_file"] == "/tmp/local-agent.sandbox"
     assert "server_image" not in workspace.kwargs
+    assert workspace.kwargs["extra_bind_mounts"] == []
     assert built["base_image"].startswith("docker.io/swebench/")
     assert built["custom_tag"] == "sweb.eval.x86_64.django_1776_django-12345"
     assert built["target"] == "source-minimal"

--- a/tests/test_swebench_apptainer_mount_dir.py
+++ b/tests/test_swebench_apptainer_mount_dir.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from types import SimpleNamespace
 
+from benchmarks.swebench import run_infer as swebench_run_infer
 from benchmarks.swebench.run_infer import SWEBenchEvaluation
 from benchmarks.utils.models import EvalInstance, EvalMetadata
 from openhands.sdk import LLM
@@ -48,4 +50,29 @@ def test_apptainer_mount_dir_uses_default_current_attempt(monkeypatch, tmp_path)
     assert evaluation.current_attempt == 1
     assert mount_dir.parent == tmp_path / "workspaces"
     assert mount_dir.name.startswith("django__django-12345-attempt1-")
+    assert mount_dir.is_dir()
+
+
+def test_apptainer_mount_dir_retries_uuid_collision(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENHANDS_APPTAINER_WORKSPACE_ROOT", str(tmp_path))
+    uuids = iter(
+        [
+            SimpleNamespace(hex="abc12345deadbeef"),
+            SimpleNamespace(hex="def67890deadbeef"),
+        ]
+    )
+    monkeypatch.setattr(swebench_run_infer.uuid, "uuid4", lambda: next(uuids))
+
+    evaluation = object.__new__(SWEBenchEvaluation)
+    object.__setattr__(evaluation, "current_attempt", 2)
+    existing_mount_dir = tmp_path / "django__django-12345-attempt2-abc12345"
+    existing_mount_dir.mkdir()
+
+    mount_dir = Path(
+        evaluation.get_apptainer_mount_dir(
+            EvalInstance(id="django__django-12345", data={})
+        )
+    )
+
+    assert mount_dir == tmp_path / "django__django-12345-attempt2-def67890"
     assert mount_dir.is_dir()

--- a/tests/test_swebench_apptainer_mount_dir.py
+++ b/tests/test_swebench_apptainer_mount_dir.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
 from benchmarks.swebench.run_infer import SWEBenchEvaluation
-from benchmarks.utils.models import EvalInstance
+from benchmarks.utils.models import EvalInstance, EvalMetadata
+from openhands.sdk import LLM
+from openhands.sdk.critic import PassCritic
 
 
 def test_apptainer_mount_dir_uses_writable_env_root(monkeypatch, tmp_path):
@@ -18,4 +20,32 @@ def test_apptainer_mount_dir_uses_writable_env_root(monkeypatch, tmp_path):
 
     assert mount_dir.parent == tmp_path
     assert mount_dir.name.startswith("django__django-12345-attempt2-")
+    assert mount_dir.is_dir()
+
+
+def test_apptainer_mount_dir_uses_default_current_attempt(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "OPENHANDS_APPTAINER_WORKSPACE_ROOT", str(tmp_path / "workspaces")
+    )
+
+    evaluation = SWEBenchEvaluation(
+        metadata=EvalMetadata(
+            llm=LLM(model="test-model"),
+            dataset="test",
+            max_iterations=1,
+            eval_output_dir=str(tmp_path / "output"),
+            details={},
+            critic=PassCritic(),
+        )
+    )
+
+    mount_dir = Path(
+        evaluation.get_apptainer_mount_dir(
+            EvalInstance(id="django__django-12345", data={})
+        )
+    )
+
+    assert evaluation.current_attempt == 1
+    assert mount_dir.parent == tmp_path / "workspaces"
+    assert mount_dir.name.startswith("django__django-12345-attempt1-")
     assert mount_dir.is_dir()

--- a/tests/test_swebench_apptainer_mount_dir.py
+++ b/tests/test_swebench_apptainer_mount_dir.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from benchmarks.swebench.run_infer import SWEBenchEvaluation
+from benchmarks.utils.models import EvalInstance
+
+
+def test_apptainer_mount_dir_uses_writable_env_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENHANDS_APPTAINER_WORKSPACE_ROOT", str(tmp_path))
+
+    evaluation = object.__new__(SWEBenchEvaluation)
+    object.__setattr__(evaluation, "current_attempt", 2)
+
+    mount_dir = Path(
+        evaluation.get_apptainer_mount_dir(
+            EvalInstance(id="django__django-12345", data={})
+        )
+    )
+
+    assert mount_dir.parent == tmp_path
+    assert mount_dir.name.startswith("django__django-12345-attempt2-")
+    assert mount_dir.is_dir()

--- a/uv.lock
+++ b/uv.lock
@@ -2573,13 +2573,14 @@ wheels = [
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.24.0"
+version = "1.27.0"
 source = { editable = "vendor/software-agent-sdk/openhands-agent-server" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "docker" },
     { name = "fastapi" },
+    { name = "openai" },
     { name = "openhands-sdk" },
     { name = "pydantic" },
     { name = "sqlalchemy" },
@@ -2594,6 +2595,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "docker", specifier = ">=7.1,<8" },
     { name = "fastapi", specifier = ">=0.104" },
+    { name = "openai", specifier = ">=2.33.0,<3" },
     { name = "openhands-sdk", editable = "vendor/software-agent-sdk/openhands-sdk" },
     { name = "pydantic", specifier = ">=2" },
     { name = "sqlalchemy", specifier = ">=2" },
@@ -2719,7 +2721,7 @@ dev = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.24.0"
+version = "1.27.0"
 source = { editable = "vendor/software-agent-sdk/openhands-sdk" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2771,7 +2773,7 @@ provides-extras = ["boto3"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.24.0"
+version = "1.27.0"
 source = { editable = "vendor/software-agent-sdk/openhands-tools" }
 dependencies = [
     { name = "binaryornot" },
@@ -2802,7 +2804,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-workspace"
-version = "1.24.0"
+version = "1.27.0"
 source = { editable = "vendor/software-agent-sdk/openhands-workspace" }
 dependencies = [
     { name = "openhands-agent-server" },


### PR DESCRIPTION
## Summary
- add local Apptainer agent-server SIF builds for SWE-bench images when the matching registry image is missing
- reuse local SIFs by SDK SHA, Dockerfile content hash, SWE-bench image tag, and build target
- install `transformers` into built agent-server SIFs so HF chat-template token counting works inside Apptainer
- bind host `custom_tokenizer` paths into Apptainer workspaces and pass condenser token/output limits through the SWE-bench harness
- bind a per-instance writable host directory onto `/workspace` for Apptainer inference so repo setup does not depend on mutating the SIF filesystem under fakeroot/compat mode
- update `vendor/software-agent-sdk` to `43376f18`, which is proposed in OpenHands/software-agent-sdk#3641

## Scope
This PR contains Apptainer/HPC runtime and image-building support for SWE-bench. Generic failed-run patch capture is split out into OpenHands/benchmarks#751 so it can be reviewed independently and applies to Docker as well.

## Validation
- `IMAGE_TAG_PREFIX=test PYTHONPATH="$PWD" /home/gneubig/work/openhands-benchmarks-venv/bin/python -m pytest tests/test_swebench_apptainer_build.py tests/test_swebench_apptainer_mount_dir.py tests/test_condenser_config.py -q`
- prior validation from the same branch: py_compile, ruff check, and ruff format check on the touched benchmark files
- ADP full SWE-bench run is currently using these Apptainer runtime/image changes with 2x L40S and 4 workers; no missing-image or `/workspace` permission failures are currently observed.

Note: the local alternate worktree does not have the SDK submodule checked out, so `IMAGE_TAG_PREFIX=test` is used for the focused test command to avoid reading the SDK Dockerfile only for image tag construction.

## Issue

Closes #746
