### PR TITLE
feat(eval): build SWE-bench-style eval instances from PR-linked captures (ALL-2451)

### DIFF
--- a/benchmarks/scripts/pr_to_eval_instance.py
+++ b/benchmarks/scripts/pr_to_eval_instance.py
@@ -1,0 +1,71 @@
+"""Emit a SWE-bench-style eval-instance row from a GitHub PR (ALL-2451).
+
+Intended to run from the PR-merge capture job: clone/inspect the PR, then call
+this to append an eval instance to a dataset. Reads a GitHub PR JSON payload
+(as produced by ``gh pr view <n> --json number,title,body,baseRefOid,headRefOid,url``
+or the REST API) from a file or stdin.
+
+Examples:
+    gh pr view 123 --repo owner/repo \\
+        --json number,title,body,baseRefOid,headRefOid,url \\
+        | python -m benchmarks.scripts.pr_to_eval_instance \\
+            --repo owner/repo --base-commit <sha> --out instances.jsonl
+"""
+
+import argparse
+import json
+import sys
+
+from benchmarks.utils.pr_snapshot import (
+    build_swebench_instance,
+    pr_snapshot_from_github_json,
+    write_instances_jsonl,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pr-json",
+        help="Path to a GitHub PR JSON payload (default: read stdin)",
+    )
+    parser.add_argument(
+        "--repo", help="GitHub 'owner/repo' (overrides the payload if set)"
+    )
+    parser.add_argument(
+        "--base-commit",
+        help="Commit the agent started from; defaults to the PR base SHA",
+    )
+    parser.add_argument(
+        "--patch-file", help="Path to the unified diff (base..head) for the PR"
+    )
+    parser.add_argument("--out", required=True, help="Destination .jsonl dataset file")
+    parser.add_argument(
+        "--append", action="store_true", help="Append to --out instead of overwriting"
+    )
+    args = parser.parse_args(argv)
+
+    raw = (
+        open(args.pr_json, encoding="utf-8").read()
+        if args.pr_json
+        else sys.stdin.read()
+    )
+    pr = json.loads(raw)
+    if args.repo:
+        pr["repo"] = args.repo
+
+    patch = None
+    if args.patch_file:
+        patch = open(args.patch_file, encoding="utf-8").read()
+
+    snapshot = pr_snapshot_from_github_json(
+        pr, base_commit=args.base_commit, patch=patch
+    )
+    row = build_swebench_instance(snapshot)
+    write_instances_jsonl([row], args.out, append=args.append)
+    print(f"Wrote instance {row['instance_id']} to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/utils/pr_snapshot.py
+++ b/benchmarks/utils/pr_snapshot.py
@@ -1,0 +1,132 @@
+"""Build SWE-bench-style eval instances from PR-linked task captures (ALL-2451).
+
+When an OpenHands Cloud conversation produces a pull request, we want to turn it
+into an evaluation instance: the initial repo state the agent started from
+(``repo`` + ``base_commit``), the task (``problem_statement``), and the change
+that resulted (``patch``). That makes the conversation replayable as an eval.
+
+This module is the deterministic data-shaping kernel: given the PR metadata and
+the captured base commit, it produces a row in the same shape the SWE-bench
+harness already consumes (see ``benchmarks/swebench/run_infer.py``, which reads
+``instance.data['repo']`` / ``['base_commit']`` / ``['problem_statement']`` and
+loads datasets from JSONL via ``get_dataset``).
+
+The PR-merge trigger and the clone/delta-storage job (a Kubernetes job started
+when a PR moves to MERGED/CLOSED) are deployment concerns tracked separately;
+this module is what that job calls to emit each instance.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class PRSnapshot(BaseModel):
+    """A PR-linked task capture, sufficient to recreate the initial eval state."""
+
+    repo: str = Field(..., description="GitHub 'owner/repo'")
+    pr_number: int = Field(..., description="Pull request number")
+    base_commit: str = Field(
+        ..., description="Commit the agent started from (initial repo state)"
+    )
+    title: str = Field(default="", description="PR title")
+    body: str = Field(default="", description="PR description / task text")
+    head_commit: str | None = Field(
+        default=None, description="Tip commit of the PR branch (final state)"
+    )
+    patch: str | None = Field(
+        default=None,
+        description="Unified diff base_commit..head (the resulting change)",
+    )
+    html_url: str | None = Field(default=None, description="PR URL, for provenance")
+
+
+def _instance_id(repo: str, pr_number: int) -> str:
+    """SWE-bench-style id, e.g. 'django__django-11333'."""
+    return f"{repo.replace('/', '__')}-{pr_number}"
+
+
+def build_swebench_instance(snapshot: PRSnapshot) -> dict[str, Any]:
+    """Return a SWE-bench-style dataset row for ``snapshot``.
+
+    The row carries the fields the SWE-bench harness reads (``instance_id``,
+    ``repo``, ``base_commit``, ``problem_statement``) plus the resulting
+    ``patch`` and provenance metadata. It is JSON-serialisable and can be
+    written to a ``.jsonl`` dataset consumable by ``get_dataset``.
+    """
+    problem_statement = snapshot.title
+    if snapshot.body:
+        problem_statement = (
+            f"{snapshot.title}\n\n{snapshot.body}" if snapshot.title else snapshot.body
+        )
+    return {
+        "instance_id": _instance_id(snapshot.repo, snapshot.pr_number),
+        "repo": snapshot.repo,
+        "base_commit": snapshot.base_commit,
+        "problem_statement": problem_statement,
+        "patch": snapshot.patch or "",
+        "hints_text": "",
+        "pr_url": snapshot.html_url,
+        "head_commit": snapshot.head_commit,
+        "created_from": "openhands-cloud-pr",
+    }
+
+
+def pr_snapshot_from_github_json(
+    pr: dict[str, Any], base_commit: str | None = None, patch: str | None = None
+) -> PRSnapshot:
+    """Build a ``PRSnapshot`` from a GitHub PR payload (``gh pr view --json ...``).
+
+    ``base_commit`` defaults to the PR's base SHA, but callers that captured the
+    exact commit the agent started from should pass it explicitly — a PR's base
+    ref can advance after the conversation started.
+    """
+    base = pr.get("baseRefOid") or {}
+    base_sha = base_commit or (base if isinstance(base, str) else "")
+    if not base_sha:
+        # REST shape: {"base": {"sha": ...}, "head": {"sha": ...}}
+        base_sha = (pr.get("base") or {}).get("sha", "")
+    head = pr.get("headRefOid")
+    if not head:
+        head = (pr.get("head") or {}).get("sha")
+
+    repo = pr.get("repo") or _repo_from_url(pr.get("html_url") or pr.get("url") or "")
+    number = pr.get("number")
+    if number is None:
+        raise ValueError("PR payload missing 'number'")
+
+    return PRSnapshot(
+        repo=repo,
+        pr_number=int(number),
+        base_commit=base_sha,
+        title=pr.get("title", "") or "",
+        body=pr.get("body", "") or "",
+        head_commit=head,
+        patch=patch,
+        html_url=pr.get("html_url") or pr.get("url"),
+    )
+
+
+def _repo_from_url(url: str) -> str:
+    """Extract 'owner/repo' from a GitHub PR URL."""
+    parts = [p for p in url.split("/") if p]
+    # .../github.com/<owner>/<repo>/pull/<n>
+    if "pull" in parts:
+        i = parts.index("pull")
+        if i >= 2:
+            return f"{parts[i - 2]}/{parts[i - 1]}"
+    return ""
+
+
+def write_instances_jsonl(
+    rows: list[dict[str, Any]], path: str | Path, append: bool = False
+) -> None:
+    """Write SWE-bench-style rows to a ``.jsonl`` dataset file."""
+    mode = "a" if append else "w"
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, mode, encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, sort_keys=True) + "\n")

--- a/tests/test_pr_snapshot.py
+++ b/tests/test_pr_snapshot.py
@@ -1,0 +1,119 @@
+"""Tests for benchmarks.utils.pr_snapshot (ALL-2451)."""
+
+import json
+
+from benchmarks.utils.dataset import get_dataset
+from benchmarks.utils.pr_snapshot import (
+    PRSnapshot,
+    build_swebench_instance,
+    pr_snapshot_from_github_json,
+    write_instances_jsonl,
+)
+
+
+def test_build_instance_has_swebench_fields():
+    snap = PRSnapshot(
+        repo="OpenHands/OpenHands",
+        pr_number=123,
+        base_commit="abc123",
+        title="Fix the bug",
+        body="Steps to reproduce ...",
+        head_commit="def456",
+        patch="diff --git a/x b/x\n",
+        html_url="https://github.com/OpenHands/OpenHands/pull/123",
+    )
+
+    row = build_swebench_instance(snap)
+
+    assert row["instance_id"] == "OpenHands__OpenHands-123"
+    assert row["repo"] == "OpenHands/OpenHands"
+    assert row["base_commit"] == "abc123"
+    assert row["problem_statement"] == "Fix the bug\n\nSteps to reproduce ..."
+    assert row["patch"] == "diff --git a/x b/x\n"
+    assert row["pr_url"].endswith("/pull/123")
+    assert row["created_from"] == "openhands-cloud-pr"
+
+
+def test_build_instance_without_body_uses_title_only():
+    snap = PRSnapshot(repo="o/r", pr_number=7, base_commit="c0", title="Title only")
+    row = build_swebench_instance(snap)
+    assert row["problem_statement"] == "Title only"
+    assert row["patch"] == ""
+
+
+def test_from_github_graphql_json():
+    pr = {
+        "number": 42,
+        "title": "Add feature",
+        "body": "Do the thing",
+        "baseRefOid": "base-sha",
+        "headRefOid": "head-sha",
+        "url": "https://github.com/o/r/pull/42",
+        "repo": "o/r",
+    }
+
+    snap = pr_snapshot_from_github_json(pr)
+
+    assert snap.repo == "o/r"
+    assert snap.pr_number == 42
+    assert snap.base_commit == "base-sha"
+    assert snap.head_commit == "head-sha"
+
+
+def test_from_github_rest_json_and_repo_from_url():
+    pr = {
+        "number": 9,
+        "title": "t",
+        "body": "",
+        "base": {"sha": "rest-base"},
+        "head": {"sha": "rest-head"},
+        "html_url": "https://github.com/acme/widgets/pull/9",
+    }
+
+    snap = pr_snapshot_from_github_json(pr)
+
+    assert snap.repo == "acme/widgets"  # derived from the URL
+    assert snap.base_commit == "rest-base"
+    assert snap.head_commit == "rest-head"
+
+
+def test_explicit_base_commit_overrides_payload():
+    pr = {"number": 1, "title": "t", "baseRefOid": "stale", "repo": "o/r"}
+    snap = pr_snapshot_from_github_json(pr, base_commit="captured-sha")
+    assert snap.base_commit == "captured-sha"
+
+
+def test_write_jsonl_roundtrips_through_get_dataset(tmp_path):
+    rows = [
+        build_swebench_instance(
+            PRSnapshot(repo="o/r", pr_number=1, base_commit="c1", title="one")
+        ),
+        build_swebench_instance(
+            PRSnapshot(repo="o/r", pr_number=2, base_commit="c2", title="two")
+        ),
+    ]
+    out = tmp_path / "instances.jsonl"
+    write_instances_jsonl(rows, out)
+
+    # Plain JSONL is readable line-by-line ...
+    lines = out.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["instance_id"] == "o__r-1"
+
+    # ... and loads through the harness's dataset loader.
+    df = get_dataset(str(out), split="train")
+    assert set(df["instance_id"]) == {"o__r-1", "o__r-2"}
+
+
+def test_write_jsonl_append(tmp_path):
+    out = tmp_path / "instances.jsonl"
+    write_instances_jsonl(
+        [build_swebench_instance(PRSnapshot(repo="o/r", pr_number=1, base_commit="c"))],
+        out,
+    )
+    write_instances_jsonl(
+        [build_swebench_instance(PRSnapshot(repo="o/r", pr_number=2, base_commit="c"))],
+        out,
+        append=True,
+    )
+    assert len(out.read_text(encoding="utf-8").strip().splitlines()) == 2


### PR DESCRIPTION
## Why

When an OpenHands Cloud conversation produces a pull request, we'd like to replay it as an evaluation instance. An eval needs the **initial** repo state the agent started from (`repo` + `base_commit`), the **task** (`problem_statement`), and the **resulting change** (`patch`). This is the data-shaping kernel of ALL-2451 — it turns a PR-linked capture into a dataset row in the exact shape the SWE-bench harness already consumes, so captured conversations become replayable evals. It pairs with the workspace-archive work (software-agent-sdk#3867, runtime-api#623, OpenHands#14953) that captures the final git delta.

## What

- `benchmarks/utils/pr_snapshot.py`:
  - `PRSnapshot` — a PR-linked capture (repo, pr_number, base_commit, title/body, head_commit, optional patch).
  - `build_swebench_instance()` — emits a row with the fields `swebench/run_infer.py` reads (`instance_id`, `repo`, `base_commit`, `problem_statement`) plus `patch` and provenance. JSON-serialisable; `instance_id` follows the `owner__repo-<n>` convention.
  - `pr_snapshot_from_github_json()` — accepts both the `gh pr view --json` (GraphQL) and REST PR shapes; derives `owner/repo` from the URL when absent; supports an explicit `base_commit` override (a PR's base ref can advance after the conversation started).
  - `write_instances_jsonl()` — writes rows to a `.jsonl` dataset.
- `benchmarks/scripts/pr_to_eval_instance.py` — CLI the PR-merge capture job calls to emit/append one instance from a PR payload.

## Scope / follow-up

This is the deterministic kernel. The **PR-merge trigger + clone/delta-storage Kubernetes job** (ALL-2451's "trigger a job when a PR goes MERGED/CLOSED; update the delta, not the whole repo") is the remaining infra piece and needs a deploy/automation home + product decisions on the dataset destination — out of scope for this PR. This is what that job calls per instance.

## How to Test

```
uv run pytest tests/test_pr_snapshot.py -v
```

Covers field mapping (with/without body), both GitHub JSON shapes, `owner/repo` derived from the URL, the explicit base-commit override, and a JSONL roundtrip through `get_dataset`. `ruff check`/`format` clean.
