### PR TITLE
feat(swebench): record structured assembly cleanup telemetry

### DIFF
--- a/benchmarks/swebench/build_base_images.py
+++ b/benchmarks/swebench/build_base_images.py
@@ -533,6 +533,16 @@ def assemble_agent_image(
         )
 
     tag_label = final_tags[0] if final_tags else base_tag
+    if not final_tags:
+        return BuildOutput(
+            base_image=base_tag,
+            tags=[],
+            error="No final tags provided for agent image assembly",
+            status="failed",
+            duration_seconds=round(time.monotonic() - overall_started, 3),
+            build_seconds=0.0,
+            push_seconds=push_seconds,
+        )
 
     # Step 1: docker build (local daemon, no remote driver)
     build_cmd = [
@@ -553,7 +563,24 @@ def assemble_agent_image(
 
     logger.info("[assembly] Building: %s", " ".join(build_cmd))
     build_started = time.monotonic()
-    proc, timeout_error = _run_docker_command(build_cmd)
+    try:
+        proc, timeout_error = _run_docker_command(build_cmd)
+    except Exception as exc:
+        build_seconds = round(time.monotonic() - build_started, 3)
+        error = f"docker build raised: {exc!r}"
+        logger.warning("[assembly] %s: %s", error, tag_label)
+        return BuildOutput(
+            base_image=base_tag,
+            tags=[],
+            error=error,
+            status="failed",
+            duration_seconds=round(
+                max(time.monotonic() - overall_started, build_seconds + push_seconds),
+                3,
+            ),
+            build_seconds=build_seconds,
+            push_seconds=push_seconds,
+        )
     build_seconds = round(time.monotonic() - build_started, 3)
     if timeout_error:
         logger.info(
@@ -609,7 +636,12 @@ def assemble_agent_image(
             push_cmd = ["docker", "push", t]
             logger.info("[assembly] Pushing: %s", t)
             push_started = time.monotonic()
-            push_proc, timeout_error = _run_docker_command(push_cmd)
+            try:
+                push_proc, timeout_error = _run_docker_command(push_cmd)
+            except Exception as exc:
+                push_seconds += time.monotonic() - push_started
+                failed_pushes.append((t, f"docker push raised: {exc!r}"[:200]))
+                continue
             push_seconds += time.monotonic() - push_started
             if timeout_error:
                 failed_pushes.append((t, timeout_error[:200]))
@@ -681,7 +713,9 @@ def assemble_agent_image(
             logger.warning("[assembly] rmi cleanup raised for %s: %s", tag_label, exc)
         rmi_seconds = round(time.monotonic() - rmi_started, 3)
         rmi_returncode = rmi_proc.returncode if rmi_proc is not None else None
-        rmi_timed_out = rmi_timeout is not None
+        rmi_timed_out = (
+            True if rmi_timeout is not None else (None if rmi_proc is None else False)
+        )
         rmi_ok = (
             rmi_proc is not None and rmi_timeout is None and rmi_proc.returncode == 0
         )
@@ -712,7 +746,11 @@ def assemble_agent_image(
         system_prune_returncode = (
             sys_prune_proc.returncode if sys_prune_proc is not None else None
         )
-        system_prune_timed_out = sys_prune_timeout is not None
+        system_prune_timed_out = (
+            True
+            if sys_prune_timeout is not None
+            else (None if sys_prune_proc is None else False)
+        )
         system_prune_ok = (
             sys_prune_proc is not None
             and sys_prune_timeout is None
@@ -750,7 +788,9 @@ def assemble_agent_image(
             )
         builder_prune_seconds = round(time.monotonic() - builder_prune_started, 3)
         builder_prune_returncode = bp_proc.returncode if bp_proc is not None else None
-        builder_prune_timed_out = bp_timeout is not None
+        builder_prune_timed_out = (
+            True if bp_timeout is not None else (None if bp_proc is None else False)
+        )
         builder_prune_ok = (
             bp_proc is not None and bp_timeout is None and bp_proc.returncode == 0
         )
@@ -840,6 +880,7 @@ def _assemble_with_logging(
         "rmi_seconds",
         "system_prune_seconds",
         "builder_prune_seconds",
+        "post_build_seconds",
     )
     phase_totals = {field: 0.0 for field in phase_fields}
     phase_seen = {field: False for field in phase_fields}
@@ -865,6 +906,7 @@ def _assemble_with_logging(
                     max_retries,
                 )
                 time.sleep(2 + attempt * 2)
+            attempt_started_monotonic = time.monotonic()
             try:
                 result = assemble_agent_image(
                     base_tag=base_tag,
@@ -873,13 +915,16 @@ def _assemble_with_logging(
                     push=push,
                     git_sha=sdk_full_sha,
                 )
-            except Exception as e:
+            except Exception as exc:
                 result = BuildOutput(
                     base_image=base_image,
                     tags=[],
-                    error=repr(e),
+                    error=repr(exc),
                     status="failed",
                     log_path=str(log_path),
+                    duration_seconds=round(
+                        time.monotonic() - attempt_started_monotonic, 3
+                    ),
                 )
             result.log_path = str(log_path)
             for field in phase_fields:
@@ -926,6 +971,8 @@ def _assemble_with_logging(
 
             if should_wrap_custom_tag(custom_tag):
                 logger.info("Wrapping %s with docutils/roman", final_tag)
+                wrapper_started = time.monotonic()
+                wrap_result = None
                 try:
                     wrap_result = wrap_image(final_tag, push=push)
                 except Exception as exc:
@@ -945,6 +992,11 @@ def _assemble_with_logging(
                                 "log_path": str(log_path),
                             }
                         )
+                wrapper_seconds = time.monotonic() - wrapper_started
+                if wrap_result is not None and wrap_result.duration_seconds is not None:
+                    wrapper_seconds = max(wrapper_seconds, wrap_result.duration_seconds)
+                phase_totals["post_build_seconds"] += wrapper_seconds
+                phase_seen["post_build_seconds"] = True
                 if result.error:
                     final_result = result
                     if attempt == max_retries - 1:

--- a/benchmarks/swebench/build_base_images.py
+++ b/benchmarks/swebench/build_base_images.py
@@ -518,15 +518,21 @@ def assemble_agent_image(
     """
     import time
 
+    overall_started = time.monotonic()
+    push_seconds = 0.0
+
     if not AGENT_LAYER_DOCKERFILE.exists():
         return BuildOutput(
             base_image=base_tag,
             tags=[],
             error=f"Agent layer Dockerfile not found at {AGENT_LAYER_DOCKERFILE}",
+            status="failed",
+            duration_seconds=round(time.monotonic() - overall_started, 3),
+            build_seconds=0.0,
+            push_seconds=push_seconds,
         )
 
     tag_label = final_tags[0] if final_tags else base_tag
-    overall_started = time.monotonic()
 
     # Step 1: docker build (local daemon, no remote driver)
     build_cmd = [
@@ -556,7 +562,18 @@ def assemble_agent_image(
             build_seconds,
             timeout_error[:200],
         )
-        return BuildOutput(base_image=base_tag, tags=[], error=timeout_error)
+        return BuildOutput(
+            base_image=base_tag,
+            tags=[],
+            error=timeout_error,
+            status="failed",
+            duration_seconds=round(
+                max(time.monotonic() - overall_started, build_seconds + push_seconds),
+                3,
+            ),
+            build_seconds=build_seconds,
+            push_seconds=push_seconds,
+        )
     assert proc is not None
 
     if proc.returncode != 0:
@@ -571,10 +588,20 @@ def assemble_agent_image(
             build_seconds,
             error[:200],
         )
-        return BuildOutput(base_image=base_tag, tags=[], error=error)
+        return BuildOutput(
+            base_image=base_tag,
+            tags=[],
+            error=error,
+            status="failed",
+            duration_seconds=round(
+                max(time.monotonic() - overall_started, build_seconds + push_seconds),
+                3,
+            ),
+            build_seconds=build_seconds,
+            push_seconds=push_seconds,
+        )
 
     # Step 2: docker push each tag (collect partial failures)
-    push_seconds = 0.0
     pushed_tags: list[str] = []
     failed_pushes: list[tuple[str, str]] = []
     if push:
@@ -613,18 +640,52 @@ def assemble_agent_image(
             len(final_tags),
             error_summary[:300],
         )
-        return BuildOutput(base_image=base_tag, tags=pushed_tags, error=error_summary)
+        return BuildOutput(
+            base_image=base_tag,
+            tags=pushed_tags,
+            error=error_summary,
+            status="failed",
+            duration_seconds=round(
+                max(time.monotonic() - overall_started, build_seconds + push_seconds),
+                3,
+            ),
+            build_seconds=build_seconds,
+            push_seconds=push_seconds,
+        )
 
     push_seconds = round(push_seconds, 3)
+    rmi_seconds: float | None = None
+    rmi_returncode: int | None = None
+    rmi_timed_out: bool | None = None
+    system_prune_seconds: float | None = None
+    system_prune_returncode: int | None = None
+    system_prune_timed_out: bool | None = None
+    builder_prune_seconds: float | None = None
+    builder_prune_returncode: int | None = None
+    builder_prune_timed_out: bool | None = None
+    cleanup_ok: bool | None = None
 
     # Release disk after successful pushes. Full cold SWE/SWT-bench builds on
     # ubuntu-latest-8core otherwise keep every final image and BuildKit ingest
     # blob in the local daemon until the runner runs out of disk.
     if push and pushed_tags:
         rmi_targets = list(dict.fromkeys([*pushed_tags, base_tag]))
-        rmi_proc, rmi_timeout = _run_docker_command(
-            ["docker", "rmi", "-f", *rmi_targets]
+        cleanup_ok = True
+        rmi_started = time.monotonic()
+        try:
+            rmi_proc, rmi_timeout = _run_docker_command(
+                ["docker", "rmi", "-f", *rmi_targets]
+            )
+        except Exception as exc:
+            rmi_proc, rmi_timeout = None, None
+            logger.warning("[assembly] rmi cleanup raised for %s: %s", tag_label, exc)
+        rmi_seconds = round(time.monotonic() - rmi_started, 3)
+        rmi_returncode = rmi_proc.returncode if rmi_proc is not None else None
+        rmi_timed_out = rmi_timeout is not None
+        rmi_ok = (
+            rmi_proc is not None and rmi_timeout is None and rmi_proc.returncode == 0
         )
+        cleanup_ok = cleanup_ok and rmi_ok
         if rmi_timeout:
             logger.warning("[assembly] rmi timed out for %s", tag_label)
         elif rmi_proc is not None and rmi_proc.returncode != 0:
@@ -635,9 +696,29 @@ def assemble_agent_image(
                 (rmi_proc.stderr or rmi_proc.stdout or "").strip()[:200],
             )
 
-        sys_prune_proc, sys_prune_timeout = _run_docker_command(
-            ["docker", "system", "prune", "-f"]
+        system_prune_started = time.monotonic()
+        try:
+            sys_prune_proc, sys_prune_timeout = _run_docker_command(
+                ["docker", "system", "prune", "-f"]
+            )
+        except Exception as exc:
+            sys_prune_proc, sys_prune_timeout = None, None
+            logger.warning(
+                "[assembly] system prune cleanup raised for %s: %s",
+                tag_label,
+                exc,
+            )
+        system_prune_seconds = round(time.monotonic() - system_prune_started, 3)
+        system_prune_returncode = (
+            sys_prune_proc.returncode if sys_prune_proc is not None else None
         )
+        system_prune_timed_out = sys_prune_timeout is not None
+        system_prune_ok = (
+            sys_prune_proc is not None
+            and sys_prune_timeout is None
+            and sys_prune_proc.returncode == 0
+        )
+        cleanup_ok = cleanup_ok and system_prune_ok
         if sys_prune_timeout:
             logger.warning("[assembly] system prune timed out for %s", tag_label)
         elif sys_prune_proc is not None and sys_prune_proc.returncode != 0:
@@ -647,17 +728,33 @@ def assemble_agent_image(
                 sys_prune_proc.returncode,
             )
 
-        buildkit_cap_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "30"))
-        bp_proc, bp_timeout = _run_docker_command(
-            [
-                "docker",
-                "builder",
-                "prune",
-                "-af",
-                "--keep-storage",
-                f"{buildkit_cap_gb}g",
-            ]
+        builder_prune_started = time.monotonic()
+        try:
+            buildkit_cap_gb = int(os.getenv("OPENHANDS_BUILDKIT_KEEP_STORAGE_GB", "30"))
+            bp_proc, bp_timeout = _run_docker_command(
+                [
+                    "docker",
+                    "builder",
+                    "prune",
+                    "-af",
+                    "--keep-storage",
+                    f"{buildkit_cap_gb}g",
+                ]
+            )
+        except Exception as exc:
+            bp_proc, bp_timeout = None, None
+            logger.warning(
+                "[assembly] builder prune cleanup raised for %s: %s",
+                tag_label,
+                exc,
+            )
+        builder_prune_seconds = round(time.monotonic() - builder_prune_started, 3)
+        builder_prune_returncode = bp_proc.returncode if bp_proc is not None else None
+        builder_prune_timed_out = bp_timeout is not None
+        builder_prune_ok = (
+            bp_proc is not None and bp_timeout is None and bp_proc.returncode == 0
         )
+        cleanup_ok = cleanup_ok and builder_prune_ok
         if bp_timeout:
             logger.warning("[assembly] buildkit prune timed out for %s", tag_label)
         elif bp_proc is not None and bp_proc.returncode != 0:
@@ -667,7 +764,17 @@ def assemble_agent_image(
                 bp_proc.returncode,
             )
 
-    total_seconds = round(time.monotonic() - overall_started, 3)
+    total_seconds = round(
+        max(
+            time.monotonic() - overall_started,
+            build_seconds
+            + push_seconds
+            + (rmi_seconds or 0.0)
+            + (system_prune_seconds or 0.0)
+            + (builder_prune_seconds or 0.0),
+        ),
+        3,
+    )
 
     logger.info(
         "[assembly] OK %s: total=%.1fs build=%.1fs push=%.1fs",
@@ -677,7 +784,25 @@ def assemble_agent_image(
         push_seconds,
     )
 
-    return BuildOutput(base_image=base_tag, tags=final_tags, error=None)
+    return BuildOutput(
+        base_image=base_tag,
+        tags=final_tags,
+        error=None,
+        status="built",
+        duration_seconds=total_seconds,
+        build_seconds=build_seconds,
+        push_seconds=push_seconds,
+        rmi_seconds=rmi_seconds,
+        rmi_returncode=rmi_returncode,
+        rmi_timed_out=rmi_timed_out,
+        system_prune_seconds=system_prune_seconds,
+        system_prune_returncode=system_prune_returncode,
+        system_prune_timed_out=system_prune_timed_out,
+        builder_prune_seconds=builder_prune_seconds,
+        builder_prune_returncode=builder_prune_returncode,
+        builder_prune_timed_out=builder_prune_timed_out,
+        cleanup_ok=cleanup_ok,
+    )
 
 
 def _assemble_with_logging(
@@ -697,6 +822,7 @@ def _assemble_with_logging(
 ) -> BuildOutput:
     """Assemble a single agent image with logging and retry."""
     import time
+    from datetime import UTC, datetime
 
     base_tag = base_image_tag(custom_tag, content_hash=content_hash)
     # Include content_hash so Dockerfile changes invalidate cached assemblies.
@@ -706,8 +832,30 @@ def _assemble_with_logging(
         logger.info("Agent image %s already exists. Skipping.", final_tag)
         return BuildOutput(base_image=base_image, tags=[final_tag], error=None)
 
+    overall_started_at = datetime.now(UTC).isoformat()
+    overall_started_monotonic = time.monotonic()
+    phase_fields = (
+        "build_seconds",
+        "push_seconds",
+        "rmi_seconds",
+        "system_prune_seconds",
+        "builder_prune_seconds",
+    )
+    phase_totals = {field: 0.0 for field in phase_fields}
+    phase_seen = {field: False for field in phase_fields}
+    cleanup_phases = ("rmi", "system_prune", "builder_prune")
+    cleanup_returncodes: dict[str, int | None] = {
+        phase: None for phase in cleanup_phases
+    }
+    cleanup_timeouts: dict[str, bool | None] = {phase: None for phase in cleanup_phases}
+    cleanup_metadata_seen = {phase: False for phase in cleanup_phases}
+    cleanup_ok_seen = False
+    cleanup_ok_total = True
+    final_result: BuildOutput | None = None
+    attempts_used = 0
     assert max_retries >= 1
     for attempt in range(max_retries):
+        attempts_used = attempt + 1
         with capture_output(base_image, log_dir) as log_path:
             if attempt > 0:
                 logger.info(
@@ -730,13 +878,44 @@ def _assemble_with_logging(
                     base_image=base_image,
                     tags=[],
                     error=repr(e),
+                    status="failed",
                     log_path=str(log_path),
                 )
             result.log_path = str(log_path)
+            for field in phase_fields:
+                value = getattr(result, field, None)
+                if value is not None:
+                    phase_totals[field] += value
+                    phase_seen[field] = True
+
+            result_cleanup_ok = result.cleanup_ok
+            if result_cleanup_ok is not None:
+                cleanup_ok_seen = True
+                cleanup_ok_total = cleanup_ok_total and result_cleanup_ok
+
+            for phase in cleanup_phases:
+                returncode = getattr(result, f"{phase}_returncode", None)
+                timed_out = getattr(result, f"{phase}_timed_out", None)
+                if returncode is None and timed_out is None:
+                    continue
+                previously_seen = cleanup_metadata_seen[phase]
+                cleanup_metadata_seen[phase] = True
+                if timed_out is True:
+                    cleanup_timeouts[phase] = True
+                    cleanup_returncodes[phase] = None
+                elif cleanup_timeouts[phase] is not True:
+                    if returncode is not None and returncode != 0:
+                        cleanup_returncodes[phase] = returncode
+                        cleanup_timeouts[phase] = False
+                    elif not previously_seen:
+                        cleanup_returncodes[phase] = returncode
+                        cleanup_timeouts[phase] = timed_out
+
             if result.error:
                 logger.error("Assembly error for %s: %s", base_image, result.error)
+                final_result = result
                 if attempt == max_retries - 1:
-                    return result
+                    break
                 continue
 
             # Apply wrapping for repos that need docutils/roman (e.g. sphinx-doc)
@@ -747,21 +926,69 @@ def _assemble_with_logging(
 
             if should_wrap_custom_tag(custom_tag):
                 logger.info("Wrapping %s with docutils/roman", final_tag)
-                wrap_result = wrap_image(final_tag, push=push)
-                if wrap_result.error:
-                    result = BuildOutput(
-                        base_image=base_image,
-                        tags=result.tags,
-                        error=f"Wrapping failed: {wrap_result.error}",
-                        log_path=str(log_path),
+                try:
+                    wrap_result = wrap_image(final_tag, push=push)
+                except Exception as exc:
+                    result = result.model_copy(
+                        update={
+                            "error": f"Wrapping failed: {exc!r}",
+                            "status": "failed",
+                            "log_path": str(log_path),
+                        }
                     )
+                else:
+                    if wrap_result.error:
+                        result = result.model_copy(
+                            update={
+                                "error": f"Wrapping failed: {wrap_result.error}",
+                                "status": "failed",
+                                "log_path": str(log_path),
+                            }
+                        )
+                if result.error:
+                    final_result = result
                     if attempt == max_retries - 1:
-                        return result
+                        break
                     continue
 
-            return result
+            final_result = result
+            break
 
-    raise RuntimeError("Unreachable")
+    if final_result is None:
+        raise RuntimeError("Unreachable")
+
+    final_result.attempt_count = attempts_used
+    final_result.started_at = overall_started_at
+    final_result.finished_at = datetime.now(UTC).isoformat()
+    final_result.duration_seconds = round(
+        max(
+            time.monotonic() - overall_started_monotonic,
+            sum(phase_totals.values()),
+        ),
+        3,
+    )
+    for field in phase_fields:
+        if phase_seen[field]:
+            setattr(final_result, field, round(phase_totals[field], 3))
+    for phase in cleanup_phases:
+        if cleanup_metadata_seen[phase]:
+            setattr(
+                final_result,
+                f"{phase}_returncode",
+                cleanup_returncodes[phase],
+            )
+            setattr(
+                final_result,
+                f"{phase}_timed_out",
+                cleanup_timeouts[phase],
+            )
+    if cleanup_ok_seen:
+        final_result.cleanup_ok = cleanup_ok_total
+    if final_result.error:
+        final_result.status = "failed"
+    else:
+        final_result.status = "built"
+    return final_result
 
 
 def assemble_all_agent_images(

--- a/benchmarks/utils/build_manifest.py
+++ b/benchmarks/utils/build_manifest.py
@@ -37,6 +37,10 @@ class BuildManifestSummary(BaseModel):
     cumulative_duration_seconds: float = 0.0
     cumulative_remote_check_seconds: float = 0.0
     cumulative_build_seconds: float = 0.0
+    cumulative_push_seconds: float = 0.0
+    cumulative_rmi_seconds: float = 0.0
+    cumulative_system_prune_seconds: float = 0.0
+    cumulative_builder_prune_seconds: float = 0.0
     cumulative_post_build_seconds: float = 0.0
     cumulative_sdk_build_context_seconds: float = 0.0
     cumulative_sdk_buildx_wall_clock_seconds: float = 0.0
@@ -48,6 +52,14 @@ class BuildManifestSummary(BaseModel):
     cumulative_sdk_export_manifest_seconds: float = 0.0
     cumulative_sdk_cache_import_misses: int = 0
     cumulative_sdk_cached_steps: int = 0
+    cleanup_failures: int = 0
+    cleanup_timeouts: int = 0
+    rmi_failures: int = 0
+    rmi_timeouts: int = 0
+    system_prune_failures: int = 0
+    system_prune_timeouts: int = 0
+    builder_prune_failures: int = 0
+    builder_prune_timeouts: int = 0
     average_build_seconds: float | None = None
     median_build_seconds: float | None = None
     max_build_seconds: float | None = None
@@ -84,6 +96,15 @@ def _sum_float_field(records: list[dict[str, Any]], field_name: str) -> float:
         if value is not None:
             total += value
     return total
+
+
+def _is_nonzero_returncode(value: Any) -> bool:
+    if value is None:
+        return False
+    try:
+        return int(value) != 0
+    except (TypeError, ValueError):
+        return False
 
 
 def _sum_int_field(records: list[dict[str, Any]], field_name: str) -> int:
@@ -136,6 +157,14 @@ def summarize_build_records(
     failed_builds: list[FailedBuild] = []
 
     cumulative_duration = 0.0
+    cleanup_failures = 0
+    cleanup_timeouts = 0
+    cleanup_failure_counts = {
+        phase: 0 for phase in ("rmi", "system_prune", "builder_prune")
+    }
+    cleanup_timeout_counts = {
+        phase: 0 for phase in ("rmi", "system_prune", "builder_prune")
+    }
     retried = 0
 
     for record in records:
@@ -161,6 +190,15 @@ def summarize_build_records(
         duration_seconds = _normalize_float(record.get("duration_seconds"))
         if duration_seconds is not None:
             cumulative_duration += duration_seconds
+
+        if record.get("cleanup_ok") is False:
+            cleanup_failures += 1
+        for phase in ("rmi", "system_prune", "builder_prune"):
+            if record.get(f"{phase}_timed_out") is True:
+                cleanup_timeouts += 1
+                cleanup_timeout_counts[phase] += 1
+            if _is_nonzero_returncode(record.get(f"{phase}_returncode")):
+                cleanup_failure_counts[phase] += 1
 
         if status == "built" and duration_seconds is not None:
             build_durations.append(duration_seconds)
@@ -229,6 +267,14 @@ def summarize_build_records(
             records, "remote_check_seconds"
         ),
         cumulative_build_seconds=_sum_float_field(records, "build_seconds"),
+        cumulative_push_seconds=_sum_float_field(records, "push_seconds"),
+        cumulative_rmi_seconds=_sum_float_field(records, "rmi_seconds"),
+        cumulative_system_prune_seconds=_sum_float_field(
+            records, "system_prune_seconds"
+        ),
+        cumulative_builder_prune_seconds=_sum_float_field(
+            records, "builder_prune_seconds"
+        ),
         cumulative_post_build_seconds=_sum_float_field(records, "post_build_seconds"),
         cumulative_sdk_build_context_seconds=_sum_float_field(
             records, "sdk_build_context_seconds"
@@ -256,6 +302,14 @@ def summarize_build_records(
             records, "sdk_cache_import_miss_count"
         ),
         cumulative_sdk_cached_steps=_sum_int_field(records, "sdk_cached_step_count"),
+        cleanup_failures=cleanup_failures,
+        cleanup_timeouts=cleanup_timeouts,
+        rmi_failures=cleanup_failure_counts["rmi"],
+        rmi_timeouts=cleanup_timeout_counts["rmi"],
+        system_prune_failures=cleanup_failure_counts["system_prune"],
+        system_prune_timeouts=cleanup_timeout_counts["system_prune"],
+        builder_prune_failures=cleanup_failure_counts["builder_prune"],
+        builder_prune_timeouts=cleanup_timeout_counts["builder_prune"],
         average_build_seconds=average_build_seconds,
         median_build_seconds=median_build_seconds,
         max_build_seconds=max_build_seconds,
@@ -321,6 +375,10 @@ def render_build_summary_markdown(
     phase_lines = [
         ("Remote Checks", summary.cumulative_remote_check_seconds),
         ("Build Wrapper Time", summary.cumulative_build_seconds),
+        ("Push", summary.cumulative_push_seconds),
+        ("RMI", summary.cumulative_rmi_seconds),
+        ("System Prune", summary.cumulative_system_prune_seconds),
+        ("Builder Prune", summary.cumulative_builder_prune_seconds),
         ("Post-Build Hooks", summary.cumulative_post_build_seconds),
         ("SDK Build Context", summary.cumulative_sdk_build_context_seconds),
         ("SDK Buildx Wall Clock", summary.cumulative_sdk_buildx_wall_clock_seconds),
@@ -352,6 +410,31 @@ def render_build_summary_markdown(
             lines.append(
                 f"- **SDK Cached Steps:** {summary.cumulative_sdk_cached_steps}"
             )
+
+    cleanup_counts = (
+        summary.cleanup_failures,
+        summary.cleanup_timeouts,
+        summary.rmi_failures,
+        summary.rmi_timeouts,
+        summary.system_prune_failures,
+        summary.system_prune_timeouts,
+        summary.builder_prune_failures,
+        summary.builder_prune_timeouts,
+    )
+    if any(cleanup_counts):
+        lines.extend(["", "### Cleanup Health", ""])
+        lines.append(f"- Cleanup failures: {summary.cleanup_failures}")
+        lines.append(f"- Cleanup timeouts: {summary.cleanup_timeouts}")
+        for label, count in (
+            ("RMI failures", summary.rmi_failures),
+            ("RMI timeouts", summary.rmi_timeouts),
+            ("System prune failures", summary.system_prune_failures),
+            ("System prune timeouts", summary.system_prune_timeouts),
+            ("Builder prune failures", summary.builder_prune_failures),
+            ("Builder prune timeouts", summary.builder_prune_timeouts),
+        ):
+            if count:
+                lines.append(f"- {label}: {count}")
 
     if summary.average_build_seconds is not None:
         lines.append(

--- a/benchmarks/utils/build_manifest.py
+++ b/benchmarks/utils/build_manifest.py
@@ -191,14 +191,20 @@ def summarize_build_records(
         if duration_seconds is not None:
             cumulative_duration += duration_seconds
 
-        if record.get("cleanup_ok") is False:
-            cleanup_failures += 1
+        record_has_failure = False
+        record_has_timeout = False
         for phase in ("rmi", "system_prune", "builder_prune"):
             if record.get(f"{phase}_timed_out") is True:
+                record_has_timeout = True
                 cleanup_timeouts += 1
                 cleanup_timeout_counts[phase] += 1
             if _is_nonzero_returncode(record.get(f"{phase}_returncode")):
+                record_has_failure = True
                 cleanup_failure_counts[phase] += 1
+        if record.get("cleanup_ok") is False and not record_has_timeout:
+            record_has_failure = True
+        if record_has_failure:
+            cleanup_failures += 1
 
         if status == "built" and duration_seconds is not None:
             build_durations.append(duration_seconds)
@@ -423,7 +429,9 @@ def render_build_summary_markdown(
     )
     if any(cleanup_counts):
         lines.extend(["", "### Cleanup Health", ""])
-        lines.append(f"- Cleanup failures: {summary.cleanup_failures}")
+        lines.append(
+            f"- Cleanup failures (excluding timeouts): {summary.cleanup_failures}"
+        )
         lines.append(f"- Cleanup timeouts: {summary.cleanup_timeouts}")
         for label, count in (
             ("RMI failures", summary.rmi_failures),

--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -52,6 +52,17 @@ class BuildOutput(BaseModel):
     duration_seconds: float | None = None
     remote_check_seconds: float | None = None
     build_seconds: float | None = None
+    push_seconds: float | None = None
+    rmi_seconds: float | None = None
+    rmi_returncode: int | None = None
+    rmi_timed_out: bool | None = None
+    system_prune_seconds: float | None = None
+    system_prune_returncode: int | None = None
+    system_prune_timed_out: bool | None = None
+    builder_prune_seconds: float | None = None
+    builder_prune_returncode: int | None = None
+    builder_prune_timed_out: bool | None = None
+    cleanup_ok: bool | None = None
     post_build_seconds: float | None = None
     sdk_build_context_seconds: float | None = None
     sdk_buildx_wall_clock_seconds: float | None = None

--- a/tests/test_build_manifest.py
+++ b/tests/test_build_manifest.py
@@ -221,7 +221,15 @@ def test_summary_aggregates_assembly_cleanup_telemetry():
                 "builder_prune_returncode": None,
                 "builder_prune_timed_out": True,
                 "cleanup_ok": False,
-            }
+            },
+            {
+                "base_image": "repo/image-timeout-only",
+                "status": "built",
+                "tags": ["tag-timeout"],
+                "duration_seconds": 5.0,
+                "system_prune_timed_out": True,
+                "cleanup_ok": False,
+            },
         ],
         manifest_files=1,
     )
@@ -231,7 +239,7 @@ def test_summary_aggregates_assembly_cleanup_telemetry():
     assert summary.cumulative_system_prune_seconds == 0.2
     assert summary.cumulative_builder_prune_seconds == 0.3
     assert summary.cleanup_failures == 1
-    assert summary.cleanup_timeouts == 1
+    assert summary.cleanup_timeouts == 2
     assert summary.rmi_failures == 0
     assert summary.system_prune_failures == 1
     assert summary.builder_prune_timeouts == 1
@@ -240,5 +248,5 @@ def test_summary_aggregates_assembly_cleanup_telemetry():
     assert "### Phase Totals" in markdown
     assert "**Push:** 2s" in markdown
     assert "**System Prune:** 0s" in markdown
-    assert "Cleanup failures: 1" in markdown
-    assert "Cleanup timeouts: 1" in markdown
+    assert "Cleanup failures (excluding timeouts): 1" in markdown
+    assert "Cleanup timeouts: 2" in markdown

--- a/tests/test_build_manifest.py
+++ b/tests/test_build_manifest.py
@@ -199,3 +199,46 @@ def test_render_eval_env_summary_markdown_includes_batch_details(tmp_path):
         "Batch 1: 6 unique images in 9m 06s (attempts=1), selected_instances=10"
         in markdown
     )
+
+
+def test_summary_aggregates_assembly_cleanup_telemetry():
+    summary = summarize_build_records(
+        [
+            {
+                "base_image": "repo/image-a",
+                "status": "built",
+                "tags": ["tag-a"],
+                "duration_seconds": 10.0,
+                "build_seconds": 6.0,
+                "push_seconds": 2.0,
+                "rmi_seconds": 0.1,
+                "rmi_returncode": 0,
+                "rmi_timed_out": False,
+                "system_prune_seconds": 0.2,
+                "system_prune_returncode": 1,
+                "system_prune_timed_out": False,
+                "builder_prune_seconds": 0.3,
+                "builder_prune_returncode": None,
+                "builder_prune_timed_out": True,
+                "cleanup_ok": False,
+            }
+        ],
+        manifest_files=1,
+    )
+
+    assert summary.cumulative_push_seconds == 2.0
+    assert summary.cumulative_rmi_seconds == 0.1
+    assert summary.cumulative_system_prune_seconds == 0.2
+    assert summary.cumulative_builder_prune_seconds == 0.3
+    assert summary.cleanup_failures == 1
+    assert summary.cleanup_timeouts == 1
+    assert summary.rmi_failures == 0
+    assert summary.system_prune_failures == 1
+    assert summary.builder_prune_timeouts == 1
+
+    markdown = render_build_summary_markdown(summary, "Assembly Summary")
+    assert "### Phase Totals" in markdown
+    assert "**Push:** 2s" in markdown
+    assert "**System Prune:** 0s" in markdown
+    assert "Cleanup failures: 1" in markdown
+    assert "Cleanup timeouts: 1" in markdown

--- a/tests/test_phased_build.py
+++ b/tests/test_phased_build.py
@@ -332,6 +332,8 @@ class TestAssembleAgentImage:
         assert result.error is not None
         assert "Failed to push 1/2 tags" in result.error
         assert result.tags == ["tag-1"]
+        assert result.build_seconds is not None
+        assert result.push_seconds is not None
 
     def test_build_failure_returns_error(self, tmp_path):
         from benchmarks.swebench.build_base_images import assemble_agent_image
@@ -358,6 +360,8 @@ class TestAssembleAgentImage:
         assert result.error is not None
         assert "docker build failed" in result.error
         assert result.tags == []
+        assert result.build_seconds is not None
+        assert result.duration_seconds is not None
 
     def test_all_pushes_succeed(self, tmp_path):
         from benchmarks.swebench.build_base_images import assemble_agent_image
@@ -383,6 +387,30 @@ class TestAssembleAgentImage:
 
         assert result.error is None
         assert result.tags == ["tag-1", "tag-2"]
+        assert result.duration_seconds is not None
+        assert result.build_seconds is not None
+        assert result.push_seconds is not None
+        assert result.rmi_seconds is not None
+        assert result.rmi_returncode == 0
+        assert result.rmi_timed_out is False
+        assert result.system_prune_seconds is not None
+        assert result.system_prune_returncode == 0
+        assert result.system_prune_timed_out is False
+        assert result.builder_prune_seconds is not None
+        assert result.builder_prune_returncode == 0
+        assert result.builder_prune_timed_out is False
+        assert result.cleanup_ok is True
+        assert result.duration_seconds >= sum(
+            phase_seconds
+            for phase_seconds in (
+                result.build_seconds,
+                result.push_seconds,
+                result.rmi_seconds,
+                result.system_prune_seconds,
+                result.builder_prune_seconds,
+            )
+            if phase_seconds is not None
+        )
         commands = [call.args[0] for call in mock_run.call_args_list]
         assert commands[-3:] == [
             [
@@ -404,6 +432,106 @@ class TestAssembleAgentImage:
             ],
         ]
 
+    def test_no_push_skips_cleanup_telemetry(self, tmp_path):
+        from benchmarks.swebench.build_base_images import assemble_agent_image
+
+        dockerfile = tmp_path / "Dockerfile.agent-layer"
+        dockerfile.write_text("FROM scratch\n")
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.AGENT_LAYER_DOCKERFILE",
+                dockerfile,
+            ),
+            patch(
+                "benchmarks.swebench.build_base_images.subprocess.run",
+                return_value=_ok_proc(),
+            ) as mock_run,
+        ):
+            result = assemble_agent_image(
+                base_tag="ghcr.io/openhands/eval-base:abc",
+                builder_tag="ghcr.io/openhands/eval-builder:def",
+                final_tags=["tag-1"],
+                push=False,
+            )
+
+        assert result.error is None
+        assert result.push_seconds == 0.0
+        assert result.rmi_seconds is None
+        assert result.system_prune_seconds is None
+        assert result.builder_prune_seconds is None
+        assert result.cleanup_ok is None
+        mock_run.assert_called_once()
+
+    def test_cleanup_nonzero_does_not_fail_assembly(self, tmp_path):
+        from benchmarks.swebench.build_base_images import assemble_agent_image
+
+        dockerfile = tmp_path / "Dockerfile.agent-layer"
+        dockerfile.write_text("FROM scratch\n")
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.AGENT_LAYER_DOCKERFILE",
+                dockerfile,
+            ),
+            patch("benchmarks.swebench.build_base_images.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                _ok_proc(),  # docker build
+                _ok_proc(),  # docker push
+                _ok_proc(),  # docker rmi
+                _fail_proc("prune locked"),  # docker system prune
+                _ok_proc(),  # docker builder prune
+            ]
+
+            result = assemble_agent_image(
+                base_tag="ghcr.io/openhands/eval-base:abc",
+                builder_tag="ghcr.io/openhands/eval-builder:def",
+                final_tags=["tag-1"],
+                push=True,
+            )
+
+        assert result.error is None
+        assert result.tags == ["tag-1"]
+        assert result.status == "built"
+        assert result.cleanup_ok is False
+        assert result.system_prune_returncode == 1
+        assert result.system_prune_timed_out is False
+
+    def test_cleanup_timeout_does_not_fail_assembly(self, tmp_path):
+        from benchmarks.swebench.build_base_images import assemble_agent_image
+
+        dockerfile = tmp_path / "Dockerfile.agent-layer"
+        dockerfile.write_text("FROM scratch\n")
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.AGENT_LAYER_DOCKERFILE",
+                dockerfile,
+            ),
+            patch("benchmarks.swebench.build_base_images.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                _ok_proc(),  # docker build
+                _ok_proc(),  # docker push
+                _ok_proc(),  # docker rmi
+                _timeout_exc(stderr="prune stalled"),  # docker system prune
+                _ok_proc(),  # docker builder prune
+            ]
+
+            result = assemble_agent_image(
+                base_tag="ghcr.io/openhands/eval-base:abc",
+                builder_tag="ghcr.io/openhands/eval-builder:def",
+                final_tags=["tag-1"],
+                push=True,
+            )
+
+        assert result.error is None
+        assert result.tags == ["tag-1"]
+        assert result.cleanup_ok is False
+        assert result.system_prune_returncode is None
+        assert result.system_prune_timed_out is True
+
     def test_missing_dockerfile_returns_error(self, tmp_path):
         from benchmarks.swebench.build_base_images import assemble_agent_image
 
@@ -418,6 +546,9 @@ class TestAssembleAgentImage:
             )
         assert result.error is not None
         assert "not found" in result.error
+        assert result.status == "failed"
+        assert result.duration_seconds is not None
+        assert result.build_seconds == 0.0
 
     def test_build_timeout_returns_error(self, tmp_path):
         from benchmarks.swebench.build_base_images import assemble_agent_image
@@ -445,6 +576,8 @@ class TestAssembleAgentImage:
         assert result.tags == []
         assert result.error is not None
         assert "timed out" in result.error
+        assert result.build_seconds is not None
+        assert result.duration_seconds is not None
 
 
 # ---------------------------------------------------------------------------
@@ -541,7 +674,18 @@ class TestAssembleAllAgentImages:
     ):
         from benchmarks.swebench.build_base_images import assemble_all_agent_images
 
-        ok = BuildOutput(base_image="img-a", tags=["final-tag"], error=None)
+        ok = BuildOutput(
+            base_image="img-a",
+            tags=["final-tag"],
+            error=None,
+            duration_seconds=3.0,
+            build_seconds=2.0,
+            push_seconds=0.5,
+            rmi_seconds=0.1,
+            rmi_returncode=0,
+            rmi_timed_out=False,
+            cleanup_ok=True,
+        )
         mock_assemble.return_value = ok
 
         rc = assemble_all_agent_images(
@@ -559,6 +703,12 @@ class TestAssembleAllAgentImages:
         ]
         assert len(records) == 1
         assert records[0]["tags"] == ["final-tag"]
+        assert records[0]["duration_seconds"] == 3.0
+        assert records[0]["build_seconds"] == 2.0
+        assert records[0]["push_seconds"] == 0.5
+        assert records[0]["rmi_seconds"] == 0.1
+        assert records[0]["rmi_returncode"] == 0
+        assert records[0]["cleanup_ok"] is True
         mock_docker_command.assert_called_once_with(
             ["docker", "buildx", "prune", "-af"]
         )

--- a/tests/test_phased_build.py
+++ b/tests/test_phased_build.py
@@ -334,6 +334,7 @@ class TestAssembleAgentImage:
         assert result.tags == ["tag-1"]
         assert result.build_seconds is not None
         assert result.push_seconds is not None
+        assert mock_run.call_count == 3
 
     def test_build_failure_returns_error(self, tmp_path):
         from benchmarks.swebench.build_base_images import assemble_agent_image
@@ -498,6 +499,53 @@ class TestAssembleAgentImage:
         assert result.system_prune_returncode == 1
         assert result.system_prune_timed_out is False
 
+    def test_cleanup_exception_does_not_fail_assembly_or_skip_builder_prune(
+        self, tmp_path
+    ):
+        from benchmarks.swebench.build_base_images import assemble_agent_image
+
+        dockerfile = tmp_path / "Dockerfile.agent-layer"
+        dockerfile.write_text("FROM scratch\n")
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.AGENT_LAYER_DOCKERFILE",
+                dockerfile,
+            ),
+            patch("benchmarks.swebench.build_base_images.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                _ok_proc(),  # docker build
+                _ok_proc(),  # docker push
+                _ok_proc(),  # docker rmi
+                RuntimeError("prune crashed"),  # docker system prune
+                _ok_proc(),  # docker builder prune
+            ]
+
+            result = assemble_agent_image(
+                base_tag="ghcr.io/openhands/eval-base:abc",
+                builder_tag="ghcr.io/openhands/eval-builder:def",
+                final_tags=["tag-1"],
+                push=True,
+            )
+
+        assert result.error is None
+        assert result.status == "built"
+        assert result.tags == ["tag-1"]
+        assert result.cleanup_ok is False
+        assert result.system_prune_returncode is None
+        assert result.system_prune_timed_out is None
+        assert result.builder_prune_returncode == 0
+        assert result.builder_prune_timed_out is False
+        assert [call.args[0] for call in mock_run.call_args_list][-1] == [
+            "docker",
+            "builder",
+            "prune",
+            "-af",
+            "--keep-storage",
+            "30g",
+        ]
+
     def test_cleanup_timeout_does_not_fail_assembly(self, tmp_path):
         from benchmarks.swebench.build_base_images import assemble_agent_image
 
@@ -578,6 +626,271 @@ class TestAssembleAgentImage:
         assert "timed out" in result.error
         assert result.build_seconds is not None
         assert result.duration_seconds is not None
+
+    def test_empty_final_tags_are_not_reported_as_success(self, tmp_path):
+        from benchmarks.swebench.build_base_images import assemble_agent_image
+
+        dockerfile = tmp_path / "Dockerfile.agent-layer"
+        dockerfile.write_text("FROM scratch\n")
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.AGENT_LAYER_DOCKERFILE",
+                dockerfile,
+            ),
+            patch(
+                "benchmarks.swebench.build_base_images.subprocess.run",
+                return_value=_ok_proc(),
+            ) as mock_run,
+        ):
+            result = assemble_agent_image(
+                base_tag="base:tag",
+                builder_tag="builder:tag",
+                final_tags=[],
+                push=False,
+            )
+
+        assert result.tags == []
+        assert result.error is not None
+        assert result.status == "failed"
+        assert result.build_seconds is not None
+        assert result.push_seconds == 0.0
+        assert result.duration_seconds is not None
+        mock_run.assert_not_called()
+
+    def test_build_exception_preserves_elapsed_timing(self, tmp_path):
+        from benchmarks.swebench.build_base_images import assemble_agent_image
+
+        dockerfile = tmp_path / "Dockerfile.agent-layer"
+        dockerfile.write_text("FROM scratch\n")
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.AGENT_LAYER_DOCKERFILE",
+                dockerfile,
+            ),
+            patch(
+                "benchmarks.swebench.build_base_images.subprocess.run",
+                side_effect=RuntimeError("docker unavailable"),
+            ),
+        ):
+            result = assemble_agent_image(
+                base_tag="base:tag",
+                builder_tag="builder:tag",
+                final_tags=["final:tag"],
+                push=False,
+            )
+
+        assert result.tags == []
+        assert result.error is not None
+        assert "docker unavailable" in result.error
+        assert result.status == "failed"
+        assert result.build_seconds is not None
+        assert result.duration_seconds is not None
+
+
+class TestAssembleWithLogging:
+    def test_retries_accumulate_assembly_telemetry(self, tmp_path):
+        from benchmarks.swebench.build_base_images import _assemble_with_logging
+
+        first = BuildOutput(
+            base_image="base",
+            tags=[],
+            error="transient build failure",
+            status="failed",
+            duration_seconds=1.2,
+            build_seconds=1.0,
+            push_seconds=0.2,
+        )
+        second = BuildOutput(
+            base_image="base",
+            tags=["final"],
+            error=None,
+            status="built",
+            build_seconds=3.0,
+            push_seconds=0.4,
+            rmi_seconds=0.1,
+            rmi_returncode=0,
+            rmi_timed_out=False,
+            system_prune_seconds=0.2,
+            system_prune_returncode=0,
+            system_prune_timed_out=False,
+            builder_prune_seconds=0.3,
+            builder_prune_returncode=0,
+            builder_prune_timed_out=False,
+            cleanup_ok=True,
+        )
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.remote_image_exists",
+                return_value=False,
+            ),
+            patch(
+                "benchmarks.swebench.build_base_images.capture_output"
+            ) as mock_capture,
+            patch(
+                "benchmarks.swebench.build_base_images.assemble_agent_image",
+                side_effect=[first, second],
+            ) as mock_assemble,
+            patch(
+                "benchmarks.swebench.build_images.should_wrap_custom_tag",
+                return_value=False,
+            ),
+            patch("time.sleep"),
+        ):
+            mock_capture.return_value.__enter__.side_effect = [
+                tmp_path / "attempt-1.log",
+                tmp_path / "attempt-2.log",
+            ]
+            mock_capture.return_value.__exit__.return_value = False
+
+            result = _assemble_with_logging(
+                log_dir=tmp_path,
+                base_image="base",
+                custom_tag="tag",
+                builder_tag="builder",
+                target_image="target",
+                sdk_short_sha="sdk",
+                sdk_full_sha="sdk-full",
+                target="source-minimal",
+                max_retries=2,
+                force_build=True,
+                content_hash="hash",
+            )
+
+        assert mock_assemble.call_count == 2
+        assert result.tags == ["final"]
+        assert result.error is None
+        assert result.status == "built"
+        assert result.attempt_count == 2
+        assert result.started_at is not None
+        assert result.finished_at is not None
+        assert result.build_seconds == 4.0
+        assert result.push_seconds == 0.6
+        assert result.rmi_seconds == 0.1
+        assert result.system_prune_seconds == 0.2
+        assert result.builder_prune_seconds == 0.3
+        assert result.cleanup_ok is True
+        assert result.duration_seconds is not None
+        assert result.duration_seconds >= 5.2
+
+    def test_wrapper_retry_preserves_cleanup_timeout_and_records_wrapper_time(
+        self, tmp_path
+    ):
+        from benchmarks.swebench.build_base_images import _assemble_with_logging
+
+        first = BuildOutput(
+            base_image="base",
+            tags=["final"],
+            error=None,
+            status="built",
+            build_seconds=1.0,
+            push_seconds=0.5,
+            rmi_seconds=0.1,
+            rmi_returncode=0,
+            rmi_timed_out=False,
+            system_prune_seconds=0.2,
+            system_prune_returncode=None,
+            system_prune_timed_out=True,
+            builder_prune_seconds=0.3,
+            builder_prune_returncode=0,
+            builder_prune_timed_out=False,
+            cleanup_ok=False,
+        )
+        second = BuildOutput(
+            base_image="base",
+            tags=["final"],
+            error=None,
+            status="built",
+            build_seconds=2.0,
+            push_seconds=0.4,
+            rmi_seconds=0.1,
+            rmi_returncode=0,
+            rmi_timed_out=False,
+            system_prune_seconds=0.2,
+            system_prune_returncode=0,
+            system_prune_timed_out=False,
+            builder_prune_seconds=0.3,
+            builder_prune_returncode=0,
+            builder_prune_timed_out=False,
+            cleanup_ok=True,
+        )
+        wrapper_failure = BuildOutput(
+            base_image="final",
+            tags=[],
+            error="wrapper failed",
+            status="failed",
+            duration_seconds=0.7,
+        )
+        wrapper_success = BuildOutput(
+            base_image="final",
+            tags=["final"],
+            error=None,
+            duration_seconds=0.4,
+        )
+
+        with (
+            patch(
+                "benchmarks.swebench.build_base_images.remote_image_exists",
+                return_value=False,
+            ),
+            patch(
+                "benchmarks.swebench.build_base_images.capture_output"
+            ) as mock_capture,
+            patch(
+                "benchmarks.swebench.build_base_images.assemble_agent_image",
+                side_effect=[first, second],
+            ),
+            patch(
+                "benchmarks.swebench.build_images.should_wrap_custom_tag",
+                return_value=True,
+            ),
+            patch(
+                "benchmarks.swebench.build_images.wrap_image",
+                side_effect=[wrapper_failure, wrapper_success],
+            ) as mock_wrap,
+            patch("time.sleep"),
+        ):
+            mock_capture.return_value.__enter__.side_effect = [
+                tmp_path / "attempt-1.log",
+                tmp_path / "attempt-2.log",
+            ]
+            mock_capture.return_value.__exit__.return_value = False
+
+            result = _assemble_with_logging(
+                log_dir=tmp_path,
+                base_image="base",
+                custom_tag="wrapped",
+                builder_tag="builder",
+                target_image="target",
+                sdk_short_sha="sdk",
+                sdk_full_sha="sdk-full",
+                target="source-minimal",
+                push=True,
+                max_retries=2,
+                force_build=True,
+                content_hash="hash",
+            )
+
+        assert mock_wrap.call_count == 2
+        assert result.error is None
+        assert result.status == "built"
+        assert result.attempt_count == 2
+        assert result.system_prune_returncode is None
+        assert result.system_prune_timed_out is True
+        assert result.cleanup_ok is False
+        assert result.post_build_seconds is not None
+        assert result.duration_seconds is not None
+        phase_total = (
+            result.build_seconds
+            + result.push_seconds
+            + result.rmi_seconds
+            + result.system_prune_seconds
+            + result.builder_prune_seconds
+            + result.post_build_seconds
+        )
+        assert result.duration_seconds >= phase_total
 
 
 # ---------------------------------------------------------------------------
@@ -684,7 +997,14 @@ class TestAssembleAllAgentImages:
             rmi_seconds=0.1,
             rmi_returncode=0,
             rmi_timed_out=False,
+            system_prune_seconds=0.2,
+            system_prune_returncode=0,
+            system_prune_timed_out=False,
+            builder_prune_seconds=0.3,
+            builder_prune_returncode=0,
+            builder_prune_timed_out=False,
             cleanup_ok=True,
+            post_build_seconds=0.4,
         )
         mock_assemble.return_value = ok
 
@@ -708,6 +1028,11 @@ class TestAssembleAllAgentImages:
         assert records[0]["push_seconds"] == 0.5
         assert records[0]["rmi_seconds"] == 0.1
         assert records[0]["rmi_returncode"] == 0
+        assert records[0]["system_prune_seconds"] == 0.2
+        assert records[0]["system_prune_returncode"] == 0
+        assert records[0]["builder_prune_seconds"] == 0.3
+        assert records[0]["builder_prune_returncode"] == 0
+        assert records[0]["post_build_seconds"] == 0.4
         assert records[0]["cleanup_ok"] is True
         mock_docker_command.assert_called_once_with(
             ["docker", "buildx", "prune", "-af"]


### PR DESCRIPTION
Addresses #692.

### Summary

Record structured timing and cleanup outcomes for phased SWE-bench image assembly.

### Problem

Assembly timing was previously available primarily in human-readable logs, while `manifest.jsonl` records did not reliably preserve total, build, push, and cleanup telemetry. This made performance analysis and cleanup diagnostics depend on scraping CI logs.

### Changes

- Preserve total assembly, Docker build, Docker push, `docker rmi`, `docker system prune`, and `docker builder prune` durations.
- Record cleanup return codes, timeout states, and aggregate `cleanup_ok`.
- Preserve partial telemetry across build failures, push failures, cleanup failures, retries, and wrapper failures.
- Keep cleanup failures warning-only so they do not turn a successfully built primary image into a failed assembly.
- Prevent empty final tags from being reported as a successful build.
- Count cleanup failures and timeouts distinctly in build summary output.
- Add mocked regression coverage for successful assembly, cleanup nonzero/timeout/exception, build failure/timeout, partial push, retry, wrapper retry, no-final-tags, manifest serialization, and summary aggregation.

### Testing

- `pytest tests/test_phased_build.py tests/test_build_manifest.py -q` — 43 passed.
- Ruff check passed for the five relevant files.
- Ruff format check passed for the five relevant files.
- `git diff --check` passed.
- No real Docker build, registry push, full benchmark, or large image download was performed.

### Scope / intentionally unchanged

- Cleanup remains best-effort and warning-only for the primary artifact result.
- No changes to Docker cleanup policy, retention limits, concurrency, `ProcessPoolExecutor`, workflow configuration, or registry behavior.
- Existing optional `BuildOutput` fields and `model_dump_json()` manifest serialization are reused for backward compatibility.

### Known limitations

- Partial push retains the existing behavior and may leave local image/BuildKit state; a retry may re-push tags that already succeeded.
- The wrapper helper does not currently expose an independent timing contract; `post_build_seconds` records the outer wrapper wall-clock duration and uses any available wrapper result duration.
- Validation was limited to mocked targeted tests because Docker is unavailable on the development host.

### AI disclosure

This PR was developed with assistance from Codex. Targeted tests and static checks were run on the Tencent Cloud checkout; maintainer review is still requested.