### PR TITLE
fix(eval): wait for LiteLLM spend to settle before recording proxy_cost

### DIFF
--- a/benchmarks/utils/evaluation.py
+++ b/benchmarks/utils/evaluation.py
@@ -59,6 +59,12 @@ from openhands.workspace import APIRemoteWorkspace
 
 logger = get_logger(__name__)
 
+# LiteLLM commits virtual-key spend asynchronously; a read taken right after the
+# last request can catch a partially committed total. Measured commit latency is
+# 5-10s, so poll on that scale and cap the wait at one minute.
+_PROXY_SPEND_POLL_INTERVAL = 5
+_PROXY_SPEND_POLL_ATTEMPTS = 12
+
 # Interval in seconds between checking for per-instance timeouts
 TIMEOUT_CHECK_INTERVAL_SECONDS = 60
 
@@ -307,28 +313,39 @@ class Evaluation(ABC, BaseModel):
         instance_id: str,
         virtual_key: str | None,
     ) -> float | None:
-        """Query exact per-instance spend from the LiteLLM proxy."""
+        """Query exact per-instance spend from the LiteLLM proxy.
+
+        The proxy commits spend a few seconds after each request returns, so an
+        early read can be non-zero yet still climbing; poll until two
+        consecutive reads agree before trusting the value.
+        """
         if virtual_key is None:
             return None
 
         proxy_cost = get_key_spend(virtual_key)
-        if proxy_cost is None or proxy_cost == 0.0:
-            logger.info(
-                "[worker] proxy spend not yet available for %s, retrying...",
-                instance_id,
-            )
-            for delay in (2, 4, 8, 16):
-                time.sleep(delay)
-                retry_cost = get_key_spend(virtual_key)
-                if retry_cost is not None and retry_cost > 0:
-                    proxy_cost = retry_cost
-                    break
+        settled = False
+        for _ in range(_PROXY_SPEND_POLL_ATTEMPTS):
+            time.sleep(_PROXY_SPEND_POLL_INTERVAL)
+            retry_cost = get_key_spend(virtual_key)
+            if retry_cost is None:
+                continue
+            settled = retry_cost > 0.0 and retry_cost == proxy_cost
+            proxy_cost = retry_cost
+            if settled:
+                break
 
         if proxy_cost is not None and proxy_cost == 0.0:
             logger.warning(
                 "[worker] proxy cost still $0 for %s after retries — "
                 "spend may not have been committed by the proxy",
                 instance_id,
+            )
+        elif not settled:
+            logger.warning(
+                "[worker] proxy spend for %s never settled (last read $%s) — "
+                "the recorded cost may be incomplete",
+                instance_id,
+                proxy_cost,
             )
 
         return proxy_cost

--- a/tests/test_evaluation_proxy_cost.py
+++ b/tests/test_evaluation_proxy_cost.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import Mock, call, patch
 
+from benchmarks.utils.evaluation import _PROXY_SPEND_POLL_ATTEMPTS as POLL_ATTEMPTS
 from benchmarks.utils.models import EvalInstance, EvalMetadata, EvalOutput
 from openhands.sdk import LLM
 from openhands.sdk.critic import PassCritic
@@ -121,15 +122,15 @@ def test_proxy_cost_retries_after_initial_zero_spend(tmp_path):
         patch("benchmarks.utils.evaluation.delete_key"),
         patch(
             "benchmarks.utils.evaluation.get_key_spend",
-            side_effect=[0.0, 0.125],
+            side_effect=[0.0, 0.125, 0.125],
         ) as mock_get_key_spend,
         patch("benchmarks.utils.evaluation.time.sleep") as mock_sleep,
     ):
         _, result_output = evaluator._process_one_sync(instance, critic_attempt=1)
 
     assert result_output.test_result["proxy_cost"] == 0.125
-    assert mock_get_key_spend.call_count == 2
-    mock_sleep.assert_called_once_with(2)
+    assert mock_get_key_spend.call_count == 3
+    assert mock_sleep.call_args_list == [call(5), call(5)]
 
 
 def test_proxy_cost_retries_after_initial_none_spend(tmp_path):
@@ -141,15 +142,15 @@ def test_proxy_cost_retries_after_initial_none_spend(tmp_path):
         patch("benchmarks.utils.evaluation.delete_key"),
         patch(
             "benchmarks.utils.evaluation.get_key_spend",
-            side_effect=[None, None, 0.25],
+            side_effect=[None, None, 0.25, 0.25],
         ) as mock_get_key_spend,
         patch("benchmarks.utils.evaluation.time.sleep") as mock_sleep,
     ):
         _, result_output = evaluator._process_one_sync(instance, critic_attempt=1)
 
     assert result_output.test_result["proxy_cost"] == 0.25
-    assert mock_get_key_spend.call_count == 3
-    assert mock_sleep.call_args_list == [call(2), call(4)]
+    assert mock_get_key_spend.call_count == 4
+    assert mock_sleep.call_args_list == [call(5), call(5), call(5)]
 
 
 def test_final_failure_persists_proxy_cost_and_recovered_metrics(tmp_path):
@@ -171,7 +172,7 @@ def test_final_failure_persists_proxy_cost_and_recovered_metrics(tmp_path):
         patch("benchmarks.utils.evaluation.delete_key"),
         patch(
             "benchmarks.utils.evaluation.get_key_spend",
-            side_effect=[0.0, 0.5],
+            side_effect=[0.0, 0.5, 0.5],
         ) as mock_get_key_spend,
         patch("benchmarks.utils.evaluation.time.sleep") as mock_sleep,
     ):
@@ -185,11 +186,11 @@ def test_final_failure_persists_proxy_cost_and_recovered_metrics(tmp_path):
     assert result_output.metrics.accumulated_token_usage.prompt_tokens == 100
     assert result_output.metrics.accumulated_token_usage.completion_tokens == 25
     assert result_output.metrics.accumulated_token_usage.cache_read_tokens == 10
-    assert mock_get_key_spend.call_count == 2
-    mock_sleep.assert_called_once_with(2)
+    assert mock_get_key_spend.call_count == 3
+    assert mock_sleep.call_args_list == [call(5), call(5)]
 
 
-def test_proxy_cost_retry_uses_full_backoff_when_spend_never_appears(tmp_path):
+def test_proxy_cost_polls_full_budget_when_spend_never_appears(tmp_path):
     instance = EvalInstance(id="test_instance", data={"test": "data"})
     evaluator = _build_evaluator(instance, tmp_path)
 
@@ -198,12 +199,52 @@ def test_proxy_cost_retry_uses_full_backoff_when_spend_never_appears(tmp_path):
         patch("benchmarks.utils.evaluation.delete_key"),
         patch(
             "benchmarks.utils.evaluation.get_key_spend",
-            side_effect=[0.0, 0.0, 0.0, 0.0, 0.0],
+            side_effect=[0.0] * (POLL_ATTEMPTS + 1),
         ) as mock_get_key_spend,
         patch("benchmarks.utils.evaluation.time.sleep") as mock_sleep,
     ):
         _, result_output = evaluator._process_one_sync(instance, critic_attempt=1)
 
     assert result_output.test_result["proxy_cost"] == 0.0
-    assert mock_get_key_spend.call_count == 5
-    assert mock_sleep.call_args_list == [call(2), call(4), call(8), call(16)]
+    assert mock_get_key_spend.call_count == POLL_ATTEMPTS + 1
+    assert mock_sleep.call_count == POLL_ATTEMPTS
+
+
+def test_proxy_cost_waits_for_partially_committed_spend_to_settle(tmp_path):
+    """A non-zero read can still be climbing; the settled total is what counts."""
+    instance = EvalInstance(id="test_instance", data={"test": "data"})
+    evaluator = _build_evaluator(instance, tmp_path)
+
+    with (
+        patch("benchmarks.utils.evaluation.create_virtual_key", return_value="sk-test"),
+        patch("benchmarks.utils.evaluation.delete_key"),
+        patch(
+            "benchmarks.utils.evaluation.get_key_spend",
+            side_effect=[0.0, 0.025362, 0.077144, 0.077144],
+        ) as mock_get_key_spend,
+        patch("benchmarks.utils.evaluation.time.sleep"),
+    ):
+        _, result_output = evaluator._process_one_sync(instance, critic_attempt=1)
+
+    assert result_output.test_result["proxy_cost"] == 0.077144
+    assert mock_get_key_spend.call_count == 4
+
+
+def test_proxy_cost_returns_last_read_when_spend_never_settles(tmp_path):
+    instance = EvalInstance(id="test_instance", data={"test": "data"})
+    evaluator = _build_evaluator(instance, tmp_path)
+    climbing = [float(i + 1) for i in range(POLL_ATTEMPTS + 1)]
+
+    with (
+        patch("benchmarks.utils.evaluation.create_virtual_key", return_value="sk-test"),
+        patch("benchmarks.utils.evaluation.delete_key"),
+        patch(
+            "benchmarks.utils.evaluation.get_key_spend",
+            side_effect=climbing,
+        ) as mock_get_key_spend,
+        patch("benchmarks.utils.evaluation.time.sleep"),
+    ):
+        _, result_output = evaluator._process_one_sync(instance, critic_attempt=1)
+
+    assert result_output.test_result["proxy_cost"] == climbing[-1]
+    assert mock_get_key_spend.call_count == POLL_ATTEMPTS + 1


### PR DESCRIPTION
## Why

`proxy_cost` is the exact per-instance spend we report from LiteLLM virtual keys, and it is the number the ACP harness comparison (OpenHands/software-agent-sdk#4627, #4638) will be built on. It is currently biased low.

LiteLLM commits virtual-key spend **asynchronously**, a few seconds after each request returns. `_query_proxy_cost` runs immediately after `evaluate_instance()` — right inside that window — and its retry logic is looking for the wrong thing:

```python
proxy_cost = get_key_spend(virtual_key)
if proxy_cost is None or proxy_cost == 0.0:
    for delay in (2, 4, 8, 16):
        time.sleep(delay)
        retry_cost = get_key_spend(virtual_key)
        if retry_cost is not None and retry_cost > 0:
            proxy_cost = retry_cost
            break          # <- breaks on the first partial read
```

It retries only while spend is exactly `$0`, then `break`s on the first value above zero. A read that is non-zero but still climbing is accepted as final, so the ladder actively *selects* the partial value.

## Evidence

Measured against `llm-proxy.eval.all-hands.dev` by polling `/key/info` at fixed offsets after a single ACP turn ended (two harnesses, both reproducible):

| offset after run | opencode | kimi |
|---|---|---|
| t+0s | $0 | $0 |
| t+2s | $0 | $0 |
| **t+5s** | **$0.01308805** | **$0.02536200** |
| t+10s | $0.01541885 | $0.07714400 |
| t+20s … t+95s | $0.01541885 | $0.07714400 |

Replaying both algorithms over those curves:

| harness | settled truth | current code | error | this PR |
|---|---|---|---|---|
| opencode | $0.01541885 | $0.01308805 @ t+6s | **-15.1%** | $0.01541885 @ t+15s |
| kimi | $0.07714400 | $0.02536200 @ t+6s | **-67.1%** | $0.07714400 @ t+15s |

The size of the error depends on how much of the final total the last few requests carry, which varies per harness — so this is not a constant offset a paired comparison can absorb.

This is pre-existing and independent of which harness is used: `acp-claude` and `acp-codex` are affected today.

## Summary

- Poll until **two consecutive reads agree** rather than until spend is non-zero.
- Fixed 5s interval, 12 attempts (60s ceiling), matching the 5–10s commit latency measured above. The old exponential ladder was shaped to wait for spend to *appear*, which is no longer the goal.
- `$0` still warns as before. A total that never settles now warns too, instead of being reported silently as if it were exact.

Worst case adds ~30s per instance versus the old path; instances run concurrently in worker threads, so this is wall-clock noise against a benchmark run.

## How to Test

```bash
uv run --frozen pytest tests/test_evaluation_proxy_cost.py -q   # 6 passed
uv run --frozen ruff check benchmarks/utils/evaluation.py tests/test_evaluation_proxy_cost.py
```

`test_proxy_cost_waits_for_partially_committed_spend_to_settle` is the regression test — it feeds the measured kimi sequence `[0.0, 0.025362, 0.077144, 0.077144]` and asserts `0.077144`. The old code returns `0.025362`.

Full suite: `547 passed, 13 failed`. All 13 failures are in `tests/test_programbench.py` (hook scripts) and reproduce identically on a clean `origin/main` with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
