### PR TITLE
Improve generic Harbor and MiniSWE evaluation resilience

### DIFF
--- a/benchmarks/harbor/eval_infer.py
+++ b/benchmarks/harbor/eval_infer.py
@@ -9,12 +9,37 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from benchmarks.utils.harbor import convert_harbor_to_eval_output
 from benchmarks.utils.laminar import LaminarService
 from benchmarks.utils.report_costs import generate_cost_report
 from openhands.sdk import get_logger
 
 
 logger = get_logger(__name__)
+
+
+def refresh_eval_output_from_harbor(input_file: Path) -> bool:
+    """Rebuild converted output from raw Harbor results when they are available.
+
+    Inference archives contain both ``output.jsonl`` and the authoritative
+    ``harbor_output`` tree. Re-running the converter in the evaluation phase
+    lets converter fixes take effect during a rescore and avoids permanently
+    classifying verifier-scored agent failures according to stale JSONL.
+    """
+    harbor_output_dir = input_file.parent / "harbor_output"
+    if not harbor_output_dir.is_dir():
+        logger.info(
+            "Raw Harbor output not found at %s; using existing converted output",
+            harbor_output_dir,
+        )
+        return False
+
+    convert_harbor_to_eval_output(
+        harbor_output_dir=harbor_output_dir,
+        eval_output_path=input_file,
+    )
+    logger.info("Refreshed %s from raw Harbor results", input_file)
+    return True
 
 
 def _metric(
@@ -143,6 +168,7 @@ def main() -> None:
         else input_file.with_suffix(".report.json")
     )
     try:
+        refresh_eval_output_from_harbor(input_file)
         process_harbor_results(str(input_file), str(output_file))
         generate_cost_report(str(input_file))
     except Exception as exc:

--- a/benchmarks/harbor/run_infer.py
+++ b/benchmarks/harbor/run_infer.py
@@ -154,10 +154,34 @@ def _split_json_values(raw: str | None) -> list[str]:
         return []
     data = json.loads(raw)
     if isinstance(data, dict):
-        return [f"{key}={value}" for key, value in data.items()]
+        return [
+            f"{key}={value if isinstance(value, str) else json.dumps(value, separators=(',', ':'))}"
+            for key, value in data.items()
+        ]
     if isinstance(data, list) and all(isinstance(item, str) for item in data):
         return data
     raise ValueError("Expected a JSON object or list of KEY=VALUE strings")
+
+
+def _llm_agent_env(llm: LLM, harbor_agent: str) -> list[str]:
+    """Build credential env flags for the selected Harbor-compatible agent.
+
+    The OpenHands SDK agent consumes the generic ``LLM_*`` variables. Pier's
+    mini-SWE agent resolves ``litellm_proxy/*`` through LiteLLM, which consumes
+    the OpenAI-compatible aliases instead. Both names carry the same proxy
+    credential and endpoint.
+    """
+    values: list[str] = []
+    if llm.api_key:
+        api_key = _secret_value(llm.api_key)
+        values.append(f"LLM_API_KEY={api_key}")
+        if harbor_agent == "mini-swe-agent":
+            values.append(f"OPENAI_API_KEY={api_key}")
+    if llm.base_url:
+        values.append(f"LLM_BASE_URL={llm.base_url}")
+        if harbor_agent == "mini-swe-agent":
+            values.append(f"OPENAI_BASE_URL={llm.base_url}")
+    return values
 
 
 def run_harbor(
@@ -186,10 +210,8 @@ def run_harbor(
         str(args.num_workers),
     ]
 
-    if llm.api_key:
-        cmd.extend(["--ae", f"LLM_API_KEY={_secret_value(llm.api_key)}"])
-    if llm.base_url:
-        cmd.extend(["--ae", f"LLM_BASE_URL={llm.base_url}"])
+    for env_value in _llm_agent_env(llm, args.harbor_agent):
+        cmd.extend(["--ae", env_value])
     for env_value in _parse_key_value(
         [*args.agent_env, *_split_json_values(args.agent_env_json)]
     ):

--- a/benchmarks/utils/harbor.py
+++ b/benchmarks/utils/harbor.py
@@ -236,7 +236,16 @@ def convert_harbor_to_eval_output(
 
             instance_id = canonicalize(trial.get("task_name", result_file.parent.name))
 
-            if trial.get("exception_info"):
+            verifier_result = trial.get("verifier_result") or {}
+            rewards = verifier_result.get("rewards") or {}
+            has_primary_reward = "reward" in rewards
+
+            # Harbor can still run the verifier after an agent timeout or other
+            # non-zero exit. In that case the verifier is authoritative: a reward
+            # of 1 is a resolved task, and a reward of 0 is a completed unresolved
+            # task. Only emit an incomplete error when no primary verifier reward
+            # exists (for example, setup or verifier failures).
+            if trial.get("exception_info") and not has_primary_reward:
                 errors.append(
                     {
                         "instance_id": instance_id,
@@ -246,8 +255,6 @@ def convert_harbor_to_eval_output(
                 )
                 continue
 
-            verifier_result = trial.get("verifier_result", {})
-            rewards = verifier_result.get("rewards", {})
             passed = rewards.get("reward", 0.0) > 0
             agent_result = trial.get("agent_result", {})
 
@@ -270,6 +277,8 @@ def convert_harbor_to_eval_output(
                     "total_cost_usd": agent_result.get("cost_usd") or 0.0,
                 },
             }
+            if trial.get("exception_info"):
+                eval_entry["test_result"]["agent_exception"] = trial["exception_info"]
             results.append(eval_entry)
             logger.info(
                 f"Processed trial {instance_id}: reward={rewards.get('reward', 'N/A')}"

--- a/extras/miniswe-context-model/README.md
+++ b/extras/miniswe-context-model/README.md
@@ -1,0 +1,15 @@
+# MiniSWE context model
+
+This small optional package provides a `LitellmModel` subclass for long-running
+MiniSWE evaluations. It retains the system prompt, task, and newest complete
+assistant/tool turns while eliding old turns before a request exceeds the configured
+serialized-history budget.
+
+Install it in the MiniSWE tool environment and select:
+
+```text
+openhands_miniswe_context_model.model.ContextSafeLitellmModel
+```
+
+The `model.max_history_chars` config field defaults to 500,000 characters and can
+be overridden by the benchmark's agent configuration.

--- a/extras/miniswe-context-model/pyproject.toml
+++ b/extras/miniswe-context-model/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openhands-miniswe-context-model"
+version = "0.1.0"
+description = "Bounded-history LiteLLM model wrapper for mini-swe-agent evaluations"
+requires-python = ">=3.11"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/extras/miniswe-context-model/src/openhands_miniswe_context_model/__init__.py
+++ b/extras/miniswe-context-model/src/openhands_miniswe_context_model/__init__.py
@@ -1,0 +1,3 @@
+"""Context-safe model helpers for mini-swe-agent evaluations."""
+
+__version__ = "0.1.0"

--- a/extras/miniswe-context-model/src/openhands_miniswe_context_model/history.py
+++ b/extras/miniswe-context-model/src/openhands_miniswe_context_model/history.py
@@ -1,0 +1,94 @@
+"""History bounding that preserves tool-call protocol boundaries."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+
+ELISION_NOTICE = (
+    "[Earlier assistant and tool interactions were omitted to stay within the "
+    "model context window. Their effects remain in the current workspace.]"
+)
+
+
+def _message_size(message: dict[str, Any]) -> int:
+    return len(
+        json.dumps(
+            message,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            default=str,
+        )
+    )
+
+
+def _history_units(messages: Sequence[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Group assistant messages with their following tool results."""
+    units: list[list[dict[str, Any]]] = []
+    for message in messages:
+        if (
+            message.get("role") == "tool"
+            and units
+            and units[-1][0].get("role") == "assistant"
+        ):
+            units[-1].append(message)
+        else:
+            units.append([message])
+    return units
+
+
+def bound_message_history(
+    messages: Sequence[dict[str, Any]],
+    *,
+    max_chars: int,
+    preserve_first: int = 2,
+    min_recent_units: int = 8,
+) -> list[dict[str, Any]]:
+    """Drop the oldest complete turns when serialized history exceeds a budget.
+
+    The initial system/task messages are always retained. Assistant tool calls and
+    their tool results are grouped into atomic units, so trimming never leaves an
+    orphaned tool response in the request sent to the model.
+    """
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    if preserve_first < 0:
+        raise ValueError("preserve_first cannot be negative")
+    if min_recent_units < 1:
+        raise ValueError("min_recent_units must be at least one")
+
+    copied = [dict(message) for message in messages]
+    if sum(_message_size(message) for message in copied) <= max_chars:
+        return copied
+
+    header = copied[:preserve_first]
+    units = _history_units(copied[preserve_first:])
+    notice = {"role": "user", "content": ELISION_NOTICE}
+    remaining = (
+        max_chars
+        - sum(_message_size(message) for message in header)
+        - _message_size(notice)
+    )
+
+    kept_reversed: list[list[dict[str, Any]]] = []
+    used = 0
+    for unit in reversed(units):
+        unit_size = sum(_message_size(message) for message in unit)
+        if (
+            kept_reversed
+            and used + unit_size > remaining
+            and len(kept_reversed) >= min_recent_units
+        ):
+            break
+        kept_reversed.append(unit)
+        used += unit_size
+
+    kept = [message for unit in reversed(kept_reversed) for message in unit]
+    dropped_count = len(copied) - len(header) - len(kept)
+    if dropped_count <= 0:
+        return copied
+
+    notice["content"] += f" ({dropped_count} messages omitted.)"
+    return [*header, notice, *kept]

--- a/extras/miniswe-context-model/src/openhands_miniswe_context_model/model.py
+++ b/extras/miniswe-context-model/src/openhands_miniswe_context_model/model.py
@@ -1,0 +1,35 @@
+"""A LiteLLM mini-swe-agent model with bounded request history."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
+from pydantic import Field
+
+from openhands_miniswe_context_model.history import bound_message_history
+
+
+class ContextSafeLitellmModelConfig(LitellmModelConfig):
+    max_history_chars: int = Field(default=500_000, gt=0)
+    """Maximum serialized characters retained in requests to the model."""
+
+    min_recent_history_units: int = Field(default=8, ge=1)
+    """Minimum number of recent assistant/tool units to retain."""
+
+
+class ContextSafeLitellmModel(LitellmModel):
+    """Retain task setup and recent complete turns below a context-safe budget."""
+
+    config: ContextSafeLitellmModelConfig
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(config_class=ContextSafeLitellmModelConfig, **kwargs)
+
+    def _prepare_messages_for_api(self, messages: list[dict]) -> list[dict]:
+        prepared = super()._prepare_messages_for_api(messages)
+        return bound_message_history(
+            prepared,
+            max_chars=self.config.max_history_chars,
+            min_recent_units=self.config.min_recent_history_units,
+        )

--- a/extras/miniswe-context-model/src/openhands_miniswe_context_model/model.py
+++ b/extras/miniswe-context-model/src/openhands_miniswe_context_model/model.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from minisweagent.models.litellm_model import LitellmModel, LitellmModelConfig
+from minisweagent.models.litellm_model import (  # pyright: ignore[reportMissingImports]
+    LitellmModel,
+    LitellmModelConfig,
+)
 from pydantic import Field
 
 from openhands_miniswe_context_model.history import bound_message_history

--- a/tests/test_harbor_eval_infer.py
+++ b/tests/test_harbor_eval_infer.py
@@ -1,0 +1,75 @@
+"""Tests for the generic Harbor evaluation phase."""
+
+import json
+from pathlib import Path
+
+from benchmarks.harbor.eval_infer import (
+    process_harbor_results,
+    refresh_eval_output_from_harbor,
+)
+
+
+def test_refresh_reconverts_authoritative_harbor_results(tmp_path: Path) -> None:
+    output_file = tmp_path / "output.jsonl"
+    output_file.write_text(
+        json.dumps(
+            {
+                "instance_id": "finished-before-timeout",
+                "test_result": {},
+                "error": "stale timeout classification",
+            }
+        )
+        + "\n"
+    )
+
+    job_dir = tmp_path / "harbor_output" / "2026-01-01__00-00-00"
+    trial_dir = job_dir / "finished-before-timeout__abc"
+    trial_dir.mkdir(parents=True)
+    (job_dir / "result.json").write_text(json.dumps({"id": "job"}))
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "finished-before-timeout",
+                "trial_name": "finished-before-timeout__abc",
+                "agent_result": {
+                    "n_input_tokens": 10,
+                    "n_output_tokens": 2,
+                    "cost_usd": 0.0,
+                },
+                "verifier_result": {"rewards": {"reward": 1.0}},
+                "exception_info": {
+                    "exception_type": "AgentTimeoutError",
+                    "exception_message": "Agent timed out after saving the answer",
+                },
+            }
+        )
+    )
+
+    assert refresh_eval_output_from_harbor(output_file) is True
+
+    report_file = tmp_path / "output.report.json"
+    report = process_harbor_results(str(output_file), str(report_file))
+    converted = json.loads(output_file.read_text())
+
+    assert report["completed_instances"] == 1
+    assert report["resolved_instances"] == 1
+    assert report["error_instances"] == 0
+    assert converted["test_result"]["agent_exception"]["exception_type"] == (
+        "AgentTimeoutError"
+    )
+
+
+def test_refresh_keeps_existing_output_without_raw_harbor_results(
+    tmp_path: Path,
+) -> None:
+    output_file = tmp_path / "output.jsonl"
+    original = (
+        json.dumps(
+            {"instance_id": "existing", "test_result": {"passed": False}, "error": None}
+        )
+        + "\n"
+    )
+    output_file.write_text(original)
+
+    assert refresh_eval_output_from_harbor(output_file) is False
+    assert output_file.read_text() == original

--- a/tests/test_harbor_run_infer.py
+++ b/tests/test_harbor_run_infer.py
@@ -10,12 +10,14 @@ import pytest
 
 from benchmarks.harbor.run_infer import (
     _is_sensitive_value,
+    _llm_agent_env,
     _load_task_ids,
     _parse_key_value,
     _resolve_target,
     _split_json_values,
     _target_args,
 )
+from openhands.sdk import LLM
 
 
 def test_load_task_ids_strips_and_ignores_comments(tmp_path: Path) -> None:
@@ -58,6 +60,12 @@ def test_split_json_values_dict() -> None:
     assert _split_json_values('{"A": "1", "B": "2"}') == ["A=1", "B=2"]
 
 
+def test_split_json_values_preserves_nested_json() -> None:
+    assert _split_json_values(
+        '{"model_kwargs": {"temperature": 1.0, "top_p": 0.95}}'
+    ) == ['model_kwargs={"temperature":1.0,"top_p":0.95}']
+
+
 def test_split_json_values_list() -> None:
     assert _split_json_values('["A=1", "B=2"]') == ["A=1", "B=2"]
 
@@ -65,6 +73,36 @@ def test_split_json_values_list() -> None:
 def test_split_json_values_invalid() -> None:
     with pytest.raises(ValueError, match="Expected a JSON object or list"):
         _split_json_values('"not-an-object-or-list"')
+
+
+def test_llm_agent_env_uses_generic_names_for_openhands() -> None:
+    assert _llm_agent_env(
+        LLM(
+            model="litellm_proxy/test/model",
+            api_key="secret",
+            base_url="https://proxy.example.com",
+        ),
+        "openhands-sdk",
+    ) == [
+        "LLM_API_KEY=secret",
+        "LLM_BASE_URL=https://proxy.example.com",
+    ]
+
+
+def test_llm_agent_env_adds_openai_proxy_aliases_for_mini_swe() -> None:
+    assert _llm_agent_env(
+        LLM(
+            model="litellm_proxy/test/model",
+            api_key="secret",
+            base_url="https://proxy.example.com",
+        ),
+        "mini-swe-agent",
+    ) == [
+        "LLM_API_KEY=secret",
+        "OPENAI_API_KEY=secret",
+        "LLM_BASE_URL=https://proxy.example.com",
+        "OPENAI_BASE_URL=https://proxy.example.com",
+    ]
 
 
 def _make_args(**kwargs: object) -> argparse.Namespace:

--- a/tests/test_miniswe_context_history.py
+++ b/tests/test_miniswe_context_history.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_HISTORY_PATH = (
+    Path(__file__).parents[1]
+    / "extras/miniswe-context-model/src/openhands_miniswe_context_model/history.py"
+)
+_SPEC = importlib.util.spec_from_file_location("miniswe_context_history", _HISTORY_PATH)
+assert _SPEC and _SPEC.loader
+_HISTORY = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_HISTORY)
+bound_message_history = _HISTORY.bound_message_history
+
+
+def _turn(index: int, size: int = 80) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": f"turn-{index}",
+            "tool_calls": [{"id": f"call-{index}", "function": {"name": "bash"}}],
+        },
+        {"role": "tool", "tool_call_id": f"call-{index}", "content": "x" * size},
+    ]
+
+
+def test_short_history_is_unchanged() -> None:
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "task"},
+        *_turn(1),
+    ]
+
+    assert bound_message_history(messages, max_chars=10_000) == messages
+
+
+def test_long_history_keeps_header_and_complete_recent_turns() -> None:
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "task"},
+        *[message for index in range(12) for message in _turn(index, size=120)],
+    ]
+
+    bounded = bound_message_history(messages, max_chars=1_200, min_recent_units=3)
+
+    assert bounded[:2] == messages[:2]
+    assert "messages omitted" in bounded[2]["content"]
+    assert bounded[-2:] == messages[-2:]
+    for index, message in enumerate(bounded):
+        if message["role"] == "tool":
+            assert index > 0
+            assert bounded[index - 1]["role"] in {"assistant", "tool"}
+
+
+def test_history_budget_validation() -> None:
+    try:
+        bound_message_history([], max_chars=0)
+    except ValueError as exc:
+        assert "max_chars" in str(exc)
+    else:
+        raise AssertionError("Expected invalid max_chars to raise")

--- a/tests/test_terminalbench.py
+++ b/tests/test_terminalbench.py
@@ -402,6 +402,39 @@ class TestConvertHarborToEvalOutput:
         assert report["error_instances"] == 1
         assert report["incomplete_ids"] == ["error-task"]
 
+    def test_trial_with_exception_and_verifier_reward_is_scored(
+        self, tmp_path: Path
+    ) -> None:
+        """A post-agent verifier result remains authoritative after a timeout."""
+        trial_result = {
+            "task_name": "completed-before-timeout",
+            "trial_name": "completed-before-timeout__abc",
+            "trial_uri": "file:///path/to/trial",
+            "agent_result": {
+                "n_input_tokens": 500,
+                "n_output_tokens": 100,
+                "cost_usd": 0.01,
+            },
+            "verifier_result": {"rewards": {"reward": 1.0}},
+            "exception_info": {
+                "type": "AgentTimeoutError",
+                "message": "Agent execution timed out",
+            },
+        }
+
+        harbor_dir = self._create_harbor_structure(
+            tmp_path, [("completed-before-timeout__abc", trial_result)]
+        )
+        output_file = tmp_path / "output.jsonl"
+
+        convert_harbor_to_eval_output(harbor_dir, output_file)
+
+        entry = json.loads(output_file.read_text())
+        assert entry["error"] is None
+        assert entry["test_result"]["passed"] is True
+        assert entry["test_result"]["rewards"] == {"reward": 1.0}
+        assert entry["test_result"]["agent_exception"] == trial_result["exception_info"]
+
     def test_mixed_valid_and_exception_trials(self, tmp_path: Path) -> None:
         """Test handling mix of successful and exception trials."""
         trials = [


### PR DESCRIPTION
## Summary

- provide the OpenAI-compatible proxy aliases expected by the MiniSWE Harbor agent while retaining the existing generic LLM variables
- add an optional bounded-history LiteLLM model that preserves setup and complete assistant/tool turns
- treat a primary verifier reward as authoritative when Harbor records an agent timeout or non-zero exit
- refresh converted output from raw Harbor results during evaluation so rescoring uses the current converter

## Root cause

Long MiniSWE runs retained unbounded message history until requests exceeded model context limits. Separately, completed verifier results could be classified as incomplete after an agent error, and evaluation-only reruns continued to aggregate stale converted JSONL instead of the authoritative Harbor trial files.

## Impact

The changes are benchmark- and provider-agnostic: context trimming is opt-in and configurable, scoring follows Harbor's primary verifier reward, and rescoring consistently uses raw results when available.

## Validation

Live evidence was refreshed on 2026-07-19 UTC from the existing PR branch `codex/deepswe-pier-eval-20260716` after re-fetching PR #759. Environment: `uv 0.11.24`, Python 3.12.13, OpenHands SDK submodule `43376f1`, Harbor CLI 0.20.0 installed in the local `.venv`, Docker daemon 29.6.1. Current remediation commit: `652d92dcd1186cb719aaadb222a31c93d7cd2c1c` (empty evidence-only commit; no source files needed changes).

Commands and observed results:

```bash
make build
```

Result: submodule initialized at `43376f1868ffd702746080714a59c16d3f69ec12`, `uv sync --dev` completed, and pre-commit hooks installed.

```bash
uv pip install harbor
```

Result: installed Harbor CLI 0.20.0 into `.venv` for the live run.

```bash
PYTHONPATH=/tmp/pr759-live OPENHANDS_SUPPRESS_BANNER=1 PYTHONUNBUFFERED=1 \
  /workspace/project/benchmarks/.venv/bin/harbor-infer \
  /tmp/pr759-live/llm-dummy.json \
  --harbor-target /tmp/pr759-live/fixture \
  --harbor-target-type path \
  --harbor-agent nop \
  --harbor-executable /workspace/project/benchmarks/.venv/bin/harbor \
  --benchmark-slug pr759-harbor-live \
  --output-dir /tmp/pr759-live/output-plugin \
  --num-workers 1 \
  --n-limit 1 \
  --note 20260719-live-nop-verifier-plugin \
  --harbor-arg=--yes \
  --harbor-arg="--verifier verifier_plugin:RewardOneVerifier"
```

Result: actual repository `harbor-infer` entrypoint invoked Harbor on a real local Harbor task fixture using Harbor `nop` agent and a deterministic local verifier plugin returning `VerifierResult(rewards={"reward": 1.0})`, so no external LLM/API spend occurred. Harbor output reported `1/1 Mean: 1.000`, `Trials 1`, `Exceptions 0`, `Reward 1.0 Count 1`. The converter logged `Processed trial fixture: reward=1.0` and `Wrote 1 successful + 0 failed entries` to `/tmp/pr759-live/output-plugin/pr759-harbor-live/dummy/noop-model_sdk_43376f1_maxiter_100_N_20260719-live-nop-verifier-plugin/output.jsonl`. Cost report showed `$0.000000`.

```bash
OPENHANDS_SUPPRESS_BANNER=1 PYTHONUNBUFFERED=1 \
  /workspace/project/benchmarks/.venv/bin/harbor-eval \
  /tmp/pr759-live/output-plugin/pr759-harbor-live/dummy/noop-model_sdk_43376f1_maxiter_100_N_20260719-live-nop-verifier-plugin/output.jsonl \
  --output-file /tmp/pr759-live/plugin-report.json
```

Result: actual repository `harbor-eval` entrypoint refreshed `output.jsonl` from raw `harbor_output`, regenerated the report, and logged `Resolved 1/1 completed instances`. `/tmp/pr759-live/plugin-report.json` contained `total_instances=1`, `completed_instances=1`, `resolved_instances=1`, `incomplete_instances=0`, `error_instances=0`, and aggregate cost/tokens all zero.

```bash
uv run pytest tests/test_harbor_eval_infer.py tests/test_harbor_run_infer.py \
  tests/test_harbor.py tests/test_terminalbench.py tests/test_miniswe_context_history.py
```

Result: `68 passed, 2 warnings in 0.20s`.

Limitations: this was the smallest safe Harbor-compatible live fixture, not a full MiniSWE or Terminal-Bench run. It deliberately used Harbor `nop` plus a local deterministic verifier to avoid external LLM spend. A preliminary shell-script verifier fixture that wrote `/logs/verifier/reward.txt` through Harbor 0.20.0 in this DinD environment ended with `RewardFileNotFoundError`; the successful evidence therefore uses a custom real Harbor verifier plugin. Docker required enabling the current sudo-capable user to access `/var/run/docker.sock` in this sandbox.

_This PR was prepared by an AI agent on behalf of the user. This validation update was added by an AI agent (OpenHands) on behalf of the user._

Closes #761

<!-- Issue association added by Codex during daily workflow resolution. -->
