### PR TITLE
Fix conda activation in SWE-bench prompts: source absolute path

### DIFF
--- a/benchmarks/swebench/prompts/default.j2
+++ b/benchmarks/swebench/prompts/default.j2
@@ -20,7 +20,7 @@ Phase 1. READING: read the problem and reword it in clearer terms
 
 Phase 2. RUNNING: install and run the tests on the repository
    2.1 Activate the environment by running  
-       ./opt/miniconda3/etc/profile.d/conda.sh ; conda activate testbed
+       source /opt/miniconda3/etc/profile.d/conda.sh ; conda activate testbed
    2.2 Follow the readme
    2.3 Install the environment and anything needed
    2.4 Iterate and figure out how to run the tests

--- a/benchmarks/swebenchmultilingual/prompts/default.j2
+++ b/benchmarks/swebenchmultilingual/prompts/default.j2
@@ -20,7 +20,7 @@ Phase 1. READING: read the problem and reword it in clearer terms
 
 Phase 2. RUNNING: install and run the tests on the repository
    2.1 Activate the environment by running  
-       ./opt/miniconda3/etc/profile.d/conda.sh ; conda activate testbed
+       source /opt/miniconda3/etc/profile.d/conda.sh ; conda activate testbed
    2.2 Follow the readme
    2.3 Install the environment and anything needed
    2.4 Iterate and figure out how to run the tests


### PR DESCRIPTION
## What

Fixes the conda-activation line in the `swebench` and `swebenchmultilingual` default prompts:

```diff
-       ./opt/miniconda3/etc/profile.d/conda.sh ; conda activate testbed
+       source /opt/miniconda3/etc/profile.d/conda.sh ; conda activate testbed
```

## Why

`./opt/miniconda3/...` is a **relative** path (resolved against the agent's cwd `/workspace/<repo>/`, where it does not exist) and it **executes** the script instead of `source`-ing it, so it cannot activate `testbed` in the agent's shell. `benchmarks/swefficiency/prompts/default.j2` already uses the correct `. /opt/...` form; this aligns the other two.

This was harmless while the runtime auto-activated `testbed`, but under the v1.24.0 agent-server (agent runs as the non-root `openhands` user, so the base image's `/root/.bashrc` auto-activation never fires) the shell starts in base conda and this broken line is the only activation path. Weak models copy it verbatim and fail; strong models work around it.

Minimal, prompt-only change. Closes #753. Related: #698.
