### PR TITLE
fix: alias locally-built agent-server image instead of failing on tag mismatch

### DIFF
--- a/benchmarks/utils/build_utils.py
+++ b/benchmarks/utils/build_utils.py
@@ -514,9 +514,25 @@ def ensure_local_image(
     if output.error is not None:
         raise RuntimeError(f"Image build failed: {output.error}")
     if agent_server_image not in output.tags:
-        raise RuntimeError(
+        if not output.tags:
+            raise RuntimeError(
+                f"Built image tags {output.tags} do not include expected tag "
+                f"{agent_server_image}"
+            )
+        # The SDK's own tagging (BuildOptions.all_tags) doesn't know about
+        # the benchmarks-side content-hash prefix that
+        # get_phased_image_tag_prefix() adds for phased-build benchmarks
+        # (swebench, swebenchmultimodal, swtbench), so the tag it produces
+        # never matches what callers expect for those benchmarks. Alias the
+        # image we actually built under the expected tag instead of failing
+        # a successful build over a tagging-scheme mismatch.
+        logger.warning(
             f"Built image tags {output.tags} do not include expected tag "
+            f"{agent_server_image}; aliasing {output.tags[0]} -> "
             f"{agent_server_image}"
+        )
+        subprocess.run(
+            ["docker", "tag", output.tags[0], agent_server_image], check=True
         )
     return True
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -199,14 +199,45 @@ class TestEnsureLocalImage:
                 custom_tag="mytag",
             )
 
+    @patch("benchmarks.utils.build_utils.subprocess.run")
     @patch("benchmarks.utils.build_utils.local_image_exists", return_value=False)
     @patch("benchmarks.utils.build_utils.build_image")
-    def test_raises_on_tag_mismatch(self, mock_build, _mock_exists):
+    def test_aliases_tag_on_mismatch(self, mock_build, _mock_exists, mock_run):
+        """The SDK's build tags don't include the benchmarks-side content
+        hash used by get_phased_image_tag_prefix() for phased-build
+        benchmarks. Rather than fail a successful build over the naming
+        mismatch, ensure_local_image should alias the built image under the
+        expected tag with `docker tag`.
+        """
         from benchmarks.utils.build_utils import ensure_local_image
 
         mock_build.return_value = BuildOutput(
             base_image="base:latest",
-            tags=["server:wrong-tag"],
+            tags=["server:actual-tag"],
+            error=None,
+        )
+        result = ensure_local_image(
+            agent_server_image="server:v1",
+            base_image="base:latest",
+            custom_tag="mytag",
+        )
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["docker", "tag", "server:actual-tag", "server:v1"], check=True
+        )
+
+    @patch("benchmarks.utils.build_utils.local_image_exists", return_value=False)
+    @patch("benchmarks.utils.build_utils.build_image")
+    def test_raises_when_build_produces_no_tags(self, mock_build, _mock_exists):
+        """A build that reports no error but also produced no tags at all
+        (nothing to alias) should still raise, distinct from the tag-mismatch
+        case above.
+        """
+        from benchmarks.utils.build_utils import ensure_local_image
+
+        mock_build.return_value = BuildOutput(
+            base_image="base:latest",
+            tags=[],
             error=None,
         )
         with pytest.raises(RuntimeError, match="do not include expected tag"):


### PR DESCRIPTION
## Summary

`ensure_local_image()` raises a `RuntimeError` whenever the tag produced by the SDK's `BuildOptions.all_tags` does not match the tag the caller expects, even though the build itself succeeded and produced a perfectly valid image.

For phased-build benchmarks (swebench, swebenchmultimodal, swtbench), the expected tag includes a benchmarks-side Dockerfile content hash via `get_phased_image_tag_prefix()` (introduced in #599 / #602). The SDK's own tagging logic (`openhands.agent_server.docker.build.BuildOptions`) has no concept of that content hash and never produces a matching tag. As a result, **every local Docker-workspace build for these benchmarks fails after a successful image build**, purely because of a naming mismatch between two independently-evolving tagging schemes — the "pull side" (`get_phased_image_tag_prefix()`) was updated by #599/#602, but the "local on-the-fly build side" (`build_utils.py::ensure_local_image()` → SDK `BuildOptions.all_tags`) was never updated to match.

## Related issue

This is the same root cause reported in #733 ("SWE-Bench Lite Docker workspace fails due to image tag validation mismatch"). That issue was closed without a linked fix PR, and I confirmed the bug is still present on current `main` by reproducing it end-to-end.

Fixes #733

## Reproduction

```
uv run swebench-infer .llm_config/example.json \
    --workspace docker \
    --num-workers 1

RuntimeError: Built image tags ['ghcr.io/openhands/eval-agent-server:<sdk_sha>-sweb.eval.x86_64.<instance>-source-minimal', ...] do not include expected tag ghcr.io/openhands/eval-agent-server:<sdk_sha>-<content_hash>-sweb.eval.x86_64.<instance>-source-minimal
```

The build completes successfully; only the tag string is missing the content hash segment.

## Fix

Instead of raising when the built tag doesn't match the expected tag, alias the image that was actually built under the expected tag with a plain `docker tag` call. The build succeeded and the image is valid — only the tag string differs, so there is nothing to fail over. Raising is still correct (and preserved) when the build produced no tags at all, since there is nothing to alias in that case.

This is a minimal, benchmarks-side-only change — it does not touch the `vendor/software-agent-sdk` submodule, since the mismatch originates entirely from how the two tagging schemes are computed within this repo.

## Tests

- Replaced `test_raises_on_tag_mismatch` (which asserted the old failing behavior) with `test_aliases_tag_on_mismatch`, asserting the `docker tag` aliasing call fires and `ensure_local_image()` now returns `True`.
- Added `test_raises_when_build_produces_no_tags` to keep coverage on the genuine failure case (empty `tags` list, nothing to alias).
- Full suite: `556 passed` (`uv run pytest tests/`).

## Manual end-to-end verification (not mocked)

Ran `ensure_local_image()` directly against a real local Docker build for a SWE-bench pytest instance, without any `IMAGE_TAG_PREFIX` override:

1. First call: build ran, the mismatch warning and `docker tag` alias fired as expected, `ensure_local_image()` returned `True` instead of raising.
2. Confirmed via `docker images` that the aliased (content-hash) tag now resolves locally.
3. Second call: hit the `local_image_exists()` fast path in `0.01s` instead of rebuilding, confirming the aliased tag is picked up correctly on subsequent runs.

## Test plan

- [x] `uv run pytest tests/test_image_utils.py -v`
- [x] `uv run pytest tests/` (full suite, 556 passed)
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files
- [x] Pre-commit hooks (Ruff format, Ruff lint, pycodestyle, Pyright strict) pass
- [x] Manual reproduction of the original bug and confirmation of the fix against a real local Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
